### PR TITLE
Raise default max http parser size to 10MB as a temporary measure pendin...

### DIFF
--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -13,7 +13,7 @@ import DataSize._
 
 object HttpResponseParser {
 
-  val DefaultMaxSize: DataSize = 1.MB
+  val DefaultMaxSize: DataSize = 10.MB
 
   val DefaultQueueSize : Int = 100
 


### PR DESCRIPTION
...g codec configuration ability.