### PR TITLE
Rename string methods to match object based ones. (+5 squashed commits)

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/WildcardURLParsingTest.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/WildcardURLParsingTest.scala
@@ -1,0 +1,53 @@
+package colossus.protocols.http
+
+import org.scalatest.{MustMatchers, WordSpec}
+
+/**
+ * Created by zoe on 12/9/14.
+ */
+class WildcardURLParsingTest extends WordSpec with MustMatchers {
+  import colossus.protocols.http.HttpMethod._
+  import colossus.protocols.http.HttpVersion._
+  import colossus.protocols.http.UrlParsing.Strings._
+    "The wildcard url parser" should {
+      "match a root url" in {
+          val url = ""
+          val request = HttpRequest(HttpHead(Get, url, `1.1`, List()), None)
+          request match {
+            case req @ Get on Root => true
+            case _ => fail()
+          }
+      }
+
+      "match a resource url" in {
+        val url = "/moose.jpg"
+        val request = HttpRequest(HttpHead(Get, url, `1.1`, List()), None)
+        request match {
+          case req @ Get on Root /: rest => rest must be("moose.jpg")
+          case _ => fail("Failed to match url")
+        }
+      }
+
+      "match a complex resource url" in {
+        val url = "/bronx/zoo/moose.jpg"
+        val request = HttpRequest(HttpHead(Get, url, `1.1`, List()), None)
+        request match {
+          case req @ Get on base /: city /: place /: animal  =>
+            base must be("/")
+            city must be("bronx")
+            place must be("zoo")
+            animal must be("moose.jpg")
+          case _ => fail("Failed to match complex url")
+        }
+      }
+
+      "partially match a url" in {
+        val url = "/bronx/zoo/moose.jpg"
+        val request = HttpRequest(HttpHead(Get, url, `1.1`, List()), None)
+        request match {
+          case req @ Get on Root /: city /: placeAndAnimal => placeAndAnimal must be("zoo/moose.jpg")
+          case _ => fail("Failed to match complex url")
+        }
+      }
+    }
+}

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -326,11 +326,11 @@ class ServiceClientSpec extends ColossusSpec {
       endpoint.clearBuffer()
       client.gracefulDisconnect()
       endpoint.disconnectCalled must equal(false)
-      intercept[NotConnectedException] {
+      intercept[CallbackExecutionException] {
         client.send(cmd2).execute{
           case Success(StatusReply(msg)) => {}
-          case Failure(nope) => throw nope
-          case _ => throw new Exception("Bad Response")
+          case Failure(nope: NotConnectedException) => throw nope
+          case _ => {}
         }
       }
       client.receivedData(rep1.raw)

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
@@ -1,12 +1,13 @@
 package colossus
 package protocols.http
 
-import core._
-import service._
+import colossus.core._
+import colossus.parsing.DataSize
+import colossus.service._
 
-class HttpClientCodec extends Codec.ClientCodec[HttpRequest, HttpResponse]{
+class HttpClientCodec(maxSize: DataSize = HttpResponseParser.DefaultMaxSize) extends Codec.ClientCodec[HttpRequest, HttpResponse]{
 
-  val parser = new HttpResponseParser
+  val parser = new HttpResponseParser(maxSize)
 
   override def encode(out: HttpRequest): DataBuffer = DataBuffer(out.bytes)
 

--- a/colossus/src/main/scala/colossus/protocols/http/UrlParsing.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/UrlParsing.scala
@@ -1,13 +1,30 @@
 package colossus
 package protocols.http
 
-object UrlParsing {
+/**
+ * URL parsing can be done using one of two paths. The first uses an object based decomposition with a minimal number
+ * of string operations. This parses using the 'on' keyword and the left associative '/' operator.
+ *
+ * The second method uses string operations in a right associative manner. Because all values are strings, it is less type
+ * safe than the object method. This is used with the 'in' keyword and the right associative '/:' operator. In this method,
+ * the final variable in the pattern will consume all remaining levels.
+ *
+ * To use either language, import the UrlParsing._ object
+*/
+ object UrlParsing {
 
+
+  /** Trait encapsulating parts of the parse of a url */
   sealed trait UrlComponent
+
+  /** Case class encapsulating a single piece of a parsed url */
   case class ParsedUrl(pieces: List[String]) extends UrlComponent
+
+  /** Case object indicting the root of a url */
   case object Root extends UrlComponent
 
   object Url {
+    /** Parses a string url into pieces for the object based url parsing DSL */
     def parse(str: String): UrlComponent = {
       val paramless = str.split("\\?").headOption
       paramless.map{ x =>
@@ -21,6 +38,9 @@ object UrlParsing {
     }
   }
 
+  /** Extractor for left-binding object based DSL. To use:
+    * case url @ Get <or other methed> on Root / first level / second level / .. repeat
+    */
   object / {
     def unapply(p: UrlComponent): Option[(UrlComponent, String)] = p match {
       case ParsedUrl(items) if (items.size == 1) => Some((Root, items.head))
@@ -29,6 +49,9 @@ object UrlParsing {
     }
   }
 
+
+
+  /** Extractor for integers */
   object Integer {
     def unapply(s: String) : Option[Int] = try {
       Some(s.toInt)
@@ -36,9 +59,43 @@ object UrlParsing {
       case n: java.lang.NumberFormatException => None
     }
   }
-  
+
+  /**
+   * Keyword which triggers left-binding object based parsing. Must be used to match a url pattern with an HTTP method.
+   */
   case object on {
     def unapply(request: HttpRequest): Option[(HttpMethod, UrlComponent)] = Some(request.head.method, Url.parse(request.head.url))
   }
+object Strings{
+  /** Constant indicating the root of the URL for use in string based parsing */
+  val Root = "/"
 
+  /** Extractor for right-binding string based DSL. To use:
+    * case irl @ Get <or other method> in ROOT /: first level /: second level /: remainder
+    */
+  object /: {
+    def unapply(s:String):Option[(String, String)] = s match {
+      case url:String if (url == "/") => Some((url, ""))
+      case url:String if (url startsWith "/") => Some("/", url drop 1)
+      case url:String  =>
+        val last = url.indexOf('/')
+        val tail = url.substring(last + 1)
+        val head = url.substring(0, last)
+        Some((if (head.isEmpty) "/" else head, tail))
+    }
+  }
+
+  /**
+   * Keyword which triggers right-binding string based parsing. Must be used to match a url pattern with an HTTP method.
+   */
+  case object on {
+    def unapply(request: HttpRequest): Option[(HttpMethod, String)] = {
+      val component = request.head.url match {
+        case "" => "/"
+        case url:String => url
+      }
+      Some(request.head.method, component)
+    }
+  }
+}
 }

--- a/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
@@ -168,19 +168,19 @@ class ZCompressor(bufferKB: Int = 10) extends Compressor {
 
 
 
-class MemcacheClientCodec extends Codec.ClientCodec[MemcacheCommand, MemcacheReply] {
-  private var parser = new MemcacheReplyParser//(NoCompressor) //config
+class MemcacheClientCodec(maxSize: DataSize = MemcacheReplyParser.DefaultMaxSize) extends Codec.ClientCodec[MemcacheCommand, MemcacheReply] {
+  private var parser = new MemcacheReplyParser(maxSize)//(NoCompressor) //config
 
   def encode(cmd: MemcacheCommand): DataBuffer = DataBuffer(cmd.bytes(NoCompressor))
   def decode(data: DataBuffer): Option[MemcacheReply] = parser.parse(data)
   def reset(){
-    parser = new MemcacheReplyParser//(NoCompressor)
+    parser = new MemcacheReplyParser(maxSize)//(NoCompressor)
   }
 }
 
-class MemcacheClient(config: ClientConfig, worker: WorkerRef) 
+class MemcacheClient(config: ClientConfig, worker: WorkerRef, maxSize : DataSize = MemcacheReplyParser.DefaultMaxSize)
   extends ServiceClient[MemcacheCommand, MemcacheReply](
-    codec   = new MemcacheClientCodec,
+    codec   = new MemcacheClientCodec(maxSize),
     config  = config,
     worker  = worker
   )

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisClientCodec.scala
@@ -4,13 +4,15 @@ package protocols.redis
 import core._
 import service._
 
-import akka.util.{ByteString, ByteStringBuilder}
+import colossus.parsing.DataSize
 
-class RedisClientCodec extends Codec.ClientCodec[Command, Reply] {
-  private var replyParser = RedisReplyParser()
+class RedisClientCodec(maxSize: DataSize = RedisReplyParser.DefaultMaxSize) extends Codec.ClientCodec[Command, Reply] {
+  private var replyParser = RedisReplyParser(maxSize)
+
   def reset(){
-    replyParser = RedisReplyParser()
+    replyParser = RedisReplyParser(maxSize)
   }
+
   def encode(cmd: Command) = DataBuffer(cmd.raw)
   def decode(data: DataBuffer): Option[Reply] = replyParser.parse(data)
 }

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisReplyParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisReplyParser.scala
@@ -2,16 +2,12 @@ package colossus
 package protocols.redis
 
 
-import core._
-import service._
-import parsing._
-import DataSize._
-
-import akka.util.{ByteString, ByteStringBuilder}
+import akka.util.ByteString
+import colossus.parsing.DataSize._
+import colossus.parsing._
 
 
 object RedisReplyParser {
-  import RedisReplyParser._
   import Combinators._
 
   val DefaultMaxSize: DataSize = 1.MB

--- a/colossus/src/main/scala/colossus/protocols/redis/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/package.scala
@@ -1,6 +1,7 @@
 package colossus
 package protocols
 
+import colossus.parsing.DataSize
 import core._
 import service._
 
@@ -26,8 +27,8 @@ package object redis {
     val name = "redis"
   }
 
-  class RedisClient(config: ClientConfig, worker: WorkerRef) extends ServiceClient(
-    codec     = new RedisClientCodec,
+  class RedisClient(config: ClientConfig, worker: WorkerRef, maxSize : DataSize = RedisReplyParser.DefaultMaxSize) extends ServiceClient(
+    codec     = new RedisClientCodec(maxSize),
     config    = config,
     worker    = worker
   ) {


### PR DESCRIPTION
New pull request with squashed commits.

Squashed commits:
[3f143d3] Move string parsing into Strings object
[e0e85f5] Move wildcard tests to live with other tests.
[859c42b] Revert "Convert ParsedUrl object to hold a vector instead of a list"

This reverts commit d8953997b2816a9059e505d27799813df966eb5f.
[d895399] Convert ParsedUrl object to hold a vector instead of a list
[e394cc5] Fix typo and remove dead code. (+3 squashed commits)
Squashed commits:
[256728a] exposed maxSize property for all Codecs
[5296c6f] exceptions thrown in the execute block of a Callback are no longer suppressed
[4279744] Wild card inclusive url parsing. Uses string parsing. New operator 'on' to trigger string parsing, and '/:' to use right binding traversal of the stack, allowing the rightmost part of the pattern to consume the remainder of the string.

Added doc comments to URL parsing (+1 squashed commit)
Squashed commits:
[db19faa] Starting wildcard url parsing - parses root url using "in" keyword rather than "on"
