### PR TITLE
ensuring unique actor names for metric systems

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -35,7 +35,7 @@ object MetricSystem {
   def apply(namespace: MetricAddress, tickPeriod: FiniteDuration = 1.second)
   (implicit system: ActorSystem): MetricSystem = {
     import system.dispatcher
-    val clock = system.actorOf(Props(classOf[MetricClock], tickPeriod), name =  "clock")
+    val clock = system.actorOf(Props(classOf[MetricClock], tickPeriod), name =  s"${namespace.idString}-clock")
     val snap = Agent[MetricMap](Map())
     val db = system.actorOf(Props(classOf[MetricDatabase], namespace, snap))
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -16,6 +16,17 @@ class MetricSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
     }
   }
 
+  "MetricSystem" must {
+    "allow multiple systems to start without any conflicts" in {
+      import akka.actor._
+      implicit val sys = ActorSystem("metrics")
+      val m1 = MetricSystem("/sys1")
+      val m2 = MetricSystem("/sys2")
+      //no exceptions means the test passed
+      sys.shutdown()
+    }
+  }
+
 
   "Metric" must {
     "add a new tagged value" in {


### PR DESCRIPTION
This fixes #15 

Even though it doesn't make a whole lot of sense to have multiple metric systems, at least you won't get an exception now.
