### PR TITLE
removing warning when IOException is caught in Worker

### DIFF
--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -493,8 +493,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
           case t: java.io.IOException => {
             key.attachment match {
               case c: Connection => {
-                //connection reset by peer, no need to log
-                log.warning(s"IO Error on ${c.id}: ${t.getMessage}")
+                //connection reset by peer, sometimes thrown by read when the connection closes
                 unregisterConnection(c, DisconnectCause.Closed)
               }
             }


### PR DESCRIPTION
The exception is only thrown when SocketChannel.read is called when the
connection has just closed.  I had recently added this in and was suspicious that it was being thrown but it turns out this is normal behavior, so there's no need to log the error (perhaps make this more configurable in the future but for now it's way too noisy).
