### PR TITLE
Changing Client Connection semantics

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -21,7 +21,7 @@ class Handler(listener: ActorRef) extends Actor {
   
 class AsyncDelegator(props: Props, server: ServerRef, worker: WorkerRef)(implicit factory: ActorRefFactory) extends Delegator(server, worker) {
   implicit val w = worker.worker
-  def acceptNewConnection = Some(AsyncHandler(factory.actorOf(props), worker))
+  def acceptNewConnection = Some(AsyncHandler(factory.actorOf(props)))
 }
 object AsyncDelegator {
   def factorize(props: Props)(implicit system: ActorSystem): Delegator.Factory = {
@@ -91,7 +91,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
       }
       withIOSystem{ implicit io =>
         //obvious this will fail to connect, but we don't care here
-        io ! IOCommand.Connect(new InetSocketAddress("localhost", TEST_PORT), worker => new MyHandler)
+        io ! IOCommand.BindAndConnectWorkerItem(new InetSocketAddress("localhost", TEST_PORT), new MyHandler)
         probe.expectMsg(100.milliseconds, "BOUND")
       }
     }
@@ -112,7 +112,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
       withIOSystem{ implicit io =>
         import RawProtocol._
         withServer(Service.become[Raw]("test", TEST_PORT){case x => x}) {
-          io ! IOCommand.Connect(new InetSocketAddress("localhost", TEST_PORT), worker => new MyHandler)
+          io ! IOCommand.BindAndConnectWorkerItem(new InetSocketAddress("localhost", TEST_PORT), new MyHandler)
           probe.expectNoMsg(200.milliseconds)
         }
       }
@@ -134,7 +134,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
       withIOSystem{ implicit io =>
         import RawProtocol._
         withServer(Service.become[Raw]("test", TEST_PORT){case x => x}) {
-          io ! IOCommand.Connect(new InetSocketAddress("localhost", TEST_PORT), worker => new MyHandler)
+          io ! IOCommand.BindAndConnectWorkerItem(new InetSocketAddress("localhost", TEST_PORT), new MyHandler)
           probe.expectMsg(200.milliseconds, "UNBOUND")
         }
       }

--- a/colossus-tests/src/test/scala/colossus/core/IOSystemSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/IOSystemSpec.scala
@@ -30,7 +30,7 @@ class IOSystemSpec extends ColossusSpec {
         val server = Service.serve[Telnet]("test", 15151){_.handle{_.become{case _ => TelnetReply("ASDF")}}}
         waitForServer(server)
 
-        sys.connect(new InetSocketAddress("localhost", 15151), _ => new MyHandler)
+        sys.connect(new InetSocketAddress("localhost", 15151), new MyHandler)
         probe.expectMsg(200.milliseconds, "CONNECTED")
 
       }

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -11,6 +11,8 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import akka.util.ByteString
 
+import org.scalatest._
+
 class ServerSpec extends ColossusSpec {
 
   def expectConnections(server: ServerRef, num: Int) {
@@ -260,9 +262,9 @@ class ServerSpec extends ColossusSpec {
             name = "highWaterTest",
             settings = ServerSettings(
               port = TEST_PORT,
-              maxConnections = 10,
-              lowWatermarkPercentage = 0.60,
-              highWatermarkPercentage = 0.80,
+              maxConnections = 2,
+              lowWatermarkPercentage = 0.00,
+              highWatermarkPercentage = 0.50,
               highWaterMaxIdleTime = 50.milliseconds,
               maxIdleTime = 1.hour
             ),
@@ -270,9 +272,10 @@ class ServerSpec extends ColossusSpec {
           )
           val server = Server(config)
           withServer(server) {
-            val idleConnections = for{i <- 1 to 9} yield TestClient(server.system, TEST_PORT, connectionAttempts = PollingDuration.NoRetry)
-            TestUtil.expectServerConnections(server, 9)
-            Thread.sleep(1000) //have to wait a second since that's how often the check it done
+            val idleConnection1 = TestClient(server.system, TEST_PORT, connectionAttempts = PollingDuration.NoRetry)
+            TestUtil.expectServerConnections(server, 1)
+            val idleConnection2 = TestClient(server.system, TEST_PORT, connectionAttempts = PollingDuration.NoRetry)
+            Thread.sleep(500) //have to wait a second since that's how often the check it done
             expectConnections(server, 0)
           }
         }

--- a/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
+++ b/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
@@ -32,7 +32,7 @@ class TaskTest extends ColossusSpec {
           }
           def receivedMessage(message: Any, sender: ActorRef){}
         }
-        sys ! BindWorkerItem(() => task)
+        sys ! BindWorkerItem( task)
         probe.expectMsg(500.milliseconds, "BOUND")
       }
     }    
@@ -50,7 +50,7 @@ class TaskTest extends ColossusSpec {
             }
           }
         }
-        sys ! BindWorkerItem(() => task)
+        sys ! BindWorkerItem( task)
         probe.expectMsg(500.milliseconds, "RECEIVED")
       }
     }
@@ -65,7 +65,7 @@ class TaskTest extends ColossusSpec {
             }
           }
         }
-        sys ! BindWorkerItem(() => task)
+        sys ! BindWorkerItem( task)
         task.proxy ! "PING"
         expectMsg(100.milliseconds, "PONG")
       }
@@ -85,7 +85,7 @@ class TaskTest extends ColossusSpec {
             probe.ref.!("UNBOUND")(proxy)
           }
         }
-        sys ! BindWorkerItem(() => task)
+        sys ! BindWorkerItem( task)
         task.proxy ! "PING"
         expectMsg(100.milliseconds, "PONG")
         task.proxy ! TaskProxy.Unbind
@@ -109,7 +109,7 @@ class TaskTest extends ColossusSpec {
             probe.ref.!("UNBOUND")(proxy)
           }
         }
-        sys ! BindWorkerItem(() => task)
+        sys ! BindWorkerItem( task)
         probe.expectMsg(100.milliseconds, "BOUND")
         task.proxy ! PoisonPill
         probe.expectMsg(100.milliseconds, "UNBOUND")

--- a/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
@@ -1,11 +1,9 @@
 package colossus
-package task
+package core
 
 import testkit._
 
-import core._
-
-import akka.actor._
+import akka.actor.ActorRef
 import akka.testkit.TestProbe
 
 import scala.concurrent.duration._
@@ -16,14 +14,71 @@ class WorkerItemSpec extends ColossusSpec {
     "bind to a worker" in {
       withIOSystem{io => 
         val probe = TestProbe()
-        class MyItem extends BindableWorkerItem {
+        class MyItem extends WorkerItem {
           override def onBind() {
             probe.ref ! "BOUND"
           }
           def receivedMessage(message: Any, sender: ActorRef){}
         }
-        io ! IOCommand.BindWorkerItem(() => new MyItem)
+        io ! IOCommand.BindWorkerItem(new MyItem)
         probe.expectMsg(100.milliseconds, "BOUND")
+      }
+    }
+
+    "not bind more than once" in {
+      withIOSystem{io =>
+        val probe = TestProbe()
+        class MyItem extends WorkerItem {
+          override def onBind() {
+            probe.ref ! "BOUND"
+          }
+          def receivedMessage(message: Any, sender: ActorRef){}
+        }
+        val item = new MyItem
+        io ! IOCommand.BindWorkerItem(item)
+        probe.expectMsg(100.milliseconds, "BOUND")
+        io ! IOCommand.BindWorkerItem(item)
+        probe.expectNoMsg(100.milliseconds)
+      }       
+
+    }
+
+    "receive messages after binding" in {
+      withIOSystem{io =>
+        val probe = TestProbe()
+        class MyItem extends WorkerItem {
+          override def onBind() {
+            boundWorker.get.worker ! WorkerCommand.Message(id.get, "PING")
+          }
+          def receivedMessage(message: Any, sender: ActorRef){
+            message match {
+              case "PING" => probe.ref ! "PONG"
+            }
+          }
+        }
+        val item = new MyItem
+        io ! IOCommand.BindWorkerItem(item)
+        probe.expectMsg(100.milliseconds, "PONG")
+      }       
+    }
+
+    "not receive messages after unbinding" in {
+      withIOSystem{io =>
+        val probe = TestProbe()
+        class MyItem extends WorkerItem {
+          override def onBind() {
+            boundWorker.get.worker ! WorkerCommand.UnbindWorkerItem(id.get)
+            boundWorker.get.worker ! WorkerCommand.Message(id.get, "PING")
+          }
+          def receivedMessage(message: Any, sender: ActorRef){
+            message match {
+              case "PING" => probe.ref ! "PONG"
+            }
+          }
+        }
+        val item = new MyItem
+        io ! IOCommand.BindWorkerItem(item)
+        probe.expectNoMsg(100.milliseconds)
       }
     }
 

--- a/colossus-tests/src/test/scala/colossus/service/ClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ClientSpec.scala
@@ -68,6 +68,7 @@ class ClientSpec extends ColossusSpec {
 
     "get connection status" in {
       withAsyncClient { (server, client) => {
+        Thread.sleep(500)
         Await.result(client.connectionStatus, 100.milliseconds) must equal(ConnectionStatus.Connected)
       }
       }

--- a/colossus-tests/src/test/scala/colossus/service/LoadBalancingClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/LoadBalancingClientSpec.scala
@@ -111,14 +111,14 @@ class LoadBalancingClientSpec extends ColossusSpec with MockitoSugar{
     "get a shared interface when bound" in {
       val (probe, worker) = FakeIOSystem.fakeWorkerRef
       val l = new LoadBalancingClient[String,Int](worker, mockGenerator, maxTries = 2)
-      l.bind(1, worker)
+      l.setBind(1, worker)
       val shared = l.shared
     }
 
     "send messages in shared interface" in {
       val (probe, worker) = FakeIOSystem.fakeWorkerRef
       val l = new LoadBalancingClient[String,Int](worker, mockGenerator, maxTries = 2)
-      l.bind(1, worker)
+      l.setBind(1, worker)
       val shared = l.shared
       shared.send("hey")
       probe.expectMsgType[IOCommand.BindWorkerItem](100.milliseconds)
@@ -133,7 +133,7 @@ class LoadBalancingClientSpec extends ColossusSpec with MockitoSugar{
       val clients = addrs(num)
       val (probe, worker) = FakeIOSystem.fakeWorkerRef
       val l = new LoadBalancingClient[String,Int](worker, mockGenerator, maxTries = 2, initialClients = clients)
-      l.bind(1, worker)
+      l.setBind(1, worker)
       val shared = l.shared
       (1 to ops).foreach{i => 
         l.receivedMessage(l.Send("hey", Promise()), probe.ref)

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -32,10 +32,9 @@ class ServiceClientSpec extends ColossusSpec {
       sentBufferSize = maxSentSize, 
       failFast = failFast
     )
-    val client = new RedisClient(config, worker)
-    client.bind(1, worker)
-    client.connect()
-    workerProbe.expectMsgType[IOCommand.Connect](50.milliseconds)
+    val client = new RedisClient(config)
+    client.setBind(1, worker)
+    workerProbe.expectMsgType[WorkerCommand.Connect](50.milliseconds)
     val endpoint = new MockWriteEndpoint(30, workerProbe, Some(client))
     client.connected(endpoint)
     (endpoint, client, workerProbe)
@@ -354,24 +353,6 @@ class ServiceClientSpec extends ColossusSpec {
       probe.expectNoMsg(50.milliseconds)
     }
 
-    //TODO:  I need to be a real test.  I'm confused.  Do I call connect? or connected(endpoint). What is the right API?
-    "not allow a disconnected client to reconnect" in {
-      val (endpoint, client, probe) = newClient(true, 10)
-      endpoint.disconnect()
-      val newEndpoint = new MockWriteEndpoint(30, probe, Some(client))
-      intercept[StaleClientException]{
-        client.connect()
-      }
-    }
-
-    "not allow a gracefully disconnected client to reconnect" in {
-      val (endpoint, client, probe) = newClient(true, 10)
-      client.gracefulDisconnect()
-      val newEndpoint = new MockWriteEndpoint(30, probe, Some(client))
-      intercept[StaleClientException]{
-        client.connect()
-      }
-    }
 
     "get a shared interface" in {
       val (endpoint, client, probe) = newClient(true, 10)

--- a/colossus/src/main/scala/colossus/core/ActorHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ActorHandler.scala
@@ -76,7 +76,7 @@ object ActorHandler {
 
   def apply(address: InetSocketAddress, name: String = "async-client")(implicit io: IOSystem) = {
     val actor = io.actorSystem.actorOf(Props(classOf[ActorHandler]), name = name)
-    io ! IOCommand.Connect(address, worker => new AsyncHandler(actor, worker))
+    io ! IOCommand.BindAndConnectWorkerItem(address, new AsyncHandler(actor))
     actor
   }
 

--- a/colossus/src/main/scala/colossus/core/AsyncHandler.scala
+++ b/colossus/src/main/scala/colossus/core/AsyncHandler.scala
@@ -15,11 +15,11 @@ trait WatchedHandler extends ConnectionHandler {
 }
 
 //the sender (the worker
-case class AsyncHandler(handler: ActorRef, worker: WorkerRef) extends WatchedHandler with ClientConnectionHandler {
+case class AsyncHandler(handler: ActorRef) extends WatchedHandler with ClientConnectionHandler {
   import ConnectionCommand._
   import ConnectionEvent._
 
-  implicit val sender = worker.worker
+  implicit lazy val sender = boundWorker.get.worker
 
   private var endpointOpt: Option[WriteEndpoint] = None
   def endpoint = endpointOpt.getOrElse(throw new Exception("Attempted to use non-connected endpoint"))
@@ -99,7 +99,7 @@ object AsyncHandler {
   def serverHandler(handler: ActorRef, worker: WorkerRef)(implicit fact: ActorRefFactory): AsyncHandler = {
     val actor = fact.actorOf(Props[ActorHandler])
     actor ! ActorHandler.RegisterListener(handler)
-    AsyncHandler(actor, worker)
+    AsyncHandler(actor)
   }
     
 }

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -14,6 +14,7 @@ import scala.collection.JavaConversions._
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
 
+class WorkerItemException(message: String) extends Exception(message)
 
 /**
  * Represents the binding of an item to a worker
@@ -31,11 +32,14 @@ case class WorkerItemBinding(id: Long, worker: WorkerRef) {
 }
 
 /**
- * A WorkerItem is anything that can be attached to and communicated through a Worker.  Examples are Tasks and
- * ConnectionHandlers.
+ * A WorkerItem is anything that can be bound to worker to receive both events
+ * and external messages.  WorkerItems are expected to be single-threaded and
+ * non-blocking.  Once a WorkerItem is bound to a worker, all of its methods
+ * are executed in the event-loop thread of the bound worker.
  */
-private[colossus] trait WorkerItem {
+trait WorkerItem {
   private var _binding: Option[WorkerItemBinding] = None
+  //todo - change these from Option[x] to just x and rethrow None exception as WorkerItemException
   def id = _binding.map{_.id}
   def boundWorker = _binding.map{_.worker}
 
@@ -43,13 +47,38 @@ private[colossus] trait WorkerItem {
   def binding = _binding
   def isBound = _binding.isDefined
 
+  /**
+   * Attempt to bind this WorkerItem to the worker.  When the binding succeeds,
+   * `onBind()` is called and the item will be able to receive events and
+   * messages.  Notice that this method is asynchronous.
+   *
+   * @param worker The worker to bind to
+   */
+  def bind(worker: WorkerRef) {
+    if (isBound) {
+      throw new WorkerItemException(s"Cannot bind WorkerItem, already bound with id ${id.get}")
+    }
+    boundWorker.get.bind(this)
+  }
+
+  /**
+   * Unbinds the WorkerItem, if it is bound.  When unbinding is complete,
+   * `onUnbind()` is called.  This method is asynchronous.
+   */
+  def unbind() {
+    if (!isBound) {
+      throw new WorkerItemException(s"Cannot unbind WorkerItem, not bound to any worker")
+    }
+    boundWorker.get.unbind(id.get)
+  }
+
 
   /**
    * bind the item to a Worker.
    * @param id  The id assigned to this Item.
    * @param worker The Worker whom was bound
    */
-  private[colossus] def bind(id: Long, worker: WorkerRef) {
+  private[colossus] def setBind(id: Long, worker: WorkerRef) {
     _binding = Some(WorkerItemBinding(id, worker))
     onBind()
   }
@@ -57,7 +86,7 @@ private[colossus] trait WorkerItem {
   /**
    * Called when this item is unbound from a Worker.
    */
-  private[colossus] def unbind(){
+  private[colossus] def setUnbind(){
     _binding = None
     onUnbind()
   }
@@ -82,16 +111,6 @@ private[colossus] trait WorkerItem {
 
 
 }
-
-/**
- * BindableWorkItem is the public facing trait which is meant for Tasks and other objects which are Bindable to
- * a Worker.  Connection handlers purposely do not implement this trait so
- * users don't accidentally attempt to bind connection handlers this way, which
- * won't work
- *
- * TODO; this is probably not needed anymore
- */
-trait BindableWorkerItem extends WorkerItem
 
 
 /**
@@ -129,8 +148,12 @@ case class WorkerRef(id: Int, metrics: LocalCollection, worker: ActorRef, system
    * and initialized within this worker to ensure that the worker item's
    * lifecycle is single-threaded.
    */
-  def bind(item: BindableWorkerItem) {
-    worker ! IOCommand.BindWorkerItem(() => item)
+  def bind(item: WorkerItem) {
+    worker ! IOCommand.BindWorkerItem(item)
+  }
+
+  def unbind(workerItemId: Long) {
+    worker ! WorkerCommand.UnbindWorkerItem(workerItemId)
   }
 }
 
@@ -153,16 +176,20 @@ class WorkerItemManager(worker: WorkerRef, log: LoggingAdapter) {
    * Binds a new worker item to this worker
    */
   def bind(workerItem: WorkerItem) {
-    val id = newId()
-    workerItems(id) = workerItem
-    workerItem.bind(id, worker)
+    if (workerItem.isBound) {
+      log.error(s"Attempted to bind worker ${workerItem.binding} that was already bound")
+    } else {
+      val id = newId()
+      workerItems(id) = workerItem
+      workerItem.setBind(id, worker)
+    }
   }
 
   def unbind(id: Long) {
     if (workerItems contains id) {
       val item = workerItems(id)
       workerItems -= id
-      item.unbind()   
+      item.setUnbind()   
     } else {
       log.error(s"Attempted to unbind worker $id that is not bound to this worker")
     }    
@@ -310,18 +337,13 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
   def handleIOCommand(cmd: IOCommand) {
     import IOCommand._
     cmd match {
-      case Connect(address, handlerFactory) => {
-        val handler = handlerFactory(me)
-        workerItems.bind(handler)
-        clientConnect(address, handler)
-      }
-      case Reconnect(address, handler) => {
-        clientConnect(address, handler)
-      }
       case BindWorkerItem(workerItem) => {
-        workerItems.bind(workerItem())
+        workerItems.bind(workerItem)
       }
-
+      case BindAndConnectWorkerItem(address, item) => {
+        workerItems.bind(item)
+        self ! WorkerCommand.Connect(address, item.id.get)
+      }
     }
   }
 
@@ -373,6 +395,14 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
       case Disconnect(connectionId) => {
         connections.get(connectionId).foreach{con =>
           unregisterConnection(con, DisconnectCause.Disconnect)
+        }
+      }
+      case Connect(address, id) => {
+        getWorkerItem(id).map{
+          case handler: ClientConnectionHandler => clientConnect(address, handler)
+          case other => log.error(s"Attempted to attach connection ($address) to a worker item that's not a ClientConnectionHandler")
+        }.getOrElse {
+          log.error(s"Attempted to attach connection (${address}) to non-existant WorkerItem $id")
         }
       }
     }
@@ -464,6 +494,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
             key.attachment match {
               case c: Connection => {
                 //connection reset by peer, no need to log
+                log.warning(s"IO Error on ${c.id}: ${t.getMessage}")
                 unregisterConnection(c, DisconnectCause.Closed)
               }
             }
@@ -499,7 +530,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
               unregisterConnection(c, DisconnectCause.Error(j))
             }
             case other: Throwable => {
-              log.warning("Error handling write: ${other.getClass.getName} : ${other.getMessage}")
+              log.warning(s"Error handling write: ${other.getClass.getName} : ${other.getMessage}")
             }
           }
           case _ => {}
@@ -554,6 +585,9 @@ object Worker {
 sealed trait WorkerCommand
 object WorkerCommand {
 
+  //open a new client connection to the specified address.  The bound
+  //[WorkerItem] with id `id` will act as the event handler for the connection
+  case class Connect(address: InetSocketAddress, id: Long) extends WorkerCommand
   case class UnbindWorkerItem(id: Long) extends WorkerCommand
   case class Schedule(in: FiniteDuration, message: Any) extends WorkerCommand
   case class Message(id: Long, message: Any) extends WorkerCommand

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -142,6 +142,7 @@ case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, heade
 object HttpHead {
 
   import java.net.URI
+  //todo, this throws exceptions on malformed URLS, should catch and return 400 instead
   def parseParameters(q: String): Map[String, String] = {
     if (q != null && q.length > -1) {
       val params = scala.collection.mutable.HashMap[String, String]()

--- a/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
@@ -178,10 +178,9 @@ class MemcacheClientCodec(maxSize: DataSize = MemcacheReplyParser.DefaultMaxSize
   }
 }
 
-class MemcacheClient(config: ClientConfig, worker: WorkerRef, maxSize : DataSize = MemcacheReplyParser.DefaultMaxSize)
+class MemcacheClient(config: ClientConfig, maxSize : DataSize = MemcacheReplyParser.DefaultMaxSize)
   extends ServiceClient[MemcacheCommand, MemcacheReply](
     codec   = new MemcacheClientCodec(maxSize),
-    config  = config,
-    worker  = worker
+    config  = config
   )
 

--- a/colossus/src/main/scala/colossus/protocols/redis/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/package.scala
@@ -27,10 +27,9 @@ package object redis {
     val name = "redis"
   }
 
-  class RedisClient(config: ClientConfig, worker: WorkerRef, maxSize : DataSize = RedisReplyParser.DefaultMaxSize) extends ServiceClient(
+  class RedisClient(config: ClientConfig, maxSize : DataSize = RedisReplyParser.DefaultMaxSize) extends ServiceClient(
     codec     = new RedisClientCodec(maxSize),
-    config    = config,
-    worker    = worker
+    config    = config
   ) {
     import UnifiedProtocol._
     def info: Callback[Map[String, String]] = send(Command(CMD_INFO)).mapTry{_.flatMap{

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -12,13 +12,13 @@ import scala.concurrent.duration._
 /**
  * This correctly routes messages to the right worker and handler
  */
-class ClientProxy(config: ClientConfig, system: IOSystem, handlerFactory: ActorRef => WorkerRef => ClientConnectionHandler) extends Actor with ActorLogging  with Stash {
+class ClientProxy(config: ClientConfig, system: IOSystem, handlerFactory: ActorRef => ClientConnectionHandler) extends Actor with ActorLogging  with Stash {
   import WorkerCommand._
   import ConnectionEvent._
   import config._
 
   override def preStart() {
-    system.workerManager ! IOCommand.Connect(address, handlerFactory(self))
+    system.workerManager ! IOCommand.BindWorkerItem(handlerFactory(self))
     context.become(binding)
   }
 
@@ -26,6 +26,7 @@ class ClientProxy(config: ClientConfig, system: IOSystem, handlerFactory: ActorR
 
   def binding: Receive = {
     case Bound(id) => {
+      println(s"service client bound $id")
       context.become(proxy(id, sender))
       unstashAll()
     }
@@ -35,6 +36,9 @@ class ClientProxy(config: ClientConfig, system: IOSystem, handlerFactory: ActorR
 
 
   def proxy(connectionId: Long, worker: ActorRef): Receive = {
+    case Bound(wat) => {
+      println(s"RECEIVED BOUND AGAIN! $connectionId vs $wat")
+    }
     case Connected => {} //we ignore this because there's nothing to do with it.  Maybe add a callback in the future
     case AsyncServiceClient.Disconnect => self ! PoisonPill //the worker is watching us and will close the underlying connection
     case x => worker ! Message(connectionId, x)
@@ -78,15 +82,13 @@ class AsyncHandlerGenerator[I,O](config: ClientConfig, codec: Codec[I,O]) {
    */
   class AsyncHandler(
     config: ClientConfig,
-    worker: WorkerRef,
     val caller: ActorRef
-  ) extends ServiceClient[I,O](codec, config, worker) with WatchedHandler {
-    implicit val sender = worker.worker
+  ) extends ServiceClient[I,O](codec, config) with WatchedHandler {
     val watchedActor = caller
 
     override def onBind() {
       super.onBind()
-      caller.!(ConnectionEvent.Bound(id.get))(worker.worker)
+      caller.!(ConnectionEvent.Bound(id.get))(boundWorker.get.worker)
     }
 
     override def receivedMessage(message: Any, sender: ActorRef) {
@@ -125,6 +127,6 @@ class AsyncHandlerGenerator[I,O](config: ClientConfig, codec: Codec[I,O]) {
     }
   }
 
-  val handlerFactory: ActorRef => WorkerRef => ConnectionHandler = caller => worker => new AsyncHandler(config, worker, caller)
+  val handlerFactory: ActorRef => ConnectionHandler = caller => new AsyncHandler(config, caller)
 
 }

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -2,7 +2,7 @@ package colossus
 package service
 
 import akka.actor.ActorRef
-import core.{BindableWorkerItem, WorkerRef}
+import core.{WorkerItem, WorkerRef}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.reflect.ClassTag
 
@@ -77,7 +77,7 @@ class LoadBalancingClient[I,O] (
   generator: InetSocketAddress => ServiceClient[I,O], 
   maxTries: Int = Int.MaxValue,   
   initialClients: Seq[InetSocketAddress] = Nil
-) extends LocalClient[I,O] with BindableWorkerItem {
+) extends LocalClient[I,O] with WorkerItem {
 
 
   private val clients = collection.mutable.ArrayBuffer[ServiceClient[I,O]]()
@@ -101,7 +101,6 @@ class LoadBalancingClient[I,O] (
     
   private def addClient(address: InetSocketAddress, regen: Boolean): ServiceClient[I,O] = {
     val client = generator(address)
-    client.connect()
     clients.append(client)
     regeneratePermutations()
     client

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -5,6 +5,7 @@ import java.net.InetSocketAddress
 
 import akka.actor._
 import akka.event.Logging
+import akka.util.ByteString
 import colossus.core._
 import colossus.metrics._
 
@@ -84,7 +85,6 @@ trait SharedClient[I,O] extends ClientLike[I,O,Future] {
 }
 
 trait ServiceClientLike[I,O] extends LocalClient[I,O] {
-  def connect()
   def gracefulDisconnect()
   def config: ClientConfig
   def shared: SharedClient[I,O]
@@ -93,7 +93,11 @@ trait ServiceClientLike[I,O] extends LocalClient[I,O] {
 
 object ServiceClient {
 
-  def apply[I,O](codec: Codec[I,O], config: ClientConfig, worker: WorkerRef): ServiceClient[I,O] = new ServiceClient(codec, config, worker)
+  def apply[I,O](codec: Codec[I,O], config: ClientConfig, worker: WorkerRef): ServiceClient[I,O] = {
+    val c = new ServiceClient(codec, config)
+    worker.bind(c)
+    c
+  }
 
 }
 
@@ -110,19 +114,14 @@ class StaleClientException(msg : String) extends Exception(msg)
  * A ServiceClient is a non-blocking, synchronous interface that handles
  * sending atomic commands on a connection and parsing their replies
  *
- * Notice - a service client will not connect on it's own, the connect() method
- * must be called.  This is to avoid multiple connection requests when a
- * service client handler is created in the closure of a
- * ConnectionCommand.Connect message. 
- *
- * Therefore, if you are directly creating a client inside a server delegator,
- * you should call connect().  If you are creating the handler as part of a
- * Connect message to a worker or IOSystem, you should not call connect()
+ * Notice - The client will not begin to connect until it is bound to a worker,
+ * so when using the default constructor a service client will not connect on
+ * it's own.  You must either call `bind` on the client or use the constructor
+ * that accepts a worker
  */
 class ServiceClient[I,O](
   val codec: Codec[I,O], 
-  val config: ClientConfig,
-  val worker: WorkerRef
+  val config: ClientConfig
 ) extends ClientConnectionHandler with ServiceClientLike[I,O] {
   import colossus.IOCommand._
   import colossus.core.WorkerCommand._
@@ -130,14 +129,17 @@ class ServiceClient[I,O](
 
   type ResponseHandler = Try[O] => Unit
 
-  private val periods = List(1.second, 1.minute)
-  private val requests  = worker.metrics.getOrAdd(Rate(name / "requests", periods))
-  private val errors    = worker.metrics.getOrAdd(Rate(name / "errors", periods))
-  private val droppedRequests    = worker.metrics.getOrAdd(Rate(name / "dropped_requests", periods))
-  private val connectionFailures    = worker.metrics.getOrAdd(Rate(name / "connection_failures", periods))
-  private val disconnects  = worker.metrics.getOrAdd(Rate(name / "disconnects", periods))
+  private lazy val worker = boundWorker.get
 
-  private val latency = worker.metrics.getOrAdd(Histogram(name / "latency", periods = List(60.seconds), sampleRate = 0.10, percentiles = List(0.75,0.99)))
+  //todo: figure out how to make these not lazy
+  private val periods = List(1.second, 1.minute)
+  private lazy val requests  = worker.metrics.getOrAdd(Rate(name / "requests", periods))
+  private lazy val errors    = worker.metrics.getOrAdd(Rate(name / "errors", periods))
+  private lazy val droppedRequests    = worker.metrics.getOrAdd(Rate(name / "dropped_requests", periods))
+  private lazy val connectionFailures    = worker.metrics.getOrAdd(Rate(name / "connection_failures", periods))
+  private lazy val disconnects  = worker.metrics.getOrAdd(Rate(name / "disconnects", periods))
+  private lazy val latency = worker.metrics.getOrAdd(Histogram(name / "latency", periods = List(60.seconds), sampleRate = 0.10, percentiles = List(0.75,0.99)))
+  lazy val log = Logging(worker.system.actorSystem, s"client:$address")
 
   case class SourcedRequest(message: I, handler: ResponseHandler) {
     val start: Long = System.currentTimeMillis
@@ -150,7 +152,6 @@ class ServiceClient[I,O](
   private val pendingBuffer = mutable.Queue[SourcedRequest]()
   private var writer: Option[WriteEndpoint] = None
   private var disconnecting: Boolean = false //set to true during graceful disconnect
-  val log = Logging(worker.system.actorSystem, s"client:$address")
 
   //TODO way too application specific
   private val hpTags: TagMap = Map("client_host" -> address.getHostName, "client_port" -> address.getPort.toString)
@@ -172,16 +173,15 @@ class ServiceClient[I,O](
     if (canReconnect) ConnectionStatus.Connecting else ConnectionStatus.NotConnected
   )
 
-  def connect() {
+  override def onBind(){
+    super.onBind()
     if(!manuallyDisconnected){
-      worker ! Connect(address, _ => this)
+      log.info(s"client ${id.get} connecting to $address")
+      worker ! Connect(address, id.get)
     }else{
-      throw new StaleClientException("This client has already been manually disconnected, create a new one.")
+      throw new StaleClientException("This client has already been manually disconnected and cannot be reused, create a new one.")
     }
   }
-
-  //todo: this should now auto-connect on binding
-  //override def onBind(){}
 
   /**
    * Allow any requests in transit to complete, but cancel all pending requests
@@ -223,21 +223,26 @@ class ServiceClient[I,O](
 
   def receivedData(data: DataBuffer) {
     val now = System.currentTimeMillis
-    codec.decodeAll(data){response =>
-      try {
-        val source = sentBuffer.dequeue()
-        latency.add(tags = hTags, value = (now - source.start).toInt) //notice only grouping by host for now
-        source.handler(Success(response))
-        requests.hit(tags = hpTags)
-      } catch {
-        case e: java.util.NoSuchElementException => {
-          throw new DataException(s"No Request for response ${response.toString}!")
+    if (writer.isEmpty) {
+      val d = ByteString(data.takeAll)
+      log.error(s"Client $name($address) received data while not connected!: ${d.utf8String}")
+    } else {
+      codec.decodeAll(data){response =>
+        try {
+          val source = sentBuffer.dequeue()
+          latency.add(tags = hTags, value = (now - source.start).toInt) //notice only grouping by host for now
+          source.handler(Success(response))
+          requests.hit(tags = hpTags)
+        } catch {
+          case e: java.util.NoSuchElementException => {
+            throw new DataException(s"No Request for response ${response.toString}!")
+          }
         }
+        
       }
-      
+      checkGracefulDisconnect()
+      checkPendingBuffer()
     }
-    checkGracefulDisconnect()
-    checkPendingBuffer()
   }
 
   def receivedMessage(message: Any, sender: ActorRef) {
@@ -248,7 +253,10 @@ class ServiceClient[I,O](
   }
 
   def connected(endpoint: WriteEndpoint) {
-    log.info(s"Connected to $address")
+    if (writer.isDefined) {
+      throw new Exception("Handler Connected twice!")
+    }
+    log.info(s"${id.get} Connected to $address")
     codec.reset()    
     writer = Some(endpoint)
     connectionAttempts = 0
@@ -283,7 +291,7 @@ class ServiceClient[I,O](
 
   override protected def connectionLost(cause : DisconnectError) {
     purgeBuffers(new NotConnectedException("Connection lost"))
-    log.warning(s"connection to ${address.toString} lost: $cause")
+    log.warning(s"${id.get} connection to ${address.toString} lost: $cause")
     disconnects.hit(tags = hpTags)
     attemptReconnect()
   }
@@ -300,7 +308,7 @@ class ServiceClient[I,O](
     if(!disconnecting) {
       if(canReconnect) {
         log.warning(s"attempting to reconnect to ${address.toString} after $connectionAttempts unsuccessful attempts.")
-        worker ! Schedule(config.connectionAttempts.interval, Reconnect(address, this))
+        worker ! Schedule(config.connectionAttempts.interval, Connect(address, id.get))
       }
       else {
         log.error(s"failed to connect to ${address.toString} after $connectionAttempts tries, giving up.")

--- a/colossus/src/main/scala/colossus/service/ServiceClientPool.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClientPool.scala
@@ -20,7 +20,6 @@ class ServiceClientPool[I,O, T <: ServiceClient[I, O]](val commonConfig: ClientC
       address = address
     )
     val client = creator(config, worker)
-    client.connect()
     client
   }
 

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -100,9 +100,7 @@ trait ServiceContext[C <: CodecDSL] {
   def receive(receiver: Receive)
 
   def clientFor[D <: CodecDSL](config: ClientConfig)(implicit provider: ClientCodecProvider[D]): ServiceClient[D#Input, D#Output] = {
-    val client = new ServiceClient(provider.clientCodec(), config, worker)
-    client.connect()
-    client
+    ServiceClient(provider.clientCodec(), config, worker)
   }
 
   def clientFor[D <: CodecDSL](host: String, port: Int, requestTimeout: Duration = 1.second)(implicit provider: ClientCodecProvider[D]): ServiceClient[D#Input, D#Output] = {

--- a/colossus/src/main/scala/colossus/util/Task.scala
+++ b/colossus/src/main/scala/colossus/util/Task.scala
@@ -12,7 +12,7 @@ import akka.actor._
  *
  */
 
-abstract class Task(implicit factory: ActorRefFactory) extends BindableWorkerItem {
+abstract class Task(implicit factory: ActorRefFactory) extends WorkerItem {
   implicit val proxy = factory.actorOf(Props[TaskProxy])
   import TaskProxy._
 
@@ -91,7 +91,7 @@ object Task {
   def apply(runner: TaskContext => Unit)(implicit io: IOSystem): ActorRef = {
     val task: BasicTask = new BasicTask()(io.actorSystem)
     task.onStart(runner(task))
-    io ! IOCommand.BindWorkerItem(() => task)
+    io ! IOCommand.BindWorkerItem(task)
     task.proxy
   }
 }


### PR DESCRIPTION
This has a bunch of small, low-level changes originating from #44 .
- Fixes #44, which was stemming from the fact that connect could be called multiple times on a client.
- Service clients now automatically connect when bound to a worker.  This means there is no longer a `connect` method for clients.  However there is one major caveat here.  When created using the default constructor, this auto-connect doesn't happen because the handler is not automatically bound to a worker.  This means if you create a service client manually (such as `new ServiceClient(config, codec)`), you have to call `bind` on the worker to bind the client to that worker.  But the connection is automatic when the constructor with the worker is used, or when creating a client in the DSL using `clientFor`, or when using the new `BindAndConnectWorkerItem` IOCommand.
- No more `BindableWorkerItem`.  This was to prevent users from accidentally trying to bind ConnectionHandlers, which would technically work but never actually establish a connection.  This is still sometimes the case (not with ServiceClient), but we have a new BindAndConnectWorkItem which does establish an outgoing connection.
- `BindWorkerItem` now accepts a `WorkerItem` instead of a `() => WorkerItem`.  This is largely because the `onBind` callback now serves as the in-thread initialization point instead of the constructor.

I will probably be adding a few more tests before merging, but I figured I throw this out there now.
