### PR TITLE
adding leading space to http header values

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -19,7 +19,7 @@ class HttpSpec extends WordSpec with MustMatchers{
       )
       val request = HttpRequest(head, Some(ByteString("hello")))
 
-      val expected = "POST /hello HTTP/1.1\r\nfoo:bar\r\n\r\nhello"
+      val expected = "POST /hello HTTP/1.1\r\nfoo: bar\r\n\r\nhello"
 
       request.bytes.utf8String must equal(expected)
     }
@@ -33,11 +33,20 @@ class HttpSpec extends WordSpec with MustMatchers{
       )
       val request = HttpRequest(head, None)
 
-      val expected = "POST /hello HTTP/1.1\r\nfoo:bar\r\n\r\n"
+      val expected = "POST /hello HTTP/1.1\r\nfoo: bar\r\n\r\n"
 
       request.bytes.utf8String must equal(expected)
     }
       
+  }
+
+  "http response" must {
+    "encode basic response" in {
+      val content = "Hello World!"
+      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, ByteString(content))
+      val expected = s"HTTP/1.1 200 OK\r\nContent-Length: ${content.length}\r\n\r\n${content}"
+      ByteString(response.bytes.takeAll).utf8String must equal (expected)
+    }
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -131,7 +131,7 @@ case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, heade
   def bytes : ByteString = {
     val reqString = ByteString(s"${method.name} $getEncodedURL HTTP/$version\r\n")
     if (headers.size > 0) {
-      val headerString = ByteString(headers.map{case(k,v) => k + ":" + v}.mkString("\r\n"))
+      val headerString = ByteString(headers.map{case(k,v) => k + ": " + v}.mkString("\r\n"))
       reqString ++ headerString ++ ByteString("\r\n\r\n")
     } else {
       reqString ++ ByteString("\r\n")

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -18,11 +18,11 @@ case class HttpResponse(version: HttpVersion, code: HttpCode, data: ByteString, 
     builder append ByteString("\r\n")
     headers.foreach{case (key, value) =>
       builder putBytes key.getBytes
-      builder putBytes ":".getBytes
+      builder putBytes ": ".getBytes
       builder putBytes value.getBytes
       builder append NEWLINE
     }
-    builder putBytes s"Content-Length:${data.size}".getBytes
+    builder putBytes s"Content-Length: ${data.size}".getBytes
     builder append NEWLINE
     builder append NEWLINE
     builder append data


### PR DESCRIPTION
Fixes #34 .  While not a requirement, it seems that some http clients (particularly monit) are hardcoded to look for a leading space in header values.
