### PR TITLE
Removing internal buffering from pipes

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -40,4 +40,22 @@ object Main extends App {
   val chatServer = ChatExample.start(9005)
 
 
+  import service._
+  import protocols.http._
+
+  Service.serve[StreamingHttp]("stream-proxy", 9090){ context =>
+    context.handle{ connection =>
+      connection.become {
+        case req => {
+          val client = context.clientFor[StreamingHttp]("localhost", 9001)
+          client.send(HttpRequest.get("/")).map{c =>
+            client.gracefulDisconnect()
+            c
+          }
+        }
+      }
+    }
+  }
+
+
 }

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -20,7 +20,7 @@ case class TestOutput(data: Source[DataBuffer])
 
 class TestCodec(pipeSize: Int = 3) extends Codec[TestOutput, TestInput]{    
   import parsing.Combinators._
-  val parser: Parser[TestInputImpl] = intUntil('\r') <~ byte >> {num => TestInputImpl(new FiniteBytePipe(num, pipeSize))}
+  val parser: Parser[TestInputImpl] = intUntil('\r') <~ byte >> {num => TestInputImpl(new FiniteBytePipe(num))}
 
   def decode(data: DataBuffer): Option[DecodedResult[TestInput]] = {
     val res = parser.parse(data)

--- a/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
@@ -83,7 +83,7 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers{
       failed must equal(true)   
     }
 
-    "input stream allowed to complete during graceful disconnect" taggedAs(org.scalatest.Tag("test")) in {
+    "input stream allowed to complete during graceful disconnect" in {
       var source: Option[Source[DataBuffer]] = None
       val (endpoint, con) = createController({input => 
         source = Some(input.source)

--- a/colossus-tests/src/test/scala/colossus/controller/PipeCombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeCombinatorSpec.scala
@@ -7,21 +7,15 @@ import scala.util.{Failure, Success}
 class PipeCombinatorSpec extends WordSpec with MustMatchers with OptionValues with TryValues{
 
   "PipeCombinator" must {
-  /*
 
     "combine 2 pipes with a map function" in {
 
-      import ReflexiveCopiers._
-
-      val writeSink: Pipe[String, String] = new InfinitePipe[String](100)
-      val readSource: Pipe[Int, Int] = new InfinitePipe[Int](100)
+      val writeSink: Pipe[String, String] = new InfinitePipe[String]
+      val readSource: Pipe[Int, Int] = new InfinitePipe[Int]
 
       val map: (String) => Seq[Int] = (s: String) => s.split(":").map(_.toInt).toSeq
 
       val combined: Pipe[String, Int] = writeSink.join(readSource)(map)
-      combined.push("1:2:3")
-      combined.push("4:5")
-      combined.complete()
 
       var callbackExecuted = false
 
@@ -29,24 +23,23 @@ class PipeCombinatorSpec extends WordSpec with MustMatchers with OptionValues wi
         case Success(x) => callbackExecuted = true; x must equal(Seq(1, 2, 3, 4, 5))
         case Failure(t) => throw t
       }
+      callbackExecuted must be (false)
+      combined.push("1:2:3") must equal(PushResult.Ok)
+      combined.push("4:5") must equal(PushResult.Ok)
+      combined.complete()
 
       callbackExecuted must be (true)
     }
 
     "completing a pipe will complete both sides" in {
-      import ReflexiveCopiers._
-
-      val writeSink: Pipe[String, String] = new InfinitePipe[String](100)
-      val readSource: Pipe[Int, Int] = new InfinitePipe[Int](100)
-
+      val writeSink: Pipe[String, String] = new InfinitePipe[String]
+      val readSource: Pipe[Int, Int] = new InfinitePipe[Int]
       val map: (String) => Seq[Int] = (s: String) => s.split(":").map(_.toInt).toSeq
-
       val combined: Pipe[String, Int] = writeSink.join(readSource)(map)
 
       combined.complete()
 
-      val t = writeSink.push("")
-      t.failure.exception mustBe a [PipeClosedException]
+      writeSink.push("") must equal(PushResult.Closed)
 
       readSource.pull {
         case Success(None) => {}
@@ -58,10 +51,8 @@ class PipeCombinatorSpec extends WordSpec with MustMatchers with OptionValues wi
 
       class GadZooksException(msg : String) extends Exception(msg)
 
-      import ReflexiveCopiers._
-
-      val writeSink: Pipe[String, String] = new InfinitePipe[String](100)
-      val readSource: Pipe[Int, Int] = new InfinitePipe[Int](100)
+      val writeSink: Pipe[String, String] = new InfinitePipe[String]
+      val readSource: Pipe[Int, Int] = new InfinitePipe[Int]
 
       val map: (String) => Seq[Int] = (s: String) => s.split(":").map(_.toInt).toSeq
 
@@ -70,19 +61,16 @@ class PipeCombinatorSpec extends WordSpec with MustMatchers with OptionValues wi
       combined.terminate(new GadZooksException("snip snap"))
 
       val t = writeSink.push("")
-      t.failure.exception mustBe a [PipeTerminatedException]
-      val ex = t.failure.exception.asInstanceOf[PipeTerminatedException]
-      ex.getCause mustBe a [GadZooksException]
+      t mustBe a[PushResult.Error]
 
 
       readSource.pull {
         case Failure(ex : PipeTerminatedException) => {
-          ex.getCause mustBe a [GadZooksException]
+          ex.getCause mustBe a[GadZooksException]
         }
-        case _ => throw new Exception("expected None")
+        case other => throw new Exception(s"expected None, got $other")
       }
     }
-    */
   }
 
 }

--- a/colossus-tests/src/test/scala/colossus/controller/PipeCombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeCombinatorSpec.scala
@@ -7,6 +7,7 @@ import scala.util.{Failure, Success}
 class PipeCombinatorSpec extends WordSpec with MustMatchers with OptionValues with TryValues{
 
   "PipeCombinator" must {
+  /*
 
     "combine 2 pipes with a map function" in {
 
@@ -81,6 +82,7 @@ class PipeCombinatorSpec extends WordSpec with MustMatchers with OptionValues wi
         case _ => throw new Exception("expected None")
       }
     }
+    */
   }
 
 }

--- a/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
@@ -12,10 +12,6 @@ import PushResult._
 
 class PipeSpec extends WordSpec with MustMatchers with CallbackMatchers {
 
-  implicit object IntCopier extends Copier[Int] {
-    def copy(i: Int) = i
-  }
-  
   "InfinitePipe" must {
 
     "push an item after pull request" in {

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -56,6 +56,12 @@ trait MasterController[Input, Output] extends ConnectionHandler {
 
   //needs to be called after various actions complete to check if it's ok to disconnect
   private[controller] def checkControllerGracefulDisconnect()
+
+  //Right now in some cases the Input or Outut Controller decide to kill the
+  //whole connection.  We should eventually make this configurable such that we
+  //can kill one half of the controller without automatically killing the whole
+  //thing
+  def disconnect()
 }
 
 

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -7,36 +7,6 @@ import scala.util.{Try, Success, Failure}
 
 import service.{Callback, UnmappedCallback}
 
-/**
- * This trait is mostly intended for ByteBuffers which need to be copied to the
- * heap if they need to be buffered, basically in every other case copy can just return itself
- */
-trait Copier[T] {
-  def copy(item: T): T
-}
-
-object Copier {
-
-  implicit object DataBufferCopier extends Copier[DataBuffer] {
-    def copy(d: DataBuffer) = d.takeCopy
-  }
-}
-
-//hrm....
-object ReflexiveCopiers{
-
-  trait Reflect[T] {
-    def copy(t : T) : T = t
-  }
-
-  implicit object StringReflect extends Copier[String] with Reflect[String]
-  implicit object IntReflect extends Copier[Int] with Reflect[Int]
-  implicit object LongReflect extends Copier[Long] with Reflect[Long]
-  implicit object ShortReflect extends Copier[Short] with Reflect[Short]
-  implicit object FloatReflect extends Copier[Float] with Reflect[Float]
-  implicit object DoubleReflect extends Copier[Double] with Reflect[Double]
-}
-
 trait Transport {
   //can be triggered by either a source or sink, this will immediately cause
   //all subsequent pull and pushes to return an Error

--- a/colossus/src/main/scala/colossus/controller/PipeCombinator.scala
+++ b/colossus/src/main/scala/colossus/controller/PipeCombinator.scala
@@ -12,7 +12,7 @@ object PipeCombinator {
 
       import scala.collection.JavaConverters._
 
-      private var queue : java.util.Queue[SNKIN] = new util.LinkedList[SNKIN]()
+      private var queue  = new util.LinkedList[SNKIN]()
 
       pipeData()
 
@@ -51,8 +51,8 @@ object PipeCombinator {
               input.complete()
             }
             case PushResult.Full(t) => {
-              //this should never happen since we catch it in Filled
-              throw new Exception("tried to push when already full")
+              queue.addFirst(next)
+              t.fill(pushToSink)
             }
             case PushResult.Filled(t) => {
               t.fill(pushToSink)

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
@@ -47,7 +47,7 @@ object HttpClientCodec {
       }
 
       private def createChunkedReponse(headers : StreamingHttpResponseHeaderStub) : ResponseAndSink = {
-        val combinator = StreamingHttpChunkPipe(new InfinitePipe[DataBuffer](streamingQueueSize), new InfinitePipe[DataBuffer](streamingQueueSize)) //uergh...this terrifies me
+        val combinator = StreamingHttpChunkPipe(new InfinitePipe[DataBuffer], new InfinitePipe[DataBuffer])
         val res = StreamingHttpResponse(headers.version, headers.code, headers.headers, combinator)
         ResponseAndSink(res, combinator)
       }
@@ -60,7 +60,7 @@ object HttpClientCodec {
 
       private def createNonChunkedPipe(headers : StreamingHttpResponseHeaderStub) : Pipe[DataBuffer, DataBuffer] = {
         val length = headers.getContentLength.getOrElse(0)
-        new FiniteBytePipe(length, streamingQueueSize)
+        new FiniteBytePipe(length)
       }
     }
   }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -44,7 +44,7 @@ object StreamingHttpResponse {
   def fromStatic(response : HttpResponse) : StreamingHttpResponse = {
     val buffer = response.data.asByteBuffer
     val data = new DataBuffer(buffer)
-    val pipe = new FiniteBytePipe(response.data.size, HttpResponseParser.DefaultQueueSize)
+    val pipe = new FiniteBytePipe(response.data.size)
     pipe.push(data)
     val strippedHeaders = response.headers.filterNot{_._1 == HttpHeaders.ContentLength}
     val finalHeaders = strippedHeaders :+ (HttpHeaders.ContentLength, response.data.size.toString)

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -44,11 +44,9 @@ object StreamingHttpResponse {
   def fromStatic(response : HttpResponse) : StreamingHttpResponse = {
     val buffer = response.data.asByteBuffer
     val data = new DataBuffer(buffer)
-    val pipe = new FiniteBytePipe(response.data.size)
-    pipe.push(data)
     val strippedHeaders = response.headers.filterNot{_._1 == HttpHeaders.ContentLength}
     val finalHeaders = strippedHeaders :+ (HttpHeaders.ContentLength, response.data.size.toString)
-    StreamingHttpResponse(response.version, response.code, finalHeaders, pipe)
+    StreamingHttpResponse(response.version, response.code, finalHeaders, Source.one(data))
   }
 
   def fromValue[T : ByteStringLike](version : HttpVersion = HttpVersion.`1.1`, code : HttpCode, headers :Seq[(String, String)] = Nil, value : T) : StreamingHttpResponse = {


### PR DESCRIPTION
This fixes #123 and addresses a serious bug in how data is pushed into streams.  Previously, when the controller pushed a `DataBuffer` into a stream, and the receiving side of the pipe could not immediately process the data, the pipe would copy the buffer and queue it, while the controller would see that as a success and thus toss the `DataBuffer`.  However, it's possible that the `DataBuffer` contained both the end of that stream as well as the beginning of the next stream.  Since the receiver would just ignore the extra data, the data would be lost forever.

This PR almost completely changes the semantics of pipes such that they are more of a synchronization mechanism now than an intermediary buffer.  The removal of any internal buffering totally eliminates the above problem as well as another issue dealing with the unnecessary copying of `DataBuffers` and worrying about queue sizes.  Now any backpressure is immediately escalated to the controller.

* Pipes are now implemented as a state machine.
* Since there is no internal buffering, pushing a value into a pipe only succeeds if the puller has already made a request.  The return `PushResult` of a push operation then depends on whether the puller's callback calls `pull` again or `complete`.  Therefore, with every push operation, the pusher will know both the success of the push and whether the pipe is able to receive more data based only on the return value.

I think there are two more things that need to be done.

* FiniteBytePipe still does some `DataBuffer` copying, and it does some crazy logic to avoid doing it when it doesn't have to.  If we supply a way to "slice" a `DataBuffer`, all that will be eliminated.
* We might want to change the signature of the pull callback, such that it's return value is an ADT rather than `Unit`, with values like `Pull`, `PullWith(new_callback)`, or `Complete`.  This would totally break the ability to turn the pull method into returning a callback, but I think this is not important.  It's more likely users will either want to loop over all the items being pulled, or use a callback just to fold the stream into a single value, which will still be doable.