### PR TITLE
fixing http request encoding bug, testkit bug

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
@@ -32,7 +32,7 @@ abstract class HttpServiceSpec extends ServiceSpec[Http] {
 
   def testGet(url: String, expectedBody: String) {
     val req = get(url)
-    val expected = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, ByteString(expectedBody), List(("Content-Length" -> expectedBody.length.toString)))
+    val expected = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, ByteString(expectedBody), List(("content-length" -> expectedBody.length.toString)))
 
     expectResponse(req, expected)
   }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -190,6 +190,14 @@ class HttpParserSuite extends WordSpec with MustMatchers{
         println(parser.parse(DataBuffer(ByteString(req))))
       }
     }
+
+    "parse a generated request" in {
+      val req = HttpRequest(HttpHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = "/foo", headers = Nil), None)
+      val data = DataBuffer(req.bytes)
+      val parser = requestParser
+      parser.parse(data) must equal(Some(req))
+      data.remaining must equal(0)
+    }
     
       
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -362,7 +362,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
             //close the connection to ensure it's not in an undefined state
             key.attachment match {
               case c: Connection => {
-                log.warning(s"closing connection $c.id due to unknown error")
+                log.warning(s"closing connection ${c.id} due to unknown error")
                 unregisterConnection(c, DisconnectCause.Error(t))
               }
               case other => {

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -130,8 +130,12 @@ case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, heade
   //TODO: optimize
   def bytes : ByteString = {
     val reqString = ByteString(s"${method.name} $getEncodedURL HTTP/$version\r\n")
-    val headerString = ByteString(headers.map{case(k,v) => k + ":" + v}.mkString("\r\n"))
-    reqString ++ headerString
+    if (headers.size > 0) {
+      val headerString = ByteString(headers.map{case(k,v) => k + ":" + v}.mkString("\r\n"))
+      reqString ++ headerString ++ ByteString("\r\n\r\n")
+    } else {
+      reqString ++ ByteString("\r\n")
+    }
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -32,7 +32,7 @@ case class HttpRequest(head: HttpHead, entity: Option[ByteString]) {
 
   //TODO optimize
   def bytes : ByteString = {
-    head.bytes ++ ByteString("\r\n\r\n") ++ entity.getOrElse(ByteString())
+    head.bytes ++ entity.getOrElse(ByteString())
   }
 }
 

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -393,7 +393,7 @@ object Combinators {
         } else {
           val ws = isWhiteSpace(b.toChar)
           if (allowWhiteSpace == false && ws) {
-            throw new ParseException(s"Invalid whitespace character in stream, after '${build.toString}'")
+            throw new ParseException(s"Invalid whitespace character '${b.toChar}' ($b) in stream, after '${build.toString}'")
           }
           if (!leadingWhiteSpace || (!ltrim || !ws)) {
             leadingWhiteSpace = false


### PR DESCRIPTION
This fixes #6 .

The issue was caused by the http request encoding containing an extra "\r\n"  in requests with a body.  I also found an issue in the test-kit where it was looking for a capitalized "Content-Length" even though the parser will always lower-case all header names.
