### PR TITLE
New logic for Workeritems, fixing lots of tests

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -20,7 +20,7 @@ object Main extends App {
 
     implicit val actorSystem = ActorSystem("COLOSSUS")
 
-    implicit val ioSystem = IOSystem("examples", numWorkers = Some(4), statsPort = Some(8080))
+    implicit val ioSystem = IOSystem("examples", numWorkers = Some(4))
 
     //the simplest example, an echo server over telnet
     val telnetServer = TelnetExample.start(9000)

--- a/colossus-examples/src/main/scala/colossus-examples/StreamExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamExample.scala
@@ -38,11 +38,14 @@ class StreamWorker(provider: ActorRef) extends Actor with ActorLogging {
   import MessageProvider._
 
   def receive = {
-    case Connected(id) => {
+    case Connected => {
+      log.info("New Stream client connected")
       context.become(alive(sender))  
       provider ! NextMessage
     }
   }
+
+
   
   def alive(connection: ActorRef): Receive = {
     case message: String => {

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteEndpoint.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteEndpoint.scala
@@ -27,9 +27,7 @@ class MockWriteEndpoint(maxBufferSize: Int, workerProbe: TestProbe,handler: Opti
   }
 
   def status: ConnectionStatus = connection_status
-  def sendMessage(message: Any){
-    workerProbe.ref ! message
-  }
+
   val worker: ActorRef = workerProbe.ref
 
   def isWritable = connection_status == ConnectionStatus.Connected && bytesAvailable > 0

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -1,10 +1,16 @@
 package colossus
 
+import core._
+
 import java.net.InetSocketAddress
 import service.{Codec, AsyncServiceClient, ClientConfig}
 
-import akka.util.ByteString
-import colossus.core._
+import akka.actor._
+import akka.pattern.ask
+import akka.testkit.TestProbe
+
+import akka.util.{ByteString, Timeout}
+import java.net.{SocketException, Socket}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -15,35 +21,83 @@ class EchoHandler extends BasicSyncHandler {
   }
 }
 
+object RawProtocol {
+  import service._
 
-object RawCodec extends Codec.ClientCodec[ByteString, ByteString] {
-  def decode(data: DataBuffer) = Some(ByteString(data.takeAll))
-  def encode(raw: ByteString) = DataBuffer(raw)
-  def reset(){}
+  object RawCodec extends Codec[ByteString, ByteString] {
+    def decode(data: DataBuffer) = Some(ByteString(data.takeAll))
+    def encode(raw: ByteString) = DataBuffer(raw)
+    def reset(){}
+  }
+
+  trait Raw extends CodecDSL {
+    type Input = ByteString
+    type Output = ByteString
+  }
+
+  implicit object RawCodecProvider extends CodecProvider[Raw] {
+    def provideCodec() = RawCodec
+
+    def errorResponse(request: ByteString, reason: Throwable) = ByteString(s"Error (${reason.getClass.getName}): ${reason.getMessage}")
+  }
+
+  implicit object RawClientCodecProvider extends ClientCodecProvider[Raw] {
+    def clientCodec() = RawCodec
+    val name = "raw"
+  }
+
 }
 
 object TestClient {
 
-  def apply(io: IOSystem, port: Int, waitForConnected: Boolean = true): AsyncServiceClient[ByteString, ByteString] = {
+  def apply(io: IOSystem, port: Int, waitForConnected: Boolean = true, reconnect: Boolean = true): AsyncServiceClient[ByteString, ByteString] = {
     val config = ClientConfig(
       name = "/test",
       requestTimeout = 100.milliseconds,
       address = new InetSocketAddress("localhost", port),
       pendingBufferSize = 0,
-      failFast = true
+      failFast = true,
+      autoReconnect = reconnect
     )
-    val client = AsyncServiceClient(config, RawCodec)(io)
+    val client = AsyncServiceClient(config, RawProtocol.RawCodec)(io)
     if (waitForConnected) {
-      var tries = 10
-      val sleepMillis = 50
-      while (Await.result(client.connectionStatus, 50.milliseconds) != ConnectionStatus.Connected) {
-        Thread.sleep(sleepMillis)
-        tries -= 1
-        if (tries == 0) {
-          throw new Exception("Test client failed to connect")
-        }
-      }
+      TestClient.waitForConnected(client)
     }
     client
   }
+
+  def waitForConnected[I,O](client: AsyncServiceClient[I,O], maxTries: Int = 5) {
+    waitForStatus(client, ConnectionStatus.Connected, maxTries)
+  }
+
+  def waitForStatus[I,O](client: AsyncServiceClient[I, O], status: ConnectionStatus, maxTries: Int = 5) {
+    var tries = maxTries
+    var last = Await.result(client.connectionStatus, 500.milliseconds)
+    while (last != status) {
+      Thread.sleep(50)
+      tries -= 1
+      if (tries == 0) {
+        throw new Exception(s"Test client failed to achieve status $status, last status was $last")
+      }
+      last = Await.result(client.connectionStatus, 500.milliseconds)
+    }
+  }
+
+}
+
+
+object TestUtil {
+  def expectServerConnections(server: ServerRef, connections: Int, maxTries: Int = 5) {
+    var tries = maxTries
+    implicit val timeout = Timeout(100.milliseconds)
+    while (Await.result((server.server ? Server.GetInfo), 100.milliseconds) != Server.ServerInfo(connections, ServerStatus.Bound)) {
+      Thread.sleep(50)
+      tries -= 1
+      if (tries == 0) {
+        throw new Exception(s"Server failed to achieve $connections connections")
+      }
+    }
+
+  }
+
 }

--- a/colossus-tests/src/test/scala/colossus/core/AsyncHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/AsyncHandlerSpec.scala
@@ -25,6 +25,13 @@ class AsyncHandlerSpec extends ColossusSpec {
   }
     
   "AsyncHandler" must {
+    "send Bound event" in {
+      withHandler {case (endpoint, handler, probe) => 
+        handler.bind(34, handler.worker)
+        probe.expectMsg(Bound(34))
+      }
+    }
+
     "send Connected event" in {
       withHandler{ case (endpoint, handler, probe) => 
         handler.connected(endpoint)

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -2,11 +2,12 @@ package colossus
 
 import testkit._
 import core._
-import service.AsyncServiceClient
+import service.{Service, AsyncServiceClient}
 
 import akka.actor._
 import akka.testkit.TestProbe
 
+import java.net.InetSocketAddress
 import scala.concurrent.duration._
 import akka.util.ByteString
 
@@ -36,10 +37,111 @@ class ConnectionHandlerSpec extends ColossusSpec {
     val props = Props(classOf[Handler], probe.ref)
     val server = createServer(AsyncDelegator.factorize(props))
     val c = TestClient(server.system, TEST_PORT)
-    probe.expectMsgType[ConnectionEvent.Bound]
+    probe.expectMsg(ConnectionEvent.Bound(1))
     probe.expectMsg(ConnectionEvent.Connected)
     (server, c, probe)
   }
+
+  "Server Connection Handler" must {
+    "bind to worker on creation" in {
+      val probe = TestProbe()
+      class MyHandler extends BasicSyncHandler {
+        override def onBind() {
+          probe.ref ! "BOUND"
+        }
+        def receivedData(data: DataBuffer){}
+      }
+      withIOSystem{ implicit io =>
+        withServer(Server.basic("test", TEST_PORT, () => new MyHandler)) {
+          val c = TestClient(io, TEST_PORT)
+          probe.expectMsg(100.milliseconds, "BOUND")
+        }
+      }
+    }
+
+    "unbind on disconnect" in {
+      val probe = TestProbe()
+      class MyHandler extends BasicSyncHandler {
+        override def onUnbind() {
+          probe.ref ! "UNBOUND"
+        }
+        def receivedData(data: DataBuffer){}
+      }
+      withIOSystem{ implicit io =>
+        withServer(Server.basic("test", TEST_PORT, () => new MyHandler)) {
+          val c = TestClient(io, TEST_PORT)
+          c.disconnect()
+          probe.expectMsg(100.milliseconds, "UNBOUND")
+        }
+      }
+    }
+  }
+
+  "Client Connection Handler" must {
+
+    "bind to worker" in {
+      val probe = TestProbe()
+      class MyHandler extends BasicSyncHandler with ClientConnectionHandler{
+        override def onBind() {
+          probe.ref ! "BOUND"
+        }
+        def receivedData(data: DataBuffer){}
+        def connectionFailed(){}
+      }
+      withIOSystem{ implicit io =>
+        //obvious this will fail to connect, but we don't care here
+        io ! IOCommand.Connect(new InetSocketAddress("localhost", TEST_PORT), worker => new MyHandler)
+        probe.expectMsg(100.milliseconds, "BOUND")
+      }
+    }
+
+    "not automatically unbind" in {
+      val probe = TestProbe()
+      class MyHandler extends BasicSyncHandler with ClientConnectionHandler{
+        override def onUnbind() {
+          probe.ref ! "UNBOUND"
+        }
+
+        override def connected(endpoint: WriteEndpoint) {
+          endpoint.disconnect()
+        }
+        def receivedData(data: DataBuffer){}
+        def connectionFailed(){}
+      }
+      withIOSystem{ implicit io =>
+        import RawProtocol._
+        withServer(Service.become[Raw]("test", TEST_PORT){case x => x}) {
+          io ! IOCommand.Connect(new InetSocketAddress("localhost", TEST_PORT), worker => new MyHandler)
+          probe.expectNoMsg(200.milliseconds)
+        }
+      }
+    }
+
+    "automatically unbind with AutoUnbindHandler mixin" in {
+      val probe = TestProbe()
+      class MyHandler extends BasicSyncHandler with ClientConnectionHandler with AutoUnbindHandler{
+        override def onUnbind() {
+          probe.ref ! "UNBOUND"
+        }
+
+        override def connected(endpoint: WriteEndpoint) {
+          endpoint.disconnect()
+        }
+        def receivedData(data: DataBuffer){}
+        def connectionFailed(){}
+      }
+      withIOSystem{ implicit io =>
+        import RawProtocol._
+        withServer(Service.become[Raw]("test", TEST_PORT){case x => x}) {
+          io ! IOCommand.Connect(new InetSocketAddress("localhost", TEST_PORT), worker => new MyHandler)
+          probe.expectMsg(200.milliseconds, "UNBOUND")
+        }
+      }
+
+    }
+
+  }
+
 
   "Async Server Handler" must {
     "receive connected event" in {

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -14,6 +14,7 @@ import java.net.InetSocketAddress
 
 import org.scalatest.Tag
 
+import RawProtocol._
 
 class ServerSpec extends ColossusSpec {
 
@@ -82,18 +83,18 @@ class ServerSpec extends ColossusSpec {
       }
     }
 
-    "shutting down a system kills client connections" ignore {
+    "shutting down a system kills client connections"  in {
       withIOSystem { implicit io => 
         val server = Server.basic("echo", TEST_PORT, () => new EchoHandler)
         val probe = TestProbe()
         probe watch server.server
         withServer(server) {
           val cio = IOSystem("client_io")
-          val c = TestClient(cio, TEST_PORT)
+          val c = TestClient(cio, TEST_PORT, reconnect = false)
           Await.result(c.send(ByteString("HELLO")), 200.milliseconds) must equal(ByteString("HELLO"))
           io.shutdown()
           probe.expectTerminated(server.server)
-          Await.result(c.connectionStatus, 100.milliseconds) must equal(ConnectionStatus.Connecting)
+          TestClient.waitForStatus(c, ConnectionStatus.NotConnected)
           cio.shutdown()
         }
       }
@@ -120,7 +121,7 @@ class ServerSpec extends ColossusSpec {
       end(server)
     }
 
-    "open up spot when connection closes" ignore {
+    "open up spot when connection closes" taggedAs(Tag("wat")) in {
       val settings = ServerSettings(
         port = TEST_PORT,
         maxConnections = 1
@@ -128,26 +129,31 @@ class ServerSpec extends ColossusSpec {
       val server = createServer(Delegator.basic(() => new EchoHandler), Some(settings))
       val c1 = TestClient(server.system, TEST_PORT)
       expectConnections(server, 1)
-      val c2 = TestClient(server.system, TEST_PORT, false)
-      //notice, we can't just check if the connectin is connected because the server will accept the connection before closing it
-      Await.result(c2.send(ByteString("hello")), 500.milliseconds)
+      val c2 = TestClient(server.system, TEST_PORT, waitForConnected = false, reconnect = false)
+      //notice, we can't just check if the connection is connected because the
+      //server will accept the connection before closing it
+      intercept[service.ServiceClientException] {
+        Await.result(c2.send(ByteString("hello")), 5000.milliseconds)
+      }
+      TestClient.waitForStatus(c2, ConnectionStatus.NotConnected)
       c1.disconnect()
-      Await.result(c1.connectionStatus, 50.milliseconds) must equal(ConnectionStatus.NotConnected)
-      expectConnections(server, 1)
-      Await.result(c1.connectionStatus, 50.milliseconds) must equal(ConnectionStatus.Connected)
+      TestUtil.expectServerConnections(server, 0)
+      val c3 = TestClient(server.system, TEST_PORT, waitForConnected = true, reconnect = false)
+      TestUtil.expectServerConnections(server, 1)
       end(server)
 
     }
 
-    "close connection when worker rejects" ignore {
+    "close connection when worker rejects" in {
       class AngryDelegator(server: ServerRef, worker: WorkerRef) extends Delegator(server, worker) {
         def acceptNewConnection = None // >:(
       }
       val server = createServer((s,w) => new AngryDelegator(s,w))
-      val c1 = TestClient(server.system, TEST_PORT)
-      intercept[service.NotConnectedException] {
+      val c1 = TestClient(server.system, TEST_PORT, reconnect = false, waitForConnected = false)
+      intercept[service.ServiceClientException] {
         Await.result(c1.send(ByteString("testing")), 100.milliseconds)
       }
+      TestClient.waitForStatus(c1, ConnectionStatus.NotConnected)
       end(server)
 
     }
@@ -166,10 +172,10 @@ class ServerSpec extends ColossusSpec {
         val server = Server(config)
         probe watch server.server
         waitForServer(server)
-        val c = TestClient(server.system, TEST_PORT)
+        val c = TestClient(server.system, TEST_PORT, reconnect = false)
         expectConnections(server, 1)
         Thread.sleep(1000)
-        expectConnections(server, 0)
+        TestUtil.expectServerConnections(server, 0)
         //TODO c.isClosed must equal(true)
       }
     }
@@ -198,10 +204,8 @@ class ServerSpec extends ColossusSpec {
 
     }
 
-    //NOTICE - this test flaps sometimes , consider rewriting
-    //this test is totally broken right now
-    /*
-    "switch to high water timeout when connection count passes the high water mark" ignore {
+    "switch to high water timeout when connection count passes the high water mark" in {
+      //for now this test only checks to see that the server switched its status
       withIOSystem { implicit io =>
         val config = ServerConfig(
           name = "highWaterTest",
@@ -210,32 +214,20 @@ class ServerSpec extends ColossusSpec {
             maxConnections = 10,
             lowWatermarkPercentage = 0.60,
             highWatermarkPercentage = 0.80,
-            highWaterMaxIdleTime = 50.milliseconds
+            highWaterMaxIdleTime = 50.milliseconds,
+            maxIdleTime = 1.hour
           ),
           delegatorFactory = Delegator.basic(() => new EchoHandler)
         )
         val server = Server(config)
-        waitForServer(server)
-        val idleConnections = for{i <- 1 to 5} yield new TestConnection(TEST_PORT)
-        Thread.sleep(100)
-        expectConnections(server, 5)
-         //these should push us over the edge of the high water mark
-         val chattyConnections = for{i <- 1 to 4} yield chattyConnection(TEST_PORT)
-        chattyConnections.foreach(_._1.start())
-         //we should now be right above the watermark //the first 5 should be culled
-        Thread.sleep(1000)
-        expectConnections(server, 4)
-        idleConnections.foreach { _.isClosed must equal(true)}
-        chattyConnections.foreach { case (t, c) =>
-          t.isAlive must equal(true)
-          t.isInterrupted must equal(false)
-          c.running = false
+        withServer(server) {
+          val idleConnections = for{i <- 1 to 9} yield TestClient(server.system, TEST_PORT, reconnect = false)
+          TestUtil.expectServerConnections(server, 9)
+          Thread.sleep(1000) //have to wait a second since that's how often the check it done
+          expectConnections(server, 0)
         }
-        Thread.sleep(230)
-        chattyConnections.foreach{case (t, _) => t.join()}
       }
     }
-    */
 
     "delegator onShutdown is called when a worker shuts down" in {
       import scala.concurrent.ExecutionContext.Implicits.global

--- a/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
+++ b/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
@@ -79,7 +79,7 @@ class TaskTest extends ColossusSpec {
               case "PING" => sender.!("PONG")(proxy)
             }
           }
-          override def unbound() {
+          override def onUnbind() {
             probe.ref.!("UNBOUND")(proxy)
           }
         }
@@ -103,7 +103,7 @@ class TaskTest extends ColossusSpec {
           }
           def receivedMessage(message: Any, sender: ActorRef) {
           }
-          override def unbound() {
+          override def onUnbind() {
             probe.ref.!("UNBOUND")(proxy)
           }
         }
@@ -127,7 +127,7 @@ class TaskTest extends ColossusSpec {
             probe.ref.!(id)(proxy)
           }
         }
-        probe.expectMsg(300.milliseconds, 1L)
+        probe.expectMsg(300.milliseconds, Some(1L))
       }
     }
     "receive and become" in {

--- a/colossus/src/main/scala/colossus/core/ActorHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ActorHandler.scala
@@ -21,7 +21,7 @@ class ActorHandler extends Actor with Stash {
   def receive = {
     case RegisterListener(listener) => {
       context.become(binding(listener))
-      unstashAll()
+      unstashAll() //this unstash must be here in case we get Bound first
     }
     case other => {
       stash()

--- a/colossus/src/main/scala/colossus/core/AsyncHandler.scala
+++ b/colossus/src/main/scala/colossus/core/AsyncHandler.scala
@@ -28,8 +28,8 @@ case class AsyncHandler(handler: ActorRef, worker: WorkerRef) extends WatchedHan
   
   }
 
-  def bound(id: Long, worker: WorkerRef){
-    handler ! Bound(id)
+  override def onBind(){
+    handler ! Bound(id.get)
   }
 
 

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -73,6 +73,14 @@ trait ClientConnectionHandler extends ConnectionHandler {
 }
 
 /**
+ * A Simple mixin trait that will cause the worker to automatically unbind this
+ * handler if the connection it's attached to is closed.  This is generally a
+ * good idea if the handler is not going to attempt any connection retry logic
+ * or is not setup to receive any actor messages
+ */
+trait AutoUnbindHandler extends ClientConnectionHandler
+
+/**
  * Convenience implementation of ConnectionHandler which provides implementations for all of
  * the necessary functions.  This allows for a devloper to extend this trait and only provide definitions
  * for the functions they require.
@@ -102,7 +110,7 @@ trait BasicSyncHandler extends ConnectionHandler {
   def readyForData(){}
 
   //this is the only method you have to implement
-  def receivedData(data: DataBuffer)
+  //def receivedData(data: DataBuffer)
 }
 
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -2,6 +2,7 @@ package colossus
 package core
 
 import akka.actor._
+import akka.event.LoggingAdapter
 import metrics._
 import service.CallbackExecution
 
@@ -18,6 +19,31 @@ import scala.util.{Failure, Success, Try}
  * ConnectionHandlers.
  */
 private[colossus] trait WorkerItem {
+  private var _id: Option[Long] = None
+  private var _boundWorker: Option[WorkerRef] = None
+  def id = _id
+  def boundWorker = _boundWorker
+
+
+  /**
+   * bind the item to a Worker.
+   * @param id  The id assigned to this Item.
+   * @param worker The Worker whom was bound
+   */
+  private[colossus] def bind(id: Long, worker: WorkerRef) {
+    _id = Some(id)
+    _boundWorker = Some(worker)
+    onBind()
+  }
+
+  /**
+   * Called when this item is unbound from a Worker.
+   */
+  private[colossus] def unbind(){
+    _id = None
+    _boundWorker = None
+    onUnbind()
+  }
 
   /**
    * Provides a way to send this WorkerItem a message from an Actor by way of
@@ -28,22 +54,24 @@ private[colossus] trait WorkerItem {
   def receivedMessage(message: Any, sender: ActorRef)
 
   /**
-   * Called when this item has successfully been bound to a Worker.
-   * @param id  The id assigned to this Item.
-   * @param worker The Worker whom was bound
+   * Called when the item is bound to a worker.
    */
-  def bound(id: Long, worker: WorkerRef)
+  def onBind(){}
 
   /**
-   * Called when this item is unbound from a Worker.
+   * Called when the item has been unbound from a worker
    */
-  def unbound(){}
+  def onUnbind(){}
+
+
 }
 
 /**
  * BindableWorkItem is the public facing trait which is meant for Tasks and other objects which are Bindable to
  * a Worker.  WorkerItem itself is directly extended by ConnectionHandler which has a different and specific lifecycle inside
  * of a Worker.
+ *
+ * TODO; this is probably not needed anymore
  */
 trait BindableWorkerItem extends WorkerItem
 
@@ -79,6 +107,51 @@ case class WorkerRef(id: Int, metrics: LocalCollection, worker: ActorRef, system
   def !(message: Any)(implicit sender: ActorRef = ActorRef.noSender)  = worker ! message
 }
 
+/**
+ * This keeps track of all the bound worker items, and properly handles added/removing them
+ */
+class WorkerItemManager(worker: WorkerRef, log: LoggingAdapter) {
+
+  private val workerItems = collection.mutable.Map[Long, WorkerItem]()
+
+  private var id: Long = 0L
+  def newId(): Long = {
+    id += 1
+    id
+  }
+
+  def get(id: Long): Option[WorkerItem] = workerItems.get(id)
+
+  /**
+   * Binds a new worker item to this worker
+   */
+  def bind(workerItem: WorkerItem) {
+    val id = newId()
+    workerItems(id) = workerItem
+    workerItem.bind(id, worker)
+  }
+
+  def unbind(id: Long) {
+    if (workerItems contains id) {
+      val item = workerItems(id)
+      workerItems -= id
+      item.unbind()   
+    } else {
+      log.error(s"Attempted to unbind worker $id that is not bound to this worker")
+    }    
+  }
+
+  def unbind(workerItem: WorkerItem) {
+    workerItem.id.map{i => 
+      unbind(i)
+    }.getOrElse(
+      //maybe throw an exception instead?  
+      log.error("Attempted to unbind worker item that was already not bound!")
+    )
+  }
+}
+
+
 
 private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMetrics with ActorLogging with CallbackExecution {
   import Server._
@@ -91,8 +164,11 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
 
   val watchedConnections = collection.mutable.Map[ActorRef, ClientConnection]()
 
+  //these ids are used for both connections and worker items so a connection
+  //and it's attached handler will have different ids
+  //TODO - we can probably improve performance by making ids a case class containing the item as a private field
   private var id: Long = 0L
-  def newId: Long = {
+  def newId(): Long = {
     id += 1
     id
   }
@@ -110,23 +186,18 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
   val buffer = ByteBuffer.allocateDirect(1024 * 128)
 
 
-  /**
-   * Using two collections here instead of just one for WorkerItems because it
-   * involves less filtering (but it may not matter)
-   *
-   * maybe encapsulate in a class
-   */
+  //collection of all the active connections
   val connections = collection.mutable.Map[Long, Connection]()
-  val workerItems = collection.mutable.Map[Long, WorkerItem]()
-  def getWorkerItem(id: Long): Option[WorkerItem] = workerItems.get(id).orElse(connections.get(id).map{_.handler})
-
 
 
   //mapping of registered servers to their delegators
   val delegators = collection.mutable.Map[ActorRef, Delegator]()
 
-
   val me = WorkerRef(workerId, metrics, self, io)
+
+  //collection of all the bound WorkerItems, including connection handlers
+  val workerItems = new WorkerItemManager(me, log)
+  def getWorkerItem(id: Long): Option[WorkerItem] = workerItems.get(id)
 
   override def preStart() {
     super.preStart()
@@ -204,19 +275,21 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
     import IOCommand._
     cmd match {
       case Connect(address, handlerFactory) => {
-        clientConnect(address, handlerFactory(me))
+        val handler = handlerFactory(me)
+        workerItems.bind(handler)
+        clientConnect(address, handler)
       }
       case Reconnect(address, handler) => {
         clientConnect(address, handler)
       }
       case BindWorkerItem(workerItem) => {
-        val id = newId
-        workerItems(id) = workerItem
-        workerItem.bound(id, me)
+        workerItems.bind(workerItem)
       }
 
     }
   }
+
+
 
   //start the connection process for either a new client or a reconnecting client
   //FIXME: https://github.com/tumblr/colossus/issues/19
@@ -225,12 +298,10 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
     channel.configureBlocking(false)  
     channel.connect(address)
     val key = channel.register(selector, SelectionKey.OP_CONNECT)
-    val connection = new ClientConnection(newId, key, channel, handler)
+    val connection = new ClientConnection(newId(), key, channel, handler)
     key.attach(connection)    
     connections(connection.id) = connection
     numConnections.increment()
-    handler.bound(connection.id, me)
-    //notice - handler connected call is not here since we're not connected yet!
     handler match {
       case w: WatchedHandler => {
         watchedConnections(w.watchedActor) = connection
@@ -238,8 +309,6 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
       }
       case _ =>{}
     }
-  
-
   }
 
 
@@ -251,6 +320,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
         getWorkerItem(wid).map{item =>
           item.receivedMessage(message, responder)
         }.getOrElse{
+          log.error(s"worker received message $message for unknown item $wid")
           responder ! MessageDeliveryFailed(wid, message)
         }
       }
@@ -261,14 +331,11 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
         //(yes we have the TaskScheduler, but lets try to get that out of here)
         context.parent ! s
       }
-      case UnbindWorkerItem(wid) => {
-        workerItems.get(wid).foreach{workerItem =>
-          workerItems -= wid
-          workerItem.unbound()
-        }
+      case UnbindWorkerItem(id) => {
+        workerItems.unbind(id)
       }
-      case Disconnect(wid) => {
-        connections.get(wid).foreach{con =>
+      case Disconnect(connectionId) => {
+        connections.get(connectionId).foreach{con =>
           unregisterConnection(con, DisconnectCause.Disconnect)
         }
       }
@@ -280,11 +347,11 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
    */
   def registerConnection(sc: SocketChannel, server: ServerRef, handler: ConnectionHandler) {
       val newKey: SelectionKey = sc.register( selector, SelectionKey.OP_READ )
-      val connection = new ServerConnection(newId, newKey, sc, handler, server)(self)
+      val connection = new ServerConnection(newId(), newKey, sc, handler, server)(self)
       newKey.attach(connection)
       connections(connection.id) = connection
       numConnections.increment()
-      handler.bound(connection.id, me)
+      workerItems.bind(handler)
       handler.connected(connection)
   }
 
@@ -292,7 +359,9 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
     connections -= con.id
     con.close(cause)
     numConnections.decrement()
-
+    if (con.unbindHandlerOnClose) {
+      workerItems.unbind(con.handler)
+    } 
   }
 
   def unregisterServer(handler: ActorRef) {

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -84,9 +84,9 @@ class AsyncHandlerGenerator[I,O](config: ClientConfig, codec: Codec[I,O]) {
     implicit val sender = worker.worker
     val watchedActor = caller
 
-    override def bound(id: Long, worker: WorkerRef) {
-      super.bound(id, worker)
-      caller.!( ConnectionEvent.Bound(id))(worker.worker)
+    override def onBind() {
+      super.onBind()
+      caller.!(ConnectionEvent.Bound(id.get))(worker.worker)
     }
 
     override def receivedMessage(message: Any, sender: ActorRef) {


### PR DESCRIPTION
This introduces a fairly low-level change about how connection handlers interact with workers.  Previously, we tracked active connections attached to a worker, but not the handlers attached to connections.   This became an issue with ServiceClients, which can automatically reconnect if unexpectedly disconnected.  During the time in which the client was reconnecting, it was not at all bound to the worker, so if someone tried to send a message to the client handler (such as with the `AsyncServiceClient`), the message would be lost.

Now we have a clear distinction between tracking connections and connection handlers, such that a connection handler can detach and re-attach to connections without becoming unbound from the worker.  In particular a client connection handler can now control when it becomes unbound from a worker (server handlers are still always onbound when their attached connection is closed).

Also fixed a whole bunch of tests, including all the tests that have been randomly failing in travis.
