### PR TITLE
Randomizing IOSystem names in tests to avoid race conditions

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
@@ -35,7 +35,7 @@ abstract class ColossusSpec(_system: ActorSystem) extends TestKit(_system) with 
    * @param f
    */
   def withIOSystem(f: IOSystem => Any) {
-    val sys = IOSystem("test-system", 2)
+    val sys = IOSystem("test-system-" + System.currentTimeMillis.toString, 2)
     try {
       f(sys)
     } finally {


### PR DESCRIPTION
Seems like Travis keeps borking randomly on tests because of actor name uniqueness problems.  I randomized the IOSystem names with timestamps and fixed a couple other tests and I *think* it fixed the problem.