### PR TITLE
Idle timeout fixes

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
@@ -1,11 +1,16 @@
 package colossus
+package core
 
-import core._
 import testkit._
+import org.scalatest.mock.MockitoSugar
+import org.mockito.Mockito._
 
+import akka.testkit.TestProbe
 import akka.util.ByteString
 
-class ConnectionSpec extends ColossusSpec {
+import scala.concurrent.duration._
+
+class ConnectionSpec extends ColossusSpec with MockitoSugar{
 
   "WriteBuffer" must {
     "write some bytes" in {
@@ -40,6 +45,29 @@ class ConnectionSpec extends ColossusSpec {
     }
     
 
+  }
+
+  "ClientConnection" must {
+    "timeout idle connection" in {
+      val channel = mock[java.nio.channels.SocketChannel]
+      val key     = mock[java.nio.channels.SelectionKey]
+      val handler = mock[ClientConnectionHandler]
+      when(handler.maxIdleTime).thenReturn(100.milliseconds)
+      val con = new ClientConnection(1, key, channel, handler)
+      val time = System.currentTimeMillis
+      con.isTimedOut(time) must equal(false)
+      con.isTimedOut(time + 101) must equal(true)
+      Thread.sleep(30)
+      con.write(DataBuffer(ByteString("asdf")))
+      val time2 = System.currentTimeMillis
+      con.isTimedOut(time + 101) must equal(false)
+      con.isTimedOut(time2 + 101) must equal(true)
+      Thread.sleep(30)
+      val time3 = System.currentTimeMillis
+      con.handleRead(DataBuffer(ByteString("WHATEVER")))(time3)
+      con.isTimedOut(time2 + 101) must equal(false)
+      con.isTimedOut(time3 + 101) must equal(true)
+    }
   }
 
 }

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -123,7 +123,8 @@ private[core] abstract class Connection(val id: Long, val key: SelectionKey, _ch
       port = port,
       id = id,
       timeOpen = now - startTime,
-      timeIdle = now - lastTimeDataReceived,
+      readIdle = now - lastTimeDataReceived,
+      writeIdle = now - lastTimeDataWritten,
       bytesSent = bytesSent,
       bytesReceived = bytesReceived
     )
@@ -152,7 +153,7 @@ private[core] abstract class Connection(val id: Long, val key: SelectionKey, _ch
   def consoleString = {
     val now = System.currentTimeMillis
     val age = now - startTime
-    val idle = now - _lastTimeDataReceived
+    val idle = timeIdle(now)
     s"$id: $host:  age: $age idle: $idle"
   }
 

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -82,6 +82,11 @@ trait ClientConnectionHandler extends ConnectionHandler {
    * Event handler for when a connection failed.
    */
   def connectionFailed()
+
+  /**
+   * If no data is either sent or received in this amount of time, the connection is closed.  Defaults to Duration.Inf but handlers can override it
+   */
+  def maxIdleTime : Duration = Duration.Inf
 }
 
 /**

--- a/colossus/src/main/scala/colossus/core/ConnectionInfo.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionInfo.scala
@@ -11,7 +11,8 @@ import java.net.InetAddress
  * @param port The port of this Connection
  * @param id The id of this Connection
  * @param timeOpen The amount of time this Connection has been open
- * @param timeIdle The amount of time this Connection has been idle
+ * @param readIdle milliseconds since the last read activity on the connection
+ * @param writeIdle milliseconds since the last write activity on the connection
  * @param bytesSent The amount of bytes that this Connection has sent
  * @param bytesReceived The amount of bytes that this Connection has received
  */
@@ -21,10 +22,14 @@ case class ConnectionInfo(
   port: Int,
   id: Long,
   timeOpen: Long = 0,
-  timeIdle: Long = 0,
+  readIdle: Long = 0,
+  writeIdle: Long = 0,
   bytesSent: Long = 0,
   bytesReceived: Long = 0
 ) {
+
+  def timeIdle = math.min(readIdle, writeIdle)
+  
   def consoleString = f"$id%-10s $domain%-10s ${host.getHostName}%-10s $timeOpen%-10s $timeIdle%-10s $bytesSent%-10s $bytesReceived%-10s"
 
   def itemValues = List(id.toString, domain, host.getHostName, timeOpen.toString, timeIdle.toString, bytesSent.toString, bytesReceived.toString)


### PR DESCRIPTION
Fixes #88 and #114 

* The new `maxIdleTime` on `ClientConnectionHandler` gives client connections a way to specify a max timeout.  This works differently from server connections, since not only are all server connections configured the same way, their idle timeout can change based on the server's number of open connections.  Client connections are largely independent of each other, so it makes the most sense to put the dependency here.  
* Connections now keep track of the last time they successfully wrote data on the socket, and use this value to determine if it is idle.