### PR TITLE
Adding more verbosity on metrics logging

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/LoggerSender.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/LoggerSender.scala
@@ -1,19 +1,17 @@
 package colossus.metrics
 
 import akka.actor._
+import colossus.metrics.senders.MetricsLogger
 
 /**
  * Simple sender that just prints the stats to the log
  */
-class LoggerSenderActor(verbose: Boolean = false) extends Actor with ActorLogging {
+class LoggerSenderActor extends Actor with ActorLogging with  MetricsLogger {
 
   def receive = {
     case s: MetricSender.Send => {
-      val frags = s.fragments
-      if (verbose) {
-        frags.foreach{stat => log.info(OpenTsdbFormatter.format(stat, s.timestamp).stripLineEnd)}
-      }
-      log.info(s"Logged ${frags.size} stats")
+      logMetrics(s)
+      log.info(s"Logged ${s.metrics.size} stats")
     }
   }
 
@@ -27,8 +25,8 @@ class LoggerSenderActor(verbose: Boolean = false) extends Actor with ActorLoggin
 
 }
 
-case class LoggerSender(verbose: Boolean = false) extends MetricSender {
+object LoggerSender extends MetricSender {
   def name = "logger"
-  def props = Props(classOf[LoggerSenderActor], verbose)
+  def props = Props(classOf[LoggerSenderActor])
 }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/OpenTsdbSender.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/OpenTsdbSender.scala
@@ -1,12 +1,13 @@
 package colossus.metrics
 
 import akka.actor._
+import colossus.metrics.senders.MetricsLogger
 import scala.concurrent.duration._
 
 import java.net._
 
 //TODO : OH jeez don't use raw socket
-class OpenTsdbSenderActor(val host: String, val port: Int) extends Actor with ActorLogging{
+class OpenTsdbSenderActor(val host: String, val port: Int) extends Actor with ActorLogging with MetricsLogger{
 
   val address = new InetSocketAddress(host, port)
   val timeout = 500
@@ -34,7 +35,10 @@ class OpenTsdbSenderActor(val host: String, val port: Int) extends Actor with Ac
   }
 
   def accepting: Receive = {
-    case s: MetricSender.Send => put(s.fragments, s.timestamp)
+    case s: MetricSender.Send => {
+      logMetrics(s)
+      put(s.fragments, s.timestamp)
+    }
   }
 
   override def postRestart(reason: Throwable) {

--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/package.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/package.scala
@@ -1,0 +1,18 @@
+package colossus.metrics
+
+import akka.actor.ActorLogging
+
+package object senders {
+
+  trait MetricsLogger{ this : ActorLogging =>
+
+    def logMetrics(s : MetricSender.Send) {
+      val frags = s.fragments
+      if (log.isDebugEnabled) {
+        frags.foreach{stat => log.debug(OpenTsdbFormatter.format(stat, s.timestamp).stripLineEnd)}
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
It is controlled now by akka / slf4j log levels.  At the debug level it will print out detailed info of each metric that is being logged which i found super useful for debugging.

Fixes #94 