### PR TITLE
load balancer fixes

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
+++ b/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
@@ -10,6 +10,8 @@ import akka.testkit.TestProbe
 
 import scala.concurrent.duration._
 
+import org.scalatest.Tag
+
 class TaskTest extends ColossusSpec {
   import IOCommand.BindWorkerItem
 
@@ -30,7 +32,7 @@ class TaskTest extends ColossusSpec {
           }
           def receivedMessage(message: Any, sender: ActorRef){}
         }
-        sys ! BindWorkerItem(task)
+        sys ! BindWorkerItem(() => task)
         probe.expectMsg(500.milliseconds, "BOUND")
       }
     }    
@@ -48,7 +50,7 @@ class TaskTest extends ColossusSpec {
             }
           }
         }
-        sys ! BindWorkerItem(task)
+        sys ! BindWorkerItem(() => task)
         probe.expectMsg(500.milliseconds, "RECEIVED")
       }
     }
@@ -63,7 +65,7 @@ class TaskTest extends ColossusSpec {
             }
           }
         }
-        sys ! BindWorkerItem(task)
+        sys ! BindWorkerItem(() => task)
         task.proxy ! "PING"
         expectMsg(100.milliseconds, "PONG")
       }
@@ -83,7 +85,7 @@ class TaskTest extends ColossusSpec {
             probe.ref.!("UNBOUND")(proxy)
           }
         }
-        sys ! BindWorkerItem(task)
+        sys ! BindWorkerItem(() => task)
         task.proxy ! "PING"
         expectMsg(100.milliseconds, "PONG")
         task.proxy ! TaskProxy.Unbind
@@ -107,7 +109,7 @@ class TaskTest extends ColossusSpec {
             probe.ref.!("UNBOUND")(proxy)
           }
         }
-        sys ! BindWorkerItem(task)
+        sys ! BindWorkerItem(() => task)
         probe.expectMsg(100.milliseconds, "BOUND")
         task.proxy ! PoisonPill
         probe.expectMsg(100.milliseconds, "UNBOUND")

--- a/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
@@ -1,0 +1,34 @@
+package colossus
+package task
+
+import testkit._
+
+import core._
+
+import akka.actor._
+import akka.testkit.TestProbe
+
+import scala.concurrent.duration._
+
+class WorkerItemSpec extends ColossusSpec {
+
+  "A WorkerItem" must {
+    "bind to a worker" in {
+      withIOSystem{io => 
+        val probe = TestProbe()
+        class MyItem extends BindableWorkerItem {
+          override def onBind() {
+            probe.ref ! "BOUND"
+          }
+          def receivedMessage(message: Any, sender: ActorRef){}
+        }
+        io ! IOCommand.BindWorkerItem(() => new MyItem)
+        probe.expectMsg(100.milliseconds, "BOUND")
+      }
+    }
+
+
+
+  }
+}
+

--- a/colossus/src/main/scala/colossus/util/Task.scala
+++ b/colossus/src/main/scala/colossus/util/Task.scala
@@ -91,7 +91,7 @@ object Task {
   def apply(runner: TaskContext => Unit)(implicit io: IOSystem): ActorRef = {
     val task: BasicTask = new BasicTask()(io.actorSystem)
     task.onStart(runner(task))
-    io ! IOCommand.BindWorkerItem(task)
+    io ! IOCommand.BindWorkerItem(() => task)
     task.proxy
   }
 }


### PR DESCRIPTION
Fixes #14 .

A few changes made here:
- The `LoadBalancingClient` now properly binds itself as a worker item for its shared interface.  No more duplicated logic
- Made some fixes around how worker items are bound and did some refactoring.

I will probably be opening another PR shortly that addresses some of the todo's I mention here.
