### PR TITLE
service connections able to receive messages through DSL

### DIFF
--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -3,6 +3,7 @@ package service
 
 import core._
 
+import akka.actor.ActorRef
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 
@@ -88,8 +89,11 @@ trait ConnectionContext[C <: CodecDSL] {
   def process(f: C#Input => Callback[C#Output]){
     become{case all => f(all)}
   }
+  def receive(receiver: PartialFunction[Any, Unit])
+  def sender(): ActorRef
   def disconnect()
   def gracefulDisconnect()
+  def connectionId: Long
 
   implicit val callbackExecutor: CallbackExecutor
 }
@@ -149,6 +153,7 @@ class BasicServiceDelegator[C <: CodecDSL](func: Initializer[C], server: ServerR
 trait DSLHandler[C <: CodecDSL] extends ServiceServer[C#Input, C#Output] with ConnectionContext[C]
 
 class UnhandledRequestException(message: String) extends Exception(message)
+class ReceiveException(message: String) extends Exception(message)
 
 class BasicServiceHandler[C <: CodecDSL]
   (config: ServiceConfig, worker: WorkerRef, provider: CodecProvider[C]) 
@@ -159,13 +164,33 @@ class BasicServiceHandler[C <: CodecDSL]
   protected def unhandled: PartialHandler[C] = PartialFunction[C#Input,Callback[C#Output]]{
     case other => Callback.successful(provider.errorResponse(other, new UnhandledRequestException(s"Unhandled Request $other")))
   }
+
+  protected def unhandledReceive: Receive = {
+    case _ => {}
+  }
   
   private var currentHandler: PartialHandler[C] = unhandled
+  private var currentMessageReceiver: Receive = unhandledReceive
+  private var currentSender: Option[ActorRef] = None
+
+  def connectionId = id.get // :(
 
   def become(handler: PartialHandler[C]) {
     currentHandler = handler
   }
 
+  def sender() = currentSender.getOrElse(throw new ReceiveException("cannot call sender outside of receive"))
+
+  def receive(handler: PartialFunction[Any, Unit]) {
+    currentMessageReceiver = handler
+  }
+
+  def receivedMessage(message: Any, sender: ActorRef) {
+    currentSender = Some(sender)
+    (currentMessageReceiver orElse unhandledReceive)(message)
+    currentSender = None
+  }
+    
   protected def fullHandler: PartialFunction[C#Input, Callback[C#Output]] = currentHandler orElse unhandled
   
   protected def processRequest(i: C#Input): Callback[C#Output] = fullHandler(i)

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -4,7 +4,6 @@ package service
 import core._
 import controller._
 
-import akka.actor._
 import akka.event.Logging
 import metrics._
 
@@ -119,8 +118,6 @@ extends Controller[I,O](codec, ControllerConfig(50)) {
     }
     checkGracefulDisconnect()
   }
-
-  def receivedMessage(message: Any, sender: ActorRef) {}
 
   override def connectionClosed(cause : DisconnectCause) {
     super.connectionClosed(cause)


### PR DESCRIPTION
Now connections have a `receive`method just like delegators where they can receive messages sent to them through the worker.

As the test shows, we still don't have a great interface to send messages to these connections, but this is first step to getting more actor-like behavior into connection handlers.