### PR TITLE
Controller cleanup

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/AsyncClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/AsyncClientSpec.scala
@@ -20,7 +20,7 @@ class AsyncClientSpec extends ColossusSpec {
     import protocols.telnet._
     import service._
     import Callback.Implicits._
-    Service.become[Telnet]("test", TEST_PORT) {
+    Service.become[Telnet]("test-" + System.nanoTime().toString, TEST_PORT) {
       case TelnetCommand(c :: tail) => {
         println("HERE")
         TelnetReply(c)

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -194,7 +194,7 @@ class ServiceClientSpec extends ColossusSpec {
       response must equal(Some(reply))
     }
 
-    "fail pending requests on disconnect with failFast" in {
+    "fail pending requests on disconnect with failFast" taggedAs(org.scalatest.Tag("test")) in {
       val command1 = Command(CMD_GET, "123456789012345678901234567890")
       val command2 = Command(CMD_GET, "foo")
       val (endpoint, client, probe) = newClient(true)
@@ -208,7 +208,7 @@ class ServiceClientSpec extends ColossusSpec {
         case Success(wat) => throw new Exception("NOPE2")
         case Failure(yay) => failed2 = true
       }
-      endpoint.disconnect()
+      endpoint.disrupt()
       failed must equal(true)
       failed2 must equal(true)
     }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -50,7 +50,7 @@ class ServiceServerSpec extends ColossusSpec {
       }
     }
 
-    "graceful disconnect" in {
+    "graceful disconnect" taggedAs(org.scalatest.Tag("test")) in {
       withIOSystem{implicit io => 
         val server = Service.serve[Redis]("test", TEST_PORT){_.handle{con => con.become{
           case x if (x.command == "DIE") => {

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -24,98 +24,189 @@ case class ControllerConfig(
 //used to terminate input streams when a connection is closing
 class DisconnectingException(message: String) extends Exception(message)
 
-//passed to the onWrite handler to indicate the status of the write for a
-//message
-sealed trait OutputResult
-object OutputResult {
 
-  // the message was successfully written
-  case object Success extends OutputResult
+sealed trait ConnectionState
+sealed trait AliveState extends ConnectionState {
+  def endpoint: WriteEndpoint
+}
+object ConnectionState {
+  case object NotConnected extends ConnectionState
+  case class Connected(endpoint: WriteEndpoint) extends ConnectionState with AliveState
+  case class Disconnecting(endpoint: WriteEndpoint) extends ConnectionState with AliveState
+}
+class InvalidConnectionStateException(state: OutputState) extends Exception(s"Invalid connection State: $state")
 
-  // the message failed, most likely due to the connection closing partway
-  case object Failure extends OutputResult
+sealed trait InputState
+object InputState {
+  //notice there is no idle state, we always default to decoding since that's
+  //what we do when we receive the first bytes of a new message
+  
+  case object Decoding extends InputState
+  case class ReadingStream(sink: Sink[DataBuffer]) extends InputState
+  case class BlockedStream(sink: Sink[DataBuffer], continueTrigger: Trigger) extends InputState
 
-  // the message was cancelled before it was written (not implemented yet) 
-  case object Cancelled extends OutputResult
+  case object Terminated extends InputState //used when disconnecting, indicates we are not planning on doing aything more
+}
+class InvalidInputStateException(state: OutputState) extends Exception(s"Invalid Input State: $state")
+
+
+//not being used yet
+//case class QueuedItem[T](item: T, postWrite: OutputResult => Unit)
+
+sealed trait OutputState 
+object OutputState{
+  case object Idle extends OutputState
+  //using postWrite instead of queued item to avoid type param
+  case class Writing(postWrite: OutputResult => Unit) extends OutputState
+  case class Streaming(source: Source[DataBuffer], postWrite: OutputResult => Unit) extends OutputState
+
+  case object Terminated extends OutputState //only used when disconnecting
+}
+class InvalidOutputStateException(state: OutputState) extends Exception(s"Invalid Output State: $state")
+
+trait MasterController[Input, Output] extends ConnectionHandler {
+  protected def state: ConnectionState
+  protected def codec: Codec[Output, Input]
+  protected def config: ControllerConfig
+
+  //needs to be called after various actions complete to check if it's ok to disconnect
+  def checkTermination()
 }
 
-abstract class Controller[Input, Output](val codec: Codec[Output, Input], val controllerConfig: ControllerConfig) 
-extends ConnectionHandler {
+trait InputController[Input, Output] extends MasterController[Input, Output] {
+  import InputState._
 
-  private var endpoint: Option[WriteEndpoint] = None
-  def isConnected = endpoint.isDefined
+  private var inputState: InputState = Decoding
 
-  //TODO: all of this would probably be cleaner with some kind of state machine
+  //we need to keep track of this outside the write-endpoint in case the endpoint changes
+  //maybe not
+  private var readsEnabled = true
+
+  def inputOnClosed() {
+    inputState match {
+      case ReadingStream(sink) => {
+        sink.terminate(new Exception("Connection Closed"))
+      }
+      case BlockedStream(sink, trigger) => {
+        sink.terminate(new Exception("Connection Closed"))
+        trigger.cancel()
+      }
+      case _ => {}
+    }
+    inputState = Terminated
+  }
+
+  protected def pauseReads() {
+    readsEnabled = false
+    endpoint.foreach{_.disableReads()}
+  }
+
+  protected def resumeReads {
+    readsEnabled = true
+    endpoint.foreach{_.enableReads()}
+  }
+
+
+  def receivedData(data: DataBuffer) {
+
+    def processAndContinue(msg : Input, buffer : DataBuffer) {
+      processMessage(msg)
+      if(buffer.hasUnreadData) receivedData(buffer)
+    }
+
+    inputState match {
+      case Decoding => codec.decode(data) match {
+        case Some(DecodedResult.Streamed(msg, sink)) => {
+          inputState = ReadingStream(sink)
+          processAndContinue(msg, data)
+        }
+        case Some(DecodedResult.Static(msg)) => processAndContinue(msg, data)
+        case None => {} //nothing to do here, just waiting for MOAR DATA
+      }
+      case ReadingStream(sink) => sink.push(data) match {
+        case Success(Ok) => {}
+        case Success(Done) => state match{
+          case ConnectionState.Disconnecting(_) {
+            //gracefulDisconnect was called, so we allowed the connection to
+            //finish reading in the stream, but now that it's done, disable
+            //reads and drop any data still in the buffer
+            endpoint.foreach{_.disableReads()}
+          case ConnectionState.Connected(_) => {
+            inputState = Decoding
+            if(buffer.hasUnreadData) receivedData(buffer)
+          }
+          case other => throw new InvalidConnectionStateException(other)
+        }
+        case Success(Full(trigger)) => state match {
+          case a: AliveState => {
+            a.endpoint.disableReads()
+            trigger.fill{() =>
+              //todo: maybe do something if endpoint disappears before trigger is called.  Also maybe need to cancel trigger?
+              a.endpoint.foreach{_.enableReads()}
+              inputState = ReadingStream(sink)
+            }
+            inputState = BlockedStream(sink, trigger)
+          }
+          case other => throw new InvalidConnectionStateException(other)
+        }
+        case Failure(a : PipeTerminatedException) => {
+          //disconnect
+          inputState = Terminated
+        }
+        case Failure(a : PipeClosedException) => {
+          //this only happens on infinite pipes
+          //TODO:  this should not be an exception/failure
+          inputState = Decoding
+          if(buffer.hasUnreadData) receivedData(buffer)
+        }
+        case Failure(t : Throwable) => {
+          //todo: when a non expected failure occurs?
+          //this can be probably merged with pipe-terminated
+          inputState = Terminated
+        }
+      }
+      case other => throw new InvalidInputStateException(other)
+    }
+  }
+
+
+  protected def processMessage(message: Input)
+
+}
+
+trait OutputController[Input, Output] extends MasterController[Input, Output] {
+
+  private var outputState: OutputState = Idle
+
+  //whether or not we should be pulling items out of the queue to write, this
+  //can be set to false through pauseWrites
+  private var writesEnabled = true
 
   //represents a message queued for writing
-  case class QueuedItem(item: Output, postWrite: OutputResult => Unit)
   //the queue of items waiting to be written.
   private val waitingToSend = new java.util.LinkedList[QueuedItem]
 
-  //only one of these will ever be filled at a time, todo: make either
-  private var currentlyWriting: Option[QueuedItem] = None
-  private var currentStream: Option[(QueuedItem, Source[DataBuffer])] = None
-
-  //set when streaming input into a message
-  private var currentSink: Option[Sink[DataBuffer]] = None
-  //set when input stream fills during writing
-  private var currentTrigger: Option[Trigger] = None
-
-
-  //whether or not we should be pulling items out of the queue to write, this can be set
-  //to fale through pauseWrites
-  private var writesEnabled = true
-
-  //we need to keep track of this outside the write-endpoint in case the endpoint changes
-  private var readsEnabled = true
-
-  //set to true when graceful disconnect has been initiated
-  private var disconnecting = false
-
-  def connected(endpt: WriteEndpoint) {
-    if (endpoint.isDefined) {
-      throw new Exception("Handler Connected twice!")
-    }
-    endpoint = Some(endpt)
-  }
-
-  private def onClosed() {
+  def outputOnClosed() {
+    //FIX
     currentStream.foreach{case (item, source) =>
       source.terminate(new Exception("Connection Closed"))
       currentStream = None
     }
 
-    currentSink.foreach{sink =>
-      sink.terminate(new Exception("Connection Closed"))
-      currentSink = None
-      currentTrigger = None
-    }
-    endpoint = None
   }
-
-  protected def connectionClosed(cause : DisconnectCause) {
-    onClosed()
-  }
-
-  protected def connectionLost(cause : DisconnectError) {
-    onClosed()
-  }
-
-  /****** OUTPUT ******/
 
   /** Push a message to be written
    * @param item the message to push
    * @param postWrite called either when writing has completed or failed
    */
   protected def push(item: Output)(postWrite: OutputResult => Unit): Boolean = {
-    if (disconnecting) {
-      false
-    } else if (waitingToSend.size < controllerConfig.outputBufferSize) {
-      waitingToSend.add(QueuedItem(item, postWrite))
-      checkQueue() 
-      true
-    } else {
-      false
+    state match {
+      case ConnectionState.Connected(_) if (waitingToSend.size < controllerConfig.outputBufferSize) => {
+        waitingToSend.add(QueuedItem(item, postWrite))
+        checkQueue() 
+        true
+      }
+      case _ => false
     }
   }
 
@@ -124,12 +215,15 @@ extends ConnectionHandler {
    * If a message is currently being streamed, the stream will be terminated
    */
   protected def purgeOutgoing() {
-    currentlyWriting.foreach{queued => queued.postWrite(OutputResult.Failure)}
-    currentlyWriting = None
-    //TODO, move NotConnectedException
-    currentStream.foreach{case (queued, sink) => sink.terminate(new service.NotConnectedException("Connection closed"))}
-    currentStream = None
-
+    outputState match {
+      case Writing(postWrite) => postWrite(OutputResult.Failure)
+      case Streaming(source) => source.terminate(new service.NotConnectedException("Connection closed"))
+      case _ => {}
+    }
+    outputState = state match {
+      case d: Disconnecting => Terminated
+      case _ => Idle
+    }
   }
 
   /** Purge all pending messages
@@ -166,15 +260,140 @@ extends ConnectionHandler {
     checkQueue()
   }
 
-  protected def pauseReads() {
-    readsEnabled = false
-    endpoint.foreach{_.disableReads()}
+  /*
+   * iterate through the queue and write items.  Writing non-streaming items is
+   * iterative whereas writing a stream enters drain, which will be recursive
+   * if the stream has multiple databuffers to immediately write
+   */
+  private def checkQueue() {
+    def go(endpoint: WriteEndpoint) {
+      while (writesEnabled && outputState == Idle && waitingToSend.size > 0) {
+        val queued = waitingToSend.remove()
+        codec.encode(queued.item) match {
+          case DataStream(sink) => {
+            outputState = Streaming(sink, queued.postWrite)
+            drain(sink)
+          }
+          case d: DataBuffer => endpoint.get.write(d) match {
+            case WriteStatus.Complete => {
+              queued.postWrite(OutputResult.Success)
+            }
+            case WriteStatus.Failed | WriteStatus.Zero => {
+              //this probably shouldn't occur since we already check if the connection is writable
+              queued.postWrite(OutputResult.Failure)
+            }
+            case WriteStatus.Partial => {
+              outputState = Writing(queued.postWrite)
+            }
+          }
+        }
+      }
+    }
+    state match {
+      case ConnectionState.Connected(e) => go(e)
+      case ConnectionState.Disconnecting(e) => go(e)
+      case _ => {}
+    }
+    checkGracefulDisconnect()
+  }
+      
+
+  /*
+   * keeps reading from a source until it's empty or writing a databuffer is
+   * incomplete.  Notice in the latter case we just wait for readyForData to be
+   * called and resume there
+   */
+  private def drain(source: Source[DataBuffer]) {
+    source.pull{
+      case Success(Some(data)) => endpoint.get.write(data) match {
+        case WriteStatus.Complete => drain(source)
+        case _ => {} //todo: maybe do something on Failure?
+      }
+      case Success(None) => {
+        outputState match {
+          case Streaming(s, postWrite) => {
+            postWrite(OutputResult.Success)
+            outputState = Idle
+            checkQueue()
+          }
+          case other => throw new InvalidOutputStateException(other)
+        }
+      }
+      case Failure(err) => {
+        //TODO: what to do here?
+
+      }
+    }
   }
 
-  protected def resumeReads {
-    readsEnabled = true
-    endpoint.foreach{_.enableReads()}
+  /*
+   * If we're currently streaming, resume the stream, otherwise when this is
+   * called it means a non-stream item has finished fully writing, so we can go
+   * back to checking the queue
+   */
+  def readyForData() {
+    outputState match {
+      case Streaming(sink, post) => drain(sink)
+      case Writing(post) => {
+        post(OutputResult.Success)
+        outputState = Idle
+        checkQueue()
+      }
+      case other => throw new InvalidOutputStateException(other)
+    }
   }
+
+}
+
+
+
+
+//passed to the onWrite handler to indicate the status of the write for a
+//message
+sealed trait OutputResult
+object OutputResult {
+
+  // the message was successfully written
+  case object Success extends OutputResult
+
+  // the message failed, most likely due to the connection closing partway
+  case object Failure extends OutputResult
+
+  // the message was cancelled before it was written (not implemented yet) 
+  case object Cancelled extends OutputResult
+}
+
+abstract class Controller[Input, Output](val codec: Codec[Output, Input], val controllerConfig: ControllerConfig) 
+extends ConnectionHandler {
+  import ConnectionState._
+
+  protected var state: ConnectionState = NotConnected
+  def isConnected = state != NotConnected
+
+  def connected(endpt: WriteEndpoint) {
+    state match {
+      case NotConnected => state = Connected(endpt)
+      case other => throw new Exception(s"Received connected event in $other state")
+    }
+  }
+
+  private def onClosed() {
+    state = NotConnected
+    inputOnClosed()
+    outputOnClosed()
+  }
+
+  protected def connectionClosed(cause : DisconnectCause) {
+    onClosed()
+  }
+
+  protected def connectionLost(cause : DisconnectError) {
+    onClosed()
+  }
+
+  /****** OUTPUT ******/
+
+
 
   //todo: rename
   protected def paused = !writesEnabled
@@ -199,147 +418,15 @@ extends ConnectionHandler {
   }
 
   private def checkGracefulDisconnect() {
-    if (
-      disconnecting && 
-      waitingToSend.size == 0 && 
-      currentlyWriting.isEmpty && 
-      currentStream.isEmpty && 
-      currentSink.isEmpty &&
-      currentTrigger.isEmpty
-    ) {
-      endpoint.foreach{_.disconnect()}
+    (state, inputState, outputState) match {
+      case (Disconnecting(endpoint), InputState.Terminated, OutputState.Terminated) => {
+        endpoint.disconnect()
+        state = NotConnected
+      }
+      case _ => {} 
     }
   }
 
-  // == PRIVATE MEMBERS ==
-
-
-
-  /*
-   * iterate through the queue and write items.  Writing non-streaming items is
-   * iterative whereas writing a stream enters drain, which will be recursive
-   * if the stream has multiple databuffers to immediately write
-   */
-  private def checkQueue() {
-    while (writesEnabled && currentlyWriting.isEmpty && currentStream.isEmpty && waitingToSend.size > 0 && endpoint.isDefined) {
-      val queued = waitingToSend.remove()
-      codec.encode(queued.item) match {
-        case DataStream(sink) => {
-          currentStream = Some((queued, sink))
-          drain(sink)
-        }
-        case d: DataBuffer => endpoint.get.write(d) match {
-          case WriteStatus.Complete => {
-            queued.postWrite(OutputResult.Success)
-          }
-          case WriteStatus.Failed | WriteStatus.Zero => {
-            //this probably shouldn't occur since we already check if the connection is writable
-            queued.postWrite(OutputResult.Failure)
-          }
-          case WriteStatus.Partial => {
-            currentlyWriting = Some(queued)
-          }
-        }
-      }
-    }
-    checkGracefulDisconnect()
-  }
-      
-
-  /*
-   * keeps reading from a source until it's empty or writing a databuffer is
-   * incomplete.  Notice in the latter case we just wait for readyForData to be
-   * called and resume there
-   */
-  private def drain(source: Source[DataBuffer]) {
-    source.pull{
-      case Success(Some(data)) => endpoint.get.write(data) match {
-        case WriteStatus.Complete => drain(source)
-        case _ => {} //todo: maybe do something on Failure?
-      }
-      case Success(None) => {
-        currentStream.foreach{case (q, s) =>
-          q.postWrite(OutputResult.Success)
-        }
-        currentStream = None
-        checkQueue()
-      }
-      case Failure(err) => {
-        //TODO: what to do here?
-
-      }
-    }
-  }
-
-  /*
-   * If we're currently streaming, resume the stream, otherwise when this is
-   * called it means a non-stream item has finished fully writing, so we can go
-   * back to checking the queue
-   */
-  def readyForData() {
-    currentStream.map{case (q,s) => drain(s)}.getOrElse{
-      currentlyWriting.foreach{q => q.postWrite(OutputResult.Success)}
-      currentlyWriting = None
-      checkQueue()
-    }
-  }
-
-  /******* INPUT *******/
-
-  def receivedData(data: DataBuffer) {
-
-    def resetSink(buffer : DataBuffer) {
-      currentSink = None
-      //recurse since the databuffer may still contain data for the next request
-      if(buffer.hasUnreadData && !disconnecting) receivedData(buffer)
-    }
-
-    def processAndContinue(msg : Input, buffer : DataBuffer) {
-      processMessage(msg)
-      if(buffer.hasUnreadData) receivedData(buffer)
-    }
-
-    currentSink match {
-      case Some(sink) => sink.push(data) match {
-        case Success(Ok) => {}
-        case Success(Done) => {
-          resetSink(data) //should we have some kind of hook exposed here to signal when a client has finished streaming something?  
-          if (disconnecting) {
-            //gracefulDisconnect was called, so we allowed the connection to
-            //finish reading in the stream, but now that it's done, disable
-            //reads
-            endpoint.foreach{_.disableReads()}
-          }
-        }
-        case Success(Full(trigger)) => {
-          endpoint.get.disableReads()
-          trigger.fill{() =>
-            //todo: maybe do something if endpoint disappears before trigger is called.  Also maybe need to cancel trigger?
-            endpoint.foreach{_.enableReads()}
-            currentTrigger = None
-          }
-          currentTrigger = Some(trigger)
-        }
-        //TODO: are the following 2 cases really exceptions..seems like they are part of the normal control flow from a controller's POV
-        case Failure(a : PipeTerminatedException) => resetSink(data)
-        case Failure(a : PipeClosedException) => resetSink(data)
-        case Failure(t : Throwable) => {
-          //todo: when a non expected failure occurs?
-        }
-      }
-      case None => codec.decode(data) match {
-        case Some(DecodedResult.Streamed(msg, sink)) => {
-          currentSink = Some(sink)
-          processAndContinue(msg, data)
-        }
-        case Some(DecodedResult.Static(msg)) => processAndContinue(msg, data)
-        case None => {}
-      }
-    }
-  }
-
-
-  protected def processMessage(message: Input)
 }
 
 

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -2,11 +2,7 @@ package colossus
 package controller
 
 import core._
-import colossus.service.{DecodedResult, Codec}
-import scala.util.{Success, Failure}
-import PushResult._
-
-import service.NotConnectedException
+import service.Codec
 
 /** trait representing a decoded message that is actually a stream
  * 
@@ -46,34 +42,13 @@ object ConnectionState {
 }
 class InvalidConnectionStateException(state: ConnectionState) extends Exception(s"Invalid connection State: $state")
 
-sealed trait InputState
-object InputState {
-  //notice there is no idle state, we always default to decoding since that's
-  //what we do when we receive the first bytes of a new message
-  
-  case object Decoding extends InputState
-  case class ReadingStream(sink: Sink[DataBuffer]) extends InputState
-  case class BlockedStream(sink: Sink[DataBuffer], continueTrigger: Trigger) extends InputState
-
-  case object Terminated extends InputState //used when disconnecting, indicates we are not planning on doing aything more
-}
-class InvalidInputStateException(state: InputState) extends Exception(s"Invalid Input State: $state")
 
 
-//not being used yet
-//case class QueuedItem[T](item: T, postWrite: OutputResult => Unit)
-
-sealed trait OutputState 
-object OutputState{
-  case object Idle extends OutputState
-  //using postWrite instead of queued item to avoid type param
-  case class Writing(postWrite: OutputResult => Unit) extends OutputState
-  case class Streaming(source: Source[DataBuffer], postWrite: OutputResult => Unit) extends OutputState
-
-  case object Terminated extends OutputState //only used when disconnecting
-}
-class InvalidOutputStateException(state: OutputState) extends Exception(s"Invalid Output State: $state")
-
+/**
+ * The base trait inherited by both InputController and OutputController and
+ * ultimately implemented by Controller.  This merely contains methods needed
+ * by both input and output controller
+ */
 trait MasterController[Input, Output] extends ConnectionHandler {
   protected def state: ConnectionState
   protected def codec: Codec[Output, Input]
@@ -82,323 +57,6 @@ trait MasterController[Input, Output] extends ConnectionHandler {
   //needs to be called after various actions complete to check if it's ok to disconnect
   private[controller] def checkControllerGracefulDisconnect()
 }
-
-trait InputController[Input, Output] extends MasterController[Input, Output] {
-  import InputState._
-
-  private[controller] var inputState: InputState = Decoding
-
-  //we need to keep track of this outside the write-endpoint in case the endpoint changes
-  //maybe not
-  private var _readsEnabled = true
-  def readsEnabled = _readsEnabled
-
-  private[controller] def inputOnClosed() {
-    inputState match {
-      case ReadingStream(sink) => {
-        sink.terminate(new Exception("Connection Closed"))
-      }
-      case BlockedStream(sink, trigger) => {
-        sink.terminate(new Exception("Connection Closed"))
-        trigger.cancel()
-      }
-      case _ => {}
-    }
-    inputState = Terminated
-  }
-
-  private[controller] def inputGracefulDisconnect() {
-    if (inputState == Decoding) {
-      pauseReads()
-      inputState = Terminated
-    }
-  }
-
-  protected def pauseReads() {
-    state match {
-      case AliveState(endpoint) => {
-        _readsEnabled = false
-        endpoint.disableReads()
-      }
-    }
-  }
-
-  protected def resumeReads() {
-    state match {
-      case AliveState(endpoint) => {
-        _readsEnabled = true
-        endpoint.enableReads()
-      }
-    }
-  }
-
-
-  def receivedData(data: DataBuffer) {
-
-    def processAndContinue(msg : Input, buffer : DataBuffer) {
-      processMessage(msg)
-      if(buffer.hasUnreadData) receivedData(buffer)
-    }
-
-    inputState match {
-      case Decoding => codec.decode(data) match {
-        case Some(DecodedResult.Streamed(msg, sink)) => {
-          inputState = ReadingStream(sink)
-          processAndContinue(msg, data)
-        }
-        case Some(DecodedResult.Static(msg)) => processAndContinue(msg, data)
-        case None => {} //nothing to do here, just waiting for MOAR DATA
-      }
-      case ReadingStream(sink) => sink.push(data) match {
-        case Success(Ok) => {}
-        case Success(Done) => state match{
-          case ConnectionState.Disconnecting(_) => {
-            //gracefulDisconnect was called, so we allowed the connection to
-            //finish reading in the stream, but now that it's done, disable
-            //reads and drop any data still in the buffer
-            pauseReads()
-            inputState = Terminated
-          }
-          case ConnectionState.Connected(_) => {
-            inputState = Decoding
-            if(data.hasUnreadData) receivedData(data)
-          }
-          case other => throw new InvalidConnectionStateException(other)
-        }
-        case Success(Full(trigger)) => state match {
-          case a: AliveState => {
-            a.endpoint.disableReads()
-            trigger.fill{() =>
-              //todo: maybe do something if endpoint disappears before trigger is called.  Also maybe need to cancel trigger?
-              resumeReads()
-              inputState = ReadingStream(sink)
-            }
-            inputState = BlockedStream(sink, trigger)
-          }
-          case other => throw new InvalidConnectionStateException(other)
-        }
-        case Failure(a : PipeTerminatedException) => {
-          //disconnect
-          inputState = Terminated
-        }
-        case Failure(a : PipeClosedException) => {
-          //this only happens on infinite pipes
-          //TODO:  this should not be an exception/failure
-          inputState = Decoding
-          if(data.hasUnreadData) receivedData(data)
-        }
-        case Failure(t : Throwable) => {
-          //todo: when a non expected failure occurs?
-          //this can be probably merged with pipe-terminated
-          inputState = Terminated
-          throw t //basically gotta kill the connection
-        }
-      }
-      case other => throw new InvalidInputStateException(other)
-    }
-  }
-
-
-  protected def processMessage(message: Input)
-
-}
-
-trait OutputController[Input, Output] extends MasterController[Input, Output] {
-  import OutputState._
-
-  case class QueuedItem(item: Output, postWrite: OutputResult => Unit)
-
-  private[controller] var outputState: OutputState = Idle
-
-  //whether or not we should be pulling items out of the queue to write, this
-  //can be set to false through pauseWrites
-  private var _writesEnabled = true
-  def writesEnabled = _writesEnabled
-
-  //represents a message queued for writing
-  //the queue of items waiting to be written.
-  private val waitingToSend = new java.util.LinkedList[QueuedItem]
-
-  private[controller] def outputOnClosed() {
-    outputState match {
-      case Streaming(source, post) => {
-        source.terminate(new NotConnectedException("Connection Closed"))
-        post(OutputResult.Failure)
-      }
-      case _ => {}
-    }
-  }
-
-  private[controller] def outputGracefulDisconnect() {
-    if (outputState == Idle) {
-      outputState = Terminated
-    }
-  }
-
-  /** Push a message to be written
-   * @param item the message to push
-   * @param postWrite called either when writing has completed or failed
-   */
-  protected def push(item: Output)(postWrite: OutputResult => Unit): Boolean = {
-    state match {
-      case ConnectionState.Connected(_) if (waitingToSend.size < controllerConfig.outputBufferSize) => {
-        waitingToSend.add(QueuedItem(item, postWrite))
-        checkQueue() 
-        true
-      }
-      case _ => false
-    }
-  }
-
-  /** Purge the outgoing message, if there is one
-   *
-   * If a message is currently being streamed, the stream will be terminated
-   */
-  protected def purgeOutgoing() {
-    outputState match {
-      case Writing(postWrite) => postWrite(OutputResult.Failure)
-      case Streaming(source, post) => {
-        source.terminate(new service.NotConnectedException("Connection closed"))
-        post(OutputResult.Failure)
-      }
-      case _ => {}
-    }
-    outputState = state match {
-      case d: ConnectionState.Disconnecting => Terminated
-      case _ => Idle
-    }
-  }
-
-  /** Purge all pending messages
-   * 
-   * If a message is currently being written, it is not affected
-   */
-  protected def purgePending() {
-    while (waitingToSend.size > 0) {
-      val q = waitingToSend.remove()
-      q.postWrite(OutputResult.Cancelled)
-    }
-  }
-
-  /** Purge both pending and outgoing messages */
-  protected def purgeAll() {
-    purgeOutgoing()
-    purgePending()
-  }
-
-  /**
-   * Pauses writing of the next item in the queue.  If there is currently a
-   * message in the process of writing, it will be unaffected.  New messages
-   * can still be pushed to the queue as long as it is not full
-   */
-  protected def pauseWrites() {
-    _writesEnabled = false
-  }
-
-  /**
-   * Resumes writing of messages if currently paused, otherwise has no affect
-   */
-  protected def resumeWrites() {
-    _writesEnabled = true
-    checkQueue()
-  }
-
-  /*
-   * iterate through the queue and write items.  Writing non-streaming items is
-   * iterative whereas writing a stream enters drain, which will be recursive
-   * if the stream has multiple databuffers to immediately write
-   */
-  private def checkQueue() {
-    def go(endpoint: WriteEndpoint) {
-      while (_writesEnabled && outputState == Idle && waitingToSend.size > 0) {
-        val queued = waitingToSend.remove()
-        codec.encode(queued.item) match {
-          case DataStream(sink) => {
-            outputState = Streaming(sink, queued.postWrite)
-            drain(sink)
-          }
-          case d: DataBuffer => endpoint.write(d) match {
-            case WriteStatus.Complete => {
-              queued.postWrite(OutputResult.Success)
-            }
-            case WriteStatus.Failed | WriteStatus.Zero => {
-              //this probably shouldn't occur since we already check if the connection is writable
-              queued.postWrite(OutputResult.Failure)
-              throw new Exception(s"Invalid write status")
-            }
-            case WriteStatus.Partial => {
-              outputState = Writing(queued.postWrite)
-            }
-          }
-        }
-      }
-    }
-    state match {
-      case a: AliveState => go(a.endpoint)
-      case _ => {}
-    }
-    checkControllerGracefulDisconnect()
-  }
-      
-
-  /*
-   * keeps reading from a source until it's empty or writing a databuffer is
-   * incomplete.  Notice in the latter case we just wait for readyForData to be
-   * called and resume there
-   */
-  private def drain(source: Source[DataBuffer]) {
-    source.pull{
-      case Success(Some(data)) => state match {
-        case AliveState(endpoint) => endpoint.write(data) match {
-          case WriteStatus.Complete => drain(source)
-          case WriteStatus.Failed  => {
-            source.terminate(new NotConnectedException("Connection closed during streaming"))
-          }
-          case WriteStatus.Zero => {
-            throw new Exception("Invalid write status")
-          }
-          case WriteStatus.Partial =>{} //don't do anything, draining will resume in readyForData
-        }
-        case other => {
-          source.terminate(new NotConnectedException("Connection closed during streaming"))
-        }
-      }
-      case Success(None) => outputState match {
-        case Streaming(s, postWrite) => {
-          postWrite(OutputResult.Success)
-          outputState = Idle
-          checkQueue()
-        }
-        case other => throw new InvalidOutputStateException(other)
-      }
-      case Failure(err) => {
-        //if we can't finish writing the current stream, not much else we can
-        //do except close the connection
-        throw err
-      }
-    }
-  }
-
-  /*
-   * If we're currently streaming, resume the stream, otherwise when this is
-   * called it means a non-stream item has finished fully writing, so we can go
-   * back to checking the queue
-   */
-  def readyForData() {
-    outputState match {
-      case Streaming(sink, post) => drain(sink)
-      case Writing(post) => {
-        post(OutputResult.Success)
-        outputState = Idle
-        checkQueue()
-      }
-      case other => throw new InvalidOutputStateException(other)
-    }
-  }
-
-}
-
-
 
 
 //passed to the onWrite handler to indicate the status of the write for a
@@ -428,6 +86,9 @@ extends InputController[Input, Output] with OutputController[Input, Output] {
       case NotConnected => state = Connected(endpt)
       case other => throw new InvalidConnectionStateException(other)
     }
+    codec.reset()
+    outputOnConnected()
+    inputOnConnected()
   }
 
   private def onClosed() {

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -59,21 +59,16 @@ trait MasterController[Input, Output] extends ConnectionHandler {
 }
 
 
-//passed to the onWrite handler to indicate the status of the write for a
-//message
-sealed trait OutputResult
-object OutputResult {
 
-  // the message was successfully written
-  case object Success extends OutputResult
-
-  // the message failed, most likely due to the connection closing partway
-  case object Failure extends OutputResult
-
-  // the message was cancelled before it was written (not implemented yet) 
-  case object Cancelled extends OutputResult
-}
-
+/**
+ * A Controller is a Connection handler that is designed to work with
+ * connections involving decoding raw bytes into input messages and encoding
+ * output messages into bytes.
+ *
+ * Unlike a service, which pairs an input "request" message with an output
+ * "response" message, the controller make no such pairing.  Thus a controller
+ * can be thought of as a duplex stream of messages.
+ */
 abstract class Controller[Input, Output](val codec: Codec[Output, Input], val controllerConfig: ControllerConfig) 
 extends InputController[Input, Output] with OutputController[Input, Output] {
   import ConnectionState._

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -1,0 +1,149 @@
+package colossus
+package controller
+
+import core._
+import colossus.service.{DecodedResult}
+import scala.util.{Success, Failure}
+import PushResult._
+
+sealed trait InputState
+object InputState {
+  //notice there is no idle state, we always default to decoding since that's
+  //what we do when we receive the first bytes of a new message
+  
+  case object Decoding extends InputState
+  case class ReadingStream(sink: Sink[DataBuffer]) extends InputState
+  case class BlockedStream(sink: Sink[DataBuffer], continueTrigger: Trigger) extends InputState
+
+  case object Terminated extends InputState //used when disconnecting, indicates we are not planning on doing aything more
+}
+class InvalidInputStateException(state: InputState) extends Exception(s"Invalid Input State: $state")
+
+
+/**
+ * The InputController maintains all state dealing with reading in messages in
+ * a controller.  It handles decoding messages and properly routing data into
+ * stream
+ */
+trait InputController[Input, Output] extends MasterController[Input, Output] {
+  import InputState._
+
+  private[controller] var inputState: InputState = Decoding
+
+  //we need to keep track of this outside the write-endpoint in case the endpoint changes
+  //maybe not
+  private var _readsEnabled = true
+  def readsEnabled = _readsEnabled
+
+  private[controller] def inputOnClosed() {
+    inputState match {
+      case ReadingStream(sink) => {
+        sink.terminate(new Exception("Connection Closed"))
+      }
+      case BlockedStream(sink, trigger) => {
+        sink.terminate(new Exception("Connection Closed"))
+        trigger.cancel()
+      }
+      case _ => {}
+    }
+    inputState = Terminated
+  }
+
+  private[controller] def inputOnConnected() {
+    inputState = Decoding
+  }
+
+  private[controller] def inputGracefulDisconnect() {
+    if (inputState == Decoding) {
+      pauseReads()
+      inputState = Terminated
+    }
+  }
+
+  protected def pauseReads() {
+    state match {
+      case AliveState(endpoint) => {
+        _readsEnabled = false
+        endpoint.disableReads()
+      }
+    }
+  }
+
+  protected def resumeReads() {
+    state match {
+      case AliveState(endpoint) => {
+        _readsEnabled = true
+        endpoint.enableReads()
+      }
+    }
+  }
+
+
+  def receivedData(data: DataBuffer) {
+
+    def processAndContinue(msg : Input, buffer : DataBuffer) {
+      processMessage(msg)
+      if(buffer.hasUnreadData) receivedData(buffer)
+    }
+
+    inputState match {
+      case Decoding => codec.decode(data) match {
+        case Some(DecodedResult.Streamed(msg, sink)) => {
+          inputState = ReadingStream(sink)
+          processAndContinue(msg, data)
+        }
+        case Some(DecodedResult.Static(msg)) => processAndContinue(msg, data)
+        case None => {} //nothing to do here, just waiting for MOAR DATA
+      }
+      case ReadingStream(sink) => sink.push(data) match {
+        case Success(Ok) => {}
+        case Success(Done) => state match{
+          case ConnectionState.Disconnecting(_) => {
+            //gracefulDisconnect was called, so we allowed the connection to
+            //finish reading in the stream, but now that it's done, disable
+            //reads and drop any data still in the buffer
+            pauseReads()
+            inputState = Terminated
+          }
+          case ConnectionState.Connected(_) => {
+            inputState = Decoding
+            if(data.hasUnreadData) receivedData(data)
+          }
+          case other => throw new InvalidConnectionStateException(other)
+        }
+        case Success(Full(trigger)) => state match {
+          case a: AliveState => {
+            a.endpoint.disableReads()
+            trigger.fill{() =>
+              //todo: maybe do something if endpoint disappears before trigger is called.  Also maybe need to cancel trigger?
+              resumeReads()
+              inputState = ReadingStream(sink)
+            }
+            inputState = BlockedStream(sink, trigger)
+          }
+          case other => throw new InvalidConnectionStateException(other)
+        }
+        case Failure(a : PipeTerminatedException) => {
+          //disconnect
+          inputState = Terminated
+          //we might not want to throw exceptions here, since terminating a pipe is normal behavior....maybe?
+        }
+        case Failure(a : PipeClosedException) => {
+          //this only happens on infinite pipes...maybe also on finite pipes, but not yet
+          //TODO:  this should not be an exception/failure
+          inputState = Decoding
+          if(data.hasUnreadData) receivedData(data)
+        }
+        case Failure(t : Throwable) => {
+          inputState = Terminated
+          throw t //basically gotta kill the connection
+        }
+      }
+      case other => throw new InvalidInputStateException(other)
+    }
+  }
+
+
+  protected def processMessage(message: Input)
+
+}

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -8,15 +8,31 @@ import PushResult._
 
 sealed trait InputState
 object InputState {
-  //notice there is no idle state, we always default to decoding since that's
-  //what we do when we receive the first bytes of a new message
   
+  /**
+   * The controller is waiting for more data to begin or continue decoding a message
+   */
   case object Decoding extends InputState
+
+  /**
+   * The controller decoded a stream message and is routing incoming data into the stream
+   */
   case class ReadingStream(sink: Sink[DataBuffer]) extends InputState
+
+  /**
+   * The controller is routing data into a stream, but the stream has indicated
+   * that it's full, so we're waiting for the continueTrigger to be called,
+   * which will resume reading in data
+   */
   case class BlockedStream(sink: Sink[DataBuffer], continueTrigger: Trigger) extends InputState
 
-  case object Terminated extends InputState //used when disconnecting, indicates we are not planning on doing aything more
+  /**
+   * The controller enters this state only during disconnects.  It indicates that we're no longer accepting new data
+   */
+  case object Terminated extends InputState
 }
+
+
 class InvalidInputStateException(state: InputState) extends Exception(s"Invalid Input State: $state")
 
 

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -1,0 +1,253 @@
+package colossus
+package controller
+
+import core._
+import colossus.service.{DecodedResult, Codec}
+import scala.util.{Success, Failure}
+
+import service.NotConnectedException
+
+
+sealed trait OutputState 
+object OutputState{
+  case object Idle extends OutputState
+  //using postWrite instead of queued item to avoid type param
+  case class Writing(postWrite: OutputResult => Unit) extends OutputState
+  case class Streaming(source: Source[DataBuffer], postWrite: OutputResult => Unit) extends OutputState
+
+  case object Terminated extends OutputState //only used when disconnecting
+}
+class InvalidOutputStateException(state: OutputState) extends Exception(s"Invalid Output State: $state")
+
+
+/** An ADT representing the result of a pushing a message to write
+*/
+sealed trait OutputResult
+object OutputResult {
+
+  // the message was successfully written
+  case object Success extends OutputResult
+
+  // the message failed, most likely due to the connection closing partway
+  case object Failure extends OutputResult
+
+  // the message was cancelled before it was written (not implemented yet) 
+  case object Cancelled extends OutputResult
+}
+
+/**
+ * The OutputController maintains all state dealing with writing messages in a
+ * controller.  It maintains a queue of messages pending write and properly
+ * handles writing both regular messages as well as streams.
+ */
+trait OutputController[Input, Output] extends MasterController[Input, Output] {
+  import OutputState._
+
+  case class QueuedItem(item: Output, postWrite: OutputResult => Unit)
+
+  private[controller] var outputState: OutputState = Idle
+
+  //whether or not we should be pulling items out of the queue to write, this
+  //can be set to false through pauseWrites
+  private var _writesEnabled = true
+  def writesEnabled = _writesEnabled
+
+  //represents a message queued for writing
+  //the queue of items waiting to be written.
+  private val waitingToSend = new java.util.LinkedList[QueuedItem]
+
+  private[controller] def outputOnConnected() {
+    outputState = Idle
+    checkQueue()
+  }
+
+  private[controller] def outputOnClosed() {
+    outputState match {
+      case Streaming(source, post) => {
+        source.terminate(new NotConnectedException("Connection Closed"))
+        post(OutputResult.Failure)
+      }
+      case _ => {}
+    }
+    outputState = Terminated
+  }
+
+  private[controller] def outputGracefulDisconnect() {
+    if (outputState == Idle) {
+      outputState = Terminated
+    }
+  }
+
+  /** Push a message to be written
+   *
+   * Pushing a message does not necessarily mean it will be written, but rather
+   * that the message is queued to be written.  Messages can be queue
+   * regardless of the state of the underlying connection, even if the
+   * connection is never reconnected.  It is up to the caller to determine
+   * whether a message should be pushed based on connection state.
+   *
+   * @param item the message to push
+   * @param postWrite called either when writing has completed or failed
+   *
+   * @return true if the message was successfully enqueued, false if the queue is full
+   */
+  protected def push(item: Output)(postWrite: OutputResult => Unit): Boolean = {
+    if (waitingToSend.size < controllerConfig.outputBufferSize) {
+      waitingToSend.add(QueuedItem(item, postWrite))
+      checkQueue() 
+      true
+    } else {
+      false
+    }
+  }
+
+  /** Purge the outgoing message, if there is one
+   *
+   * If a message is currently being streamed, the stream will be terminated
+   */
+  protected def purgeOutgoing() {
+    outputState match {
+      case Writing(postWrite) => postWrite(OutputResult.Failure)
+      case Streaming(source, post) => {
+        source.terminate(new service.NotConnectedException("Connection closed"))
+        post(OutputResult.Failure)
+      }
+      case _ => {}
+    }
+    outputState = state match {
+      case d: ConnectionState.Disconnecting => Terminated
+      case _ => Idle
+    }
+  }
+
+  /** Purge all pending messages
+   * 
+   * If a message is currently being written, it is not affected
+   */
+  protected def purgePending() {
+    while (waitingToSend.size > 0) {
+      val q = waitingToSend.remove()
+      q.postWrite(OutputResult.Cancelled)
+    }
+  }
+
+  /** Purge both pending and outgoing messages */
+  protected def purgeAll() {
+    purgeOutgoing()
+    purgePending()
+  }
+
+  /**
+   * Pauses writing of the next item in the queue.  If there is currently a
+   * message in the process of writing, it will be unaffected.  New messages
+   * can still be pushed to the queue as long as it is not full
+   */
+  protected def pauseWrites() {
+    _writesEnabled = false
+  }
+
+  /**
+   * Resumes writing of messages if currently paused, otherwise has no affect
+   */
+  protected def resumeWrites() {
+    _writesEnabled = true
+    checkQueue()
+  }
+
+  /*
+   * iterate through the queue and write items.  Writing non-streaming items is
+   * iterative whereas writing a stream enters drain, which will be recursive
+   * if the stream has multiple databuffers to immediately write
+   */
+  private def checkQueue() {
+    def go(endpoint: WriteEndpoint) {
+      while (_writesEnabled && outputState == Idle && waitingToSend.size > 0) {
+        val queued = waitingToSend.remove()
+        codec.encode(queued.item) match {
+          case DataStream(sink) => {
+            outputState = Streaming(sink, queued.postWrite)
+            drain(sink)
+          }
+          case d: DataBuffer => endpoint.write(d) match {
+            case WriteStatus.Complete => {
+              queued.postWrite(OutputResult.Success)
+            }
+            case WriteStatus.Failed | WriteStatus.Zero => {
+              //this probably shouldn't occur since we already check if the connection is writable
+              queued.postWrite(OutputResult.Failure)
+              //throw new Exception(s"Invalid write status")
+            }
+            case WriteStatus.Partial => {
+              outputState = Writing(queued.postWrite)
+            }
+          }
+        }
+      }
+    }
+    state match {
+      case a: AliveState if (waitingToSend.size > 0) => go(a.endpoint)
+      case d: ConnectionState.Disconnecting => {
+        outputState = Terminated
+      }
+      case _ => {}
+    }
+    checkControllerGracefulDisconnect()
+  }
+      
+
+  /*
+   * keeps reading from a source until it's empty or writing a databuffer is
+   * incomplete.  Notice in the latter case we just wait for readyForData to be
+   * called and resume there
+   */
+  private def drain(source: Source[DataBuffer]) {
+    source.pull{
+      case Success(Some(data)) => state match {
+        case AliveState(endpoint) => endpoint.write(data) match {
+          case WriteStatus.Complete => drain(source)
+          case WriteStatus.Failed  => {
+            source.terminate(new NotConnectedException("Connection closed during streaming"))
+          }
+          case WriteStatus.Zero => {
+            throw new Exception("Invalid write status")
+          }
+          case WriteStatus.Partial =>{} //don't do anything, draining will resume in readyForData
+        }
+        case other => {
+          source.terminate(new NotConnectedException("Connection closed during streaming"))
+        }
+      }
+      case Success(None) => outputState match {
+        case Streaming(s, postWrite) => {
+          postWrite(OutputResult.Success)
+          outputState = Idle
+          checkQueue()
+        }
+        case other => throw new InvalidOutputStateException(other)
+      }
+      case Failure(err) => {
+        //if we can't finish writing the current stream, not much else we can
+        //do except close the connection
+        throw err
+      }
+    }
+  }
+
+  /*
+   * If we're currently streaming, resume the stream, otherwise when this is
+   * called it means a non-stream item has finished fully writing, so we can go
+   * back to checking the queue
+   */
+  def readyForData() {
+    outputState match {
+      case Streaming(sink, post) => drain(sink)
+      case Writing(post) => {
+        post(OutputResult.Success)
+        outputState = Idle
+        checkQueue()
+      }
+      case other => throw new InvalidOutputStateException(other)
+    }
+  }
+
+}

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -224,7 +224,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize)) with 
       }
     }
     checkGracefulDisconnect()
-    if (paused) resumeWrites()
+    if (!writesEnabled) resumeWrites()
   }
 
   def receivedMessage(message: Any, sender: ActorRef) {

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -237,9 +237,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize)) with 
   override def connected(endpoint: WriteEndpoint) {
     super.connected(endpoint)
     log.info(s"${id.get} Connected to $address")
-    codec.reset()    
     connectionAttempts = 0
-    readyForData()
   }
 
   private def purgeBuffers(pendingException : => Throwable) {
@@ -310,7 +308,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize)) with 
           pauseWrites() //writes resumed in processMessage
         }
       } else {
-        s.handler(Failure(new ClientOverloadedException("Client is overloaded")))
+        s.handler(Failure(new ClientOverloadedException(s"Error sending ${s.message}: Client is overloaded")))
       }
     } else {
       droppedRequests.hit(tags = hpTags)


### PR DESCRIPTION
Fixes #119 and probably #115 as well.

Well, this basically turned into almost a total rewrite of the Controller class.  We now have 2 main traits, one for input and one for output, which are both pulled into `Controller`.  In addition, each sub-controller has been rewritten as a state machine, which I think helps make the code easier to read as well as eliminate some of the nonsensical states we were hitting previously.

There are still a few areas where we have some iffy or undefined logic, but this change should make it easier to identify and address those places.