### PR TITLE
adding totals back to rates, new concurrentRequests metric for services

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -12,13 +12,9 @@ import MetricAddress.Root
 
 case class MetricSystem(namespace: MetricAddress, clock: ActorRef, database: ActorRef, snapshot: Agent[MetricMap], tickPeriod: FiniteDuration) {
   
-  def query(filter: MetricFilter)(implicit ex: ExecutionContext): Future[MetricMap] = {
-    import MetricDatabase._
-    implicit val timeout = Timeout(50.milliseconds)
-    (database ? Query(filter)).collect{
-      case QueryResult(metrics) => metrics
-    }.mapTo[MetricMap]
-  }  
+  def query(filter: MetricFilter): MetricMap = snapshot().filter(filter)  
+
+  def query(queryString: String): MetricMap = query(MetricFilter(queryString))
 
   def report(config: MetricReporterConfig)(implicit fact: ActorRefFactory): ActorRef = MetricReporter(config)(this, fact)
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/Util.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/Util.scala
@@ -1,0 +1,23 @@
+package colossus
+package metrics
+
+import akka.testkit._
+import akka.actor._
+import akka.util.Timeout
+import scala.concurrent.duration._
+import org.scalatest._
+
+
+abstract class MetricIntegrationSpec(_system: ActorSystem) extends TestKit(_system) with ImplicitSender with WordSpecLike with MustMatchers with BeforeAndAfterAll {
+
+  def this() = this(ActorSystem("Spec"))
+
+  implicit val timeout = Timeout(500.milliseconds)
+
+  implicit val mySystem = system
+
+
+  override def afterAll() {
+    TestKit.shutdownActorSystem(system)
+  }
+}


### PR DESCRIPTION
This fixes both #47 and #51 .
- All rates now include a total count
- A new concurrent requests counter has been added for service servers.
