### PR TITLE
adding support for http chunked transfer

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -198,6 +198,15 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       parser.parse(data) must equal(Some(req))
       data.remaining must equal(0)
     }
+
+    "parse a request with chunked transfer encoding" in {
+      val req = s"GET /foo HTTP/1.1\r\nsomething:value\r\ntransfer-encoding: chunked\r\n\r\n3\r\nfoo\r\ne\r\n123456789abcde\r\n0\r\n\r\n"
+      val data = DataBuffer(ByteString(req))
+      val parser = requestParser
+      val parsed = parser.parse(data).get
+      parsed.entity must equal(Some(ByteString("foo123456789abcde")))
+      data.remaining must equal(0)
+    }
     
       
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
@@ -106,6 +106,15 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       }
     }
 
+    "parse a response with chunked transfer encoding" in {
+      val res = "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n3\r\nfoo\r\ne\r\n123456789abcde\r\n0\r\n\r\n"
+      val parser = new HttpResponseParser
+
+      val parsed = parser.parse(DataBuffer(ByteString(res))).get
+      parsed.data must equal (ByteString("foo123456789abcde"))
+    }
+      
+
   }
 
 

--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -58,6 +58,25 @@ class CombinatorSuite extends WordSpec with MustMatchers{
         }
       }
     }
+    "intUntil with hex base" in {
+      val parser = intUntil('!', 16)
+      parser.parse(data("3A3f!")) must equal(Some(0x3A3F))
+    }
+    "intUntil fails on invalid letter in hex" in {
+      intercept[ParseException] {
+        val parser = intUntil('!')
+        parser.parse(data("32G"))
+      }
+    }
+    "intUntil fails on invalid base" in {
+      intercept[Exception] {
+        val parser = intUntil('!', 17)
+      }
+      intercept[Exception] {
+        val parser = intUntil('!', 0)
+      }
+
+    }
     "literal" in {
       val parser = literal(ByteString("hello"))
       val d = data("helloasdf")

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -58,6 +58,7 @@ object HttpHeaders {
   val Connection        = "connection"
   val SetCookie         = "set-cookie"
   val CookieHeader      = "cookie"
+  val TransferEncoding  = "transfer-encoding"
 }
 
 case class Cookie(name: String, value: String, expiration: Option[DateTime])
@@ -105,7 +106,12 @@ case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, heade
   }
 
 
-  val contentLength: Int = headers.collectFirst{case (ContentLength, l) => l.toInt}.getOrElse(0)
+  /** Returns the value of the content-length header, if it exists.
+   * 
+   * Be aware that lacking this header may or may not be a valid request,
+   * depending if the "transfer-encoding" header is set to "chunked"
+   */
+  val contentLength: Option[Int] = headers.collectFirst{case (ContentLength, l) => l.toInt}
 
 
   lazy val cookies: List[Cookie] = multiHeader(CookieHeader).flatMap{Cookie.parseHeader}

--- a/colossus/src/main/scala/colossus/protocols/http/HttpParse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpParse.scala
@@ -1,7 +1,7 @@
 package colossus
 package protocols.http
 
-import akka.util.ByteString
+import akka.util.{ByteString, ByteStringBuilder}
 
 import parsing._
 import Combinators._
@@ -16,6 +16,13 @@ object HttpParse {
     stringUntil(':', toLower = true, allowWhiteSpace = false) ~ 
     stringUntil('\r', allowWhiteSpace = true, ltrim = true) <~ 
     byte >> {case key ~ value => (key, value)}
+  }
+
+  def chunkedBody: Parser[ByteString] = chunkedBodyBuilder(new ByteStringBuilder)
+
+  private def chunkedBodyBuilder(builder: ByteStringBuilder): Parser[ByteString] = intUntil('\r', 16) <~ byte |> {
+    case 0 => bytes(2) >> {_ => builder.result}
+    case n => bytes(n.toInt) <~ bytes(2) |> {bytes => chunkedBodyBuilder(builder.append(bytes))}
   }
 
 }


### PR DESCRIPTION
Fixes #58 

This adds (non-streaming) chunked transfer encoding support both for requests and responses.  So while this won't work for infinite streams (which is intentional), it will work for ordinary responses that happen to be chunk encoded.

There's still some quirks dealing with content-length, but they're unrelated to this fix so it'll be addressed in another PR