### PR TITLE
Graceful shutdown for controllers, services

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
@@ -107,6 +107,7 @@ abstract class ColossusSpec(_system: ActorSystem) extends TestKit(_system) with 
       val server = Server(config)
       waitForServer(server, waitTime)
       f(io, server)
+      end(server)
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -36,11 +36,17 @@ class TestController(processor: TestInput => Unit) extends Controller[TestInput,
 
   def receivedMessage(message: Any,sender: akka.actor.ActorRef): Unit = ???
 
+  def processMessage(message: TestInput) {
+    processor(message)
+  }
+
+
+  //these methods just expose protected versions
   def testPush(message: TestOutput)(onPush: OutputResult => Unit) {
     push(message)(onPush)
   }
-  def processMessage(message: TestInput) {
-    processor(message)
+  def testGracefulDisconnect() {
+    gracefulDisconnect()
   }
 }
 

--- a/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
@@ -20,8 +20,26 @@ class OutputControllerSpec extends ColossusSpec {
       val data = ByteString("Hello World!")
       val message = TestOutput(Source.one(DataBuffer(data)))
       controller.testPush(message){_ must equal (OutputResult.Success)}
-      endpoint.writeCalls(0) must equal(data)
+      endpoint.expectOneWrite(data)
 
+    }
+
+    "drain output buffer on graceful disconnect" in {
+      val (endpoint, controller) = createController()
+      val data = ByteString(List.fill(endpoint.maxWriteSize + 1)("x").mkString)
+      val message = TestOutput(Source.one(DataBuffer(data)))
+      val data2 = ByteString("m2")
+      val message2 = TestOutput(Source.one(DataBuffer(data2)))
+
+      controller.testPush(message){_ must equal (OutputResult.Success)}
+      controller.testPush(message2){_ must equal (OutputResult.Success)}
+      controller.testGracefulDisconnect()
+      endpoint.expectOneWrite(data.take(endpoint.maxWriteSize))
+      endpoint.disconnectCalled must equal(false)
+      endpoint.clearBuffer()
+      endpoint.expectWrite(data.drop(endpoint.maxWriteSize))
+      endpoint.expectWrite(data2)
+      endpoint.disconnectCalled must equal(true)  
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
@@ -14,9 +14,8 @@ class ConnectionSpec extends ColossusSpec {
       m.bytesAvailable must equal(5)
       m.readsEnabled must equal(true)
       m.writeReadyEnabled must equal(false)
-      m.bufferCleared must equal (false)
-      m.writeCalls.size must equal(1)
-      m.writeCalls.head must equal(ByteString("hello"))
+      m.expectBufferNotCleared
+      m.expectOneWrite(ByteString("hello"))
     }
 
     "partially buffer large data on overwrite" in {
@@ -25,16 +24,13 @@ class ConnectionSpec extends ColossusSpec {
       m.bytesAvailable must equal(0)
       m.readsEnabled must equal(true)
       m.writeReadyEnabled must equal(true)
-      m.bufferCleared must equal(false)
-      m.writeCalls.size must equal(1)
-      m.writeCalls.head must equal(ByteString("a1a2a3a4a5"))
+      m.expectBufferNotCleared()
+      m.expectOneWrite(ByteString("a1a2a3a4a5"))
       m.clearBuffer()
-      m.handleWrite()
       m.readsEnabled must equal(true)
       m.writeReadyEnabled must equal(false)
-      m.bufferCleared must equal(true)
-      m.writeCalls.size must equal(2)
-      m.writeCalls(1) must equal(ByteString("b1b2b3b4b5"))
+      m.expectBufferCleared()
+      m.expectOneWrite(ByteString("b1b2b3b4b5"))
     }
 
     "reject write calls when data is partially buffered" in {

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -76,10 +76,9 @@ class ServiceClientSpec extends ColossusSpec {
       val command = Command(CMD_GET, "foo")
       val (endpoint, client, probe) = newClient()
       val cb = client.send(command)
-      endpoint.numWrites must equal(0)
+      endpoint.expectNoWrite()
       cb.execute()
-      endpoint.numWrites must equal(1)
-      endpoint.writeCalls(0) must equal(command.raw)
+      endpoint.expectOneWrite(command.raw)
     }
 
     "process a reply" in {
@@ -88,8 +87,7 @@ class ServiceClientSpec extends ColossusSpec {
       val (endpoint, client, probe) = newClient()
       val cb = client.send(command).map{ r =>
         r must equal (reply)
-        endpoint.numWrites must equal(1)
-        endpoint.writeCalls(0) must equal(command.raw)
+        endpoint.expectOneWrite(command.raw)
         client.receivedData(reply.raw)
       }.recover{ case t => throw t}
 
@@ -103,11 +101,9 @@ class ServiceClientSpec extends ColossusSpec {
       val (endpoint, client, probe) = newClient()
       val cb = client.send(command)
       cb.execute()
-      endpoint.numWrites must equal(1)
-      endpoint.writeCalls(0) must equal(raw.slice(0, 30))
-      endpoint.clearBuffer() must equal(raw.slice(0,30))
-      endpoint.numWrites must equal(2)
-      endpoint.writeCalls(1) must equal(raw.slice(30, raw.size))
+      endpoint.expectOneWrite(raw.slice(0, 30))
+      endpoint.clearBuffer()
+      endpoint.expectOneWrite(raw.slice(30, raw.size))
     }
 
     "queue a second command when a big command is partially sent" in {
@@ -119,14 +115,13 @@ class ServiceClientSpec extends ColossusSpec {
       val cb2 = client.send(command2)
       cb.execute()
       cb2.execute()
-      endpoint.numWrites must equal(1)
-      endpoint.writeCalls(0) must equal(raw.slice(0, 30))
+      endpoint.expectOneWrite(raw.slice(0, 30))
       endpoint.clearBuffer()
-      endpoint.numWrites must equal(3)
+      endpoint.expectWrite(raw.slice(30, raw.size))
+      endpoint.expectOneWrite(command2.raw.slice(0, 10))
       endpoint.clearBuffer()
-      endpoint.numWrites must equal(4)
-      endpoint.writeCalls(1) must equal(raw.slice(30, raw.size))
-      endpoint.writeCalls(2) ++ endpoint.writeCalls(3) must equal(command2.raw)
+      endpoint.expectWrite(command2.raw.drop(10))
+      //endpoint.writeCalls(2) ++ endpoint.writeCalls(3) must equal(command2.raw)
 
     }
 
@@ -155,9 +150,9 @@ class ServiceClientSpec extends ColossusSpec {
       val cb = client.send(command).map{
         case wat => failed = false
       }
-      endpoint.numWrites must equal(0)
+      endpoint.expectNoWrite()
       cb.execute()
-      endpoint.numWrites must equal(1)
+      endpoint.expectOneWrite(command.raw)
       endpoint.disconnect()
       failed must equal(true)
     }
@@ -183,7 +178,7 @@ class ServiceClientSpec extends ColossusSpec {
 
       val newEndpoint = new MockWriteEndpoint(30, probe, Some(client))
       client.connected(newEndpoint)
-      newEndpoint.numWrites must equal(1)
+      newEndpoint.expectOneWrite(command2.raw)
       newEndpoint.clearBuffer()
       client.receivedData(reply.raw)
       response must equal(Some(reply))
@@ -226,7 +221,7 @@ class ServiceClientSpec extends ColossusSpec {
         case Success(r) => response2 = Some(r)
         case Failure(nope) => throw new Exception("NOPE2")
       }
-      endpoint.numWrites must equal(1)
+      endpoint.expectOneWrite(command1.raw.slice(0, 30))
       while (endpoint.clearBuffer().size > 0) {}
       client.receivedData(reply1.raw)
       client.receivedData(reply2.raw)
@@ -247,7 +242,7 @@ class ServiceClientSpec extends ColossusSpec {
           case _ => throw new Exception("Executed!")
         }
       }
-      endpoint.numWrites must equal (1)
+      endpoint.expectOneWrite(big.raw.slice(0, 30))
       var failed = false
       client.send(shouldFail).execute{
         case Success(_) => throw new Exception("Didn't fail?!?!")
@@ -275,7 +270,7 @@ class ServiceClientSpec extends ColossusSpec {
       val (endpoint, client, probe) = newClient(true)
       var failed = false
       val cb = client.send(command)
-      endpoint.numWrites must equal(0)
+      endpoint.expectNoWrite()
       endpoint.connection_status = ConnectionStatus.NotConnected
       cb.execute{
         case Success(wat) => println("HERE");throw new Exception("NOPE")
@@ -302,11 +297,11 @@ class ServiceClientSpec extends ColossusSpec {
         case Failure(nope) => throw nope
         case _ => throw new Exception("Bad Response")
       }
-      endpoint.numWrites must equal(1)
+      endpoint.expectOneWrite(cmd1.raw)
       endpoint.clearBuffer()
       client.receivedData(rep1.raw)
       res1 must equal(Some(rep1.message))
-      endpoint.numWrites must equal(2)
+      endpoint.expectOneWrite(cmd2.raw)
       endpoint.clearBuffer()
       client.receivedData(rep2.raw)
       res2 must equal(Some(rep2.message))
@@ -323,7 +318,7 @@ class ServiceClientSpec extends ColossusSpec {
         case Failure(nope) => throw nope
         case _ => throw new Exception("Bad Response")
       }
-      endpoint.numWrites must equal(1)
+      endpoint.expectOneWrite(cmd1.raw)
       endpoint.clearBuffer()
       client.gracefulDisconnect()
       endpoint.disconnectCalled must equal(false)
@@ -366,7 +361,7 @@ class ServiceClientSpec extends ColossusSpec {
     }
 
     //blocked on https://github.com/tumblr/colossus/issues/19
-    "attempts to reconnect when server closes connection" ignore {
+    "attempts to reconnect when server closes connection" in {
       //try it for real (reacting to a bug with NIO interaction)
       withIOSystem{implicit sys => 
         import protocols.redis._
@@ -374,7 +369,7 @@ class ServiceClientSpec extends ColossusSpec {
         val reply = StatusReply("LATER LOSER!!!")
         val server = Service.serve[Redis]("test", TEST_PORT) {_.handle{con => con.become{
           case c if (c.command == "BYE") => {
-            con.disconnect()
+            con.gracefulDisconnect()
             reply
           }
           case other => StatusReply("ok")
@@ -396,11 +391,11 @@ class ServiceClientSpec extends ColossusSpec {
         }
       }
     }
-    "not attempt reconnect when autoReconnect is false" taggedAs(Tag("wat")) ignore {
+    "not attempt reconnect when autoReconnect is false" taggedAs(Tag("wat")) in {
       withIOSystem{ implicit io => 
         val server = Service.serve[Raw]("rawwww", TEST_PORT) {_.handle{con => con.become{
           case foo => {
-            con.disconnect()
+            con.gracefulDisconnect()
             foo
           }
         }}}
@@ -413,11 +408,11 @@ class ServiceClientSpec extends ColossusSpec {
       }
     }
 
-    "attempt to reconnect a maximum amount of times when autoReconnect is true and a maximum amount is specified" ignore {
+    "attempt to reconnect a maximum amount of times when autoReconnect is true and a maximum amount is specified" in {
       withIOSystem{ implicit io =>
         val server = Service.serve[Raw]("rawwww", TEST_PORT) {_.handle{con => con.become{
           case foo => {
-            con.disconnect()
+            con.gracefulDisconnect()
             foo
           }
         }}}

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -1,8 +1,8 @@
 package colossus
+package service
 
 import testkit._
 import core._
-import service._
 import Callback.Implicits._
 
 import akka.testkit.TestProbe
@@ -15,9 +15,7 @@ import akka.util.ByteString
 import java.net.InetSocketAddress
 
 import protocols.redis._
-import UnifiedProtocol._
 import scala.concurrent.Await
-
 
 class ServiceServerSpec extends ColossusSpec {
 
@@ -53,6 +51,28 @@ class ServiceServerSpec extends ColossusSpec {
             case e: ErrorReply => {}
             case other => throw new Exception(s"Non-error reply: $other")
           }
+        }
+      }
+    }
+
+    "graceful disconnect" in {
+      withIOSystem{implicit io => 
+        val server = Service.serve[Redis]("test", TEST_PORT){_.handle{con => con.become{
+          case x if (x.command == "DIE") => {
+            con.gracefulDisconnect()
+            StatusReply("BYE")
+          }
+          case other => {
+            import con.callbackExecutor
+            Callback.schedule(100.milliseconds)(StatusReply("FOO"))
+          }
+        }}}
+        withServer(server) {
+          val client = AsyncServiceClient[Redis]("localhost", TEST_PORT)
+          val r1 = client.send(Command("TEST"))
+          val r2 = client.send(Command("DIE"))
+          Await.result(r1, 1.second) must equal(StatusReply("FOO"))
+          Await.result(r2, 1.second) must equal(StatusReply("BYE"))
         }
       }
     }

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -102,6 +102,10 @@ class Trigger {
   def trigger() {
     callback.foreach{f => f()}
   }
+
+  def cancel() {
+    callback = None
+  }
 }
 
 sealed trait PushResult

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -184,7 +184,7 @@ class ServiceClient[I,O](
    * Allow any requests in transit to complete, but cancel all pending requests
    * and don't allow any new ones
    */
-  def gracefulDisconnect() {
+  override def gracefulDisconnect() {
     log.info(s"Terminating connection to $address")
     //clearPendingBuffer(new NotConnectedException("Connection is closing"))
     //todo, we should maybe make the Cancelled OutputResult take a Throwable
@@ -324,7 +324,7 @@ class ServiceClient[I,O](
 
   private def checkGracefulDisconnect() {
     if (disconnecting && sentBuffer.size == 0) {
-      disconnect()
+      super.gracefulDisconnect()
     }
   }
 

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -89,6 +89,7 @@ trait ConnectionContext[C <: CodecDSL] {
     become{case all => f(all)}
   }
   def disconnect()
+  def gracefulDisconnect()
 
   implicit val callbackExecutor: CallbackExecutor
 }


### PR DESCRIPTION
Both `Controller` and `ServiceServer` now have a `gracefulDisconnect` method.

* For controllers, this will stop reading new data, reject new output messages, and wait for the outgoing messages buffer to drain before disconnecting.  
* For services this will also stop reads, and allow any pending requests to complete (or timeout) before disconnecting.

Also I cleaned up the `MockWriteBuffer` making it easier to use in tests.