### PR TITLE
Few minor fixes

### DIFF
--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -34,6 +34,8 @@ case class HttpRequest(head: HttpHead, entity: Option[ByteString]) {
   def bytes : ByteString = {
     head.bytes ++ entity.getOrElse(ByteString())
   }
+
+  def withHeader(key: String, value: String) = copy(head = head.withHeader(key, value))
 }
 
 object HttpRequest {

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -6,6 +6,7 @@ import core._
 import akka.actor._
 import akka.util.Timeout
 import akka.pattern.ask
+import java.net.InetSocketAddress
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 
@@ -62,6 +63,19 @@ object AsyncServiceClient {
     val gen = new AsyncHandlerGenerator(config, codec)
     val actor = io.actorSystem.actorOf(Props(classOf[ClientProxy], config, io, gen.handlerFactory))
     gen.client(actor)
+  }
+
+  def apply[C <: CodecDSL](host: String, port: Int, requestTimeout: Duration = 100.milliseconds)(implicit io: IOSystem, provider: ClientCodecProvider[C]): AsyncServiceClient[C#Input, C#Output] = {
+    val config = ClientConfig(
+      name = provider.name,
+      address = new InetSocketAddress(host, port),
+      requestTimeout = requestTimeout
+    )
+    AsyncServiceClient[C](config)
+  }
+
+  def apply[C <: CodecDSL](config: ClientConfig)(implicit io: IOSystem, provider: ClientCodecProvider[C]): AsyncServiceClient[C#Input, C#Output] = {
+    AsyncServiceClient(config, provider.clientCodec())
   }
 }
 


### PR DESCRIPTION
* added a convenient `withHeader` method to `HttpRequest`
* added some new constructors to `AsyncServiceClient` that mirror those when creating clients in the DSL
* added very basic debugging feature to stream parsers that when enabled, will copy all of the data they parse and output raw data for each parsed item.  Obviously defaults to off.  This should probably be refined a bit but it already has proven to be pretty useful.