### PR TITLE
Stream content length

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -1,7 +1,7 @@
 package colossus
 
 
-import colossus.core.DataBuffer
+import colossus.core.{DataBuffer, DataStream}
 import org.scalatest._
 
 import akka.util.ByteString
@@ -60,7 +60,7 @@ class HttpSpec extends WordSpec with MustMatchers{
       val content = "Hello World!"
       val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Nil, ByteString(content))
       val expected = s"HTTP/1.1 200 OK\r\nContent-Length: ${content.length}\r\n\r\n$content"
-      val stream: DataStream = StreamedResponseBuilder(StreamingHttpResponse.fromStatuc(response))
+      val stream: DataStream = StreamedResponseBuilder(StreamingHttpResponse.fromStatic(response))
     }
   }
 }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -55,6 +55,13 @@ class HttpSpec extends WordSpec with MustMatchers{
         case y => throw new Exception(s"expected a DataBuffer, received a $y instead")
       }
     }
+
+    "encode a basic response as a stream" in {
+      val content = "Hello World!"
+      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Nil, ByteString(content))
+      val expected = s"HTTP/1.1 200 OK\r\nContent-Length: ${content.length}\r\n\r\n$content"
+      val stream: DataStream = StreamedResponseBuilder(StreamingHttpResponse.fromStatuc(response))
+    }
   }
 }
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -74,4 +74,23 @@ class ServiceServerSpec extends ColossusSpec {
 
   }
 
+  "Streaming Service" must {
+
+    import protocols.http._
+
+    "Serve a basic response as a stream" taggedAs(org.scalatest.Tag("Test")) in {
+      withIOSystem{implicit io =>
+        val server = Service.become[StreamingHttp]("stream-test", TEST_PORT) {
+          case req => StreamingHttpResponse.fromStatic(req.ok("Hello World"))
+        }
+        withServer(server) { 
+          val client = AsyncServiceClient[Http]("localhost", TEST_PORT)
+          Await.result(client.send(HttpRequest.get("/")), 1.second).data must equal(ByteString("Hello World"))
+        }
+      }
+    }
+  }
+
+      
+
 }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -31,4 +31,7 @@ object HttpRequest {
     //val head = HttpHead(method, url, HttpVersion.`1.1`, Map(HttpHeaders.ContentLength -> List(bodybytes.map{_.size.toString}.getOrElse("0"))))
     HttpRequest(head, bodybytes)
   }
+
+
+  def get(url: String) = HttpRequest(HttpMethod.Get, url, None)
 }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -46,7 +46,9 @@ object StreamingHttpResponse {
     val data = new DataBuffer(buffer)
     val pipe = new FiniteBytePipe(response.data.size, HttpResponseParser.DefaultQueueSize)
     pipe.push(data)
-    StreamingHttpResponse(response.version, response.code, response.headers, pipe)
+    val strippedHeaders = response.headers.filterNot{_._1 == HttpHeaders.ContentLength}
+    val finalHeaders = strippedHeaders :+ (HttpHeaders.ContentLength, response.data.size.toString)
+    StreamingHttpResponse(response.version, response.code, finalHeaders, pipe)
   }
 
   def fromValue[T : ByteStringLike](version : HttpVersion = HttpVersion.`1.1`, code : HttpCode, headers :Seq[(String, String)] = Nil, value : T) : StreamingHttpResponse = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,7 @@ object ColossusBuild extends Build {
     organization := "com.tumblr",
     scalaVersion  := "2.11.4",
     crossScalaVersions := Seq("2.10.4", "2.11.2"),
-    version                   := "0.6.0-M1",
+    version                   := "0.6.0-SNAPSHOT",
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>
       val default = List(


### PR DESCRIPTION
This just adds in the content-length header when creating a stream from a static `HttpResponse`.