### PR TITLE
Removing shared interface from ServiceClient, LoadbalancingClient

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
@@ -5,7 +5,7 @@ import colossus.IOSystem
 import colossus.core.ServerRef
 import colossus.protocols.http._
 import colossus.protocols.redis._
-import colossus.service.{Callback, LocalClient, Service}
+import colossus.service.{Callback, Service, ServiceClient}
 import java.net.InetSocketAddress
 
 import UrlParsing._
@@ -19,7 +19,7 @@ object HttpExample {
    * Here we're demonstrating a common way of breaking out the business logic
    * from the server setup, which makes functional testing easy
    */
-  class HttpRoutes(redis: LocalClient[Command, Reply]) {
+  class HttpRoutes(redis: ServiceClient[Command, Reply]) {
     
     def invalidReply(reply: Reply) = s"Invalid reply from redis $reply"    
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -367,15 +367,6 @@ class ServiceClientSpec extends ColossusSpec {
     }
 
 
-    "get a shared interface" in {
-      val (endpoint, client, probe) = newClient(true, 10)
-      val shared = client.shared
-      val cmd1 = Command(CMD_GET, "foo")
-      val f = shared.send(cmd1)
-      //probe.expectMsg(Message(1, AsyncRequest
-      probe.expectMsgType[WorkerCommand.Message](50.milliseconds)
-    }
-
     //blocked on https://github.com/tumblr/colossus/issues/19
     "attempts to reconnect when server closes connection" in {
       //try it for real (reacting to a bug with NIO interaction)

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -63,7 +63,10 @@ class ClientProxy(config: ClientConfig, system: IOSystem, handlerFactory: ActorR
 
 }
 
-trait AsyncServiceClient[I,O] extends SharedClient[I,O] {
+trait AsyncServiceClient[I,O]  {
+  
+  def send(request: I): Future[O]
+
   def connectionStatus: Future[ConnectionStatus]
   def disconnect()
 

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -70,25 +70,9 @@ class RequestTimeoutException extends ServiceClientException("Request Timed out"
  */
 class DataException(message: String) extends ServiceClientException(message)
 
-/**
- * The ClientLike trait is intended to be an interface for anything that you
- * can connect to and send messages.  It may be a single connection (as it is
- * with ServiceClient) or may be a pool of connections
- */
-trait ClientLike[I,O,M[_]] {
-  def send(request: I): M[O]
-}
-
-trait LocalClient[I,O] extends ClientLike[I,O,Callback]{
-}
-
-trait SharedClient[I,O] extends ClientLike[I,O,Future] {
-}
-
-trait ServiceClientLike[I,O] extends LocalClient[I,O] {
+trait ServiceClientLike[I,O]  {
   def gracefulDisconnect()
-  def config: ClientConfig
-  def shared: SharedClient[I,O]
+  def send(request: I): Callback[O]
 }
 
 
@@ -122,7 +106,6 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize)) with 
 
   type ResponseHandler = Try[O] => Unit
 
-  //todo: figure out how to make these not lazy
   private val periods = List(1.second, 1.minute)
   private val requests  = worker.metrics.getOrAdd(Rate(name / "requests", periods))
   private val errors    = worker.metrics.getOrAdd(Rate(name / "errors", periods))
@@ -145,8 +128,6 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize)) with 
   //TODO way too application specific
   private val hpTags: TagMap = Map("client_host" -> address.getHostName, "client_port" -> address.getPort.toString)
   private val hTags: TagMap = Map("client_host" -> address.getHostName)
-
-  case class AsyncRequest(request: I, handler: ResponseHandler)
 
   worker.bind(this)
 
@@ -194,17 +175,6 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize)) with 
     attemptWrite(s)
   }
 
-  /** Create a shared interface that is thread safe and returns Futures
-   */
-  def shared: SharedClient[I,O] = new SharedClient[I,O] {
-    def send(request: I): Future[O] = {
-      val promise = Promise[O]()
-      val handler = {response: Try[O] => promise.complete(response);()}
-      id.map{id => worker ! Message(id, (AsyncRequest(request, handler)))}.getOrElse(promise.failure(new NotConnectedException("Not Bound to worker")))
-      promise.future
-    }
-  }
-
   /**
    * Create a callback for sending a request.  this allows you to do something like
    * service.sendCB("request"){response => "YAY"}.map{str => println(str)}.execute()
@@ -227,12 +197,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize)) with 
     if (paused) resumeWrites()
   }
 
-  def receivedMessage(message: Any, sender: ActorRef) {
-    message match {
-      case AsyncRequest(request, handler) => sendNow(request)(handler)
-      case other => throw new Exception(s"Received invalid message $other")
-    }
-  }
+  def receivedMessage(message: Any, sender: ActorRef) {}
 
   override def connected(endpoint: WriteEndpoint) {
     super.connected(endpoint)


### PR DESCRIPTION
This fixes #104 .  It is, perhaps unsurprisingly, not a lot of code.  

This was developed back when we thought there'd be more fluidity between Callbacks and Futures, such that you would want to directly use a client within a Future.  This is no longer the case, and instead any Futures that arise in the execution of a request should be converted into a Callback before any mapping, flatmapping.