### PR TITLE
metric systems get a unique id to avoid tick conflicts, system metrics optional

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/ActorMetrics.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/ActorMetrics.scala
@@ -20,7 +20,7 @@ trait ActorMetrics extends Actor with ActorLogging {
       case UnknownMetric => log.error(s"Event for unknown Metric: $m")
       case InvalidEvent => log.error(s"Invalid event $m")
     }
-    case Tick(v) => {
+    case Tick(id, v) if (id == metricSystem.id) => {
       val agg = metrics.aggregate
       metrics.tick(metricSystem.tickPeriod)
       metricSystem.database ! Tock(agg, v)


### PR DESCRIPTION
Killing two birds with one stone:

* Since the `Tick` messages used to collect metrics from various sources is broadcast on the event bus, if there are multiple metric systems, they end up reacting to ticks from the wrong systems.  Now MetricSystems have a unique id, which is included in the `Tick` message and checked by anyone processing it.
* You can now configure whether a metric system collects system-level metrics.