### PR TITLE
adding size tracking to all parsers

### DIFF
--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -13,6 +13,11 @@ import DataSize._
 
 object HttpResponseParser {
 
+
+  val DefaultMaxSize: DataSize = 1.MB
+
+  def apply(size: DataSize = DefaultMaxSize) = maxSize(size, response)
+
   def response: Parser[HttpResponse] = firstLine ~ headers |> {case (version, code) ~ headers =>
     val clength = headers.collectFirst{case (c,v) if (c == HttpHeaders.ContentLength) => v.toInt}.getOrElse(0)
     if (clength > 0) {
@@ -34,7 +39,7 @@ object HttpResponseParser {
 
 
 class HttpResponseParser(maxSize: DataSize = 1.MB) {
-  private def parser = Combinators.maxSize(maxSize, HttpResponseParser.response)
+  private def parser = HttpResponseParser(maxSize)
   var p = parser
   def parse(data: DataBuffer): Option[HttpResponse] = p.parse(data)
   def reset(){ 

--- a/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
@@ -7,9 +7,8 @@ import service._
 import akka.util.{ByteString, ByteStringBuilder}
 import java.util.zip.{Deflater, Inflater}
 
-/**
- * This codec is woefully incomplete
- */
+import parsing._
+import DataSize._
 
 
 object MemcacheCommand {
@@ -76,9 +75,9 @@ object MemcacheReply {
   
 }
 
-class MemcacheReplyParser {
+class MemcacheReplyParser(maxSize: DataSize = MemcacheReplyParser.DefaultMaxSize) {
 
-  private var parser = MemcacheReplyParser.reply
+  private var parser = MemcacheReplyParser(maxSize)
 
   def parse(data: DataBuffer): Option[MemcacheReply] = parser.parse(data)
 
@@ -91,6 +90,11 @@ object MemcacheReplyParser {
   import parsing._
   import Combinators._
   import MemcacheReply._
+
+
+  val DefaultMaxSize: DataSize = 1.MB
+
+  def apply(size: DataSize = DefaultMaxSize) = maxSize(size, reply)
 
   def reply = delimitedString(' ', '\r') <~ byte |>{pieces => pieces.head match {
     case "VALUE"      => value(Nil, pieces(1), pieces(3).toInt)

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisCommandParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisCommandParser.scala
@@ -5,10 +5,13 @@ import akka.util.{ByteString, ByteStringBuilder}
 import parsing._
 import core.DataBuffer
 import Combinators._
+import DataSize._
 
 object RedisCommandParser {
 
-  def apply() = command
+  val DefaultMaxSize: DataSize = 1.MB
+
+  def apply(size: DataSize = DefaultMaxSize) = maxSize(size, command)
 
   def command: Parser[Command] = byte |> {
     case '*' => unified

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisReplyParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisReplyParser.scala
@@ -5,6 +5,7 @@ package protocols.redis
 import core._
 import service._
 import parsing._
+import DataSize._
 
 import akka.util.{ByteString, ByteStringBuilder}
 
@@ -13,7 +14,9 @@ object RedisReplyParser {
   import RedisReplyParser._
   import Combinators._
 
-  def apply(): Parser[Reply] = reply
+  val DefaultMaxSize: DataSize = 1.MB
+
+  def apply(size: DataSize = DefaultMaxSize): Parser[Reply] = maxSize(size, reply)
   
 
   def reply: Parser[Reply] = byte |> {


### PR DESCRIPTION
Fixes #2

This will prevent the codecs from attempting to parse objects that are too large.  We might want to adjust the defaults, but for now 1MB seems pretty reasonable, and it's easy to configure. 
