### PR TITLE
Close socket on actor stop

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/OpenTsdbSender.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/OpenTsdbSender.scala
@@ -17,6 +17,10 @@ class OpenTsdbSenderActor(val host: String, val port: Int) extends Actor with Ac
 
   val socket = new Socket
 
+  override def postStop(): Unit = {
+    socket.close()
+  }
+
   def put(stats: Seq[MetricFragment], ts: Long) {
     val os = socket.getOutputStream
     val now = ts / 1000


### PR DESCRIPTION
Fix a bug where the socket wasn't being properly closed when actor restarted due to socket exception.