### PR TITLE
Small tweaks to metrics including scaladoc

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -2,17 +2,28 @@ package colossus.metrics
 
 import akka.actor._
 import akka.agent.Agent
-import akka.pattern.ask
+import colossus.metrics.MetricAddress.Root
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-import akka.util.Timeout
-import MetricAddress.Root
 
 
 case class MetricSystemId(id: Long)
 
-
+/**
+ * The MetricSystem is a set of actors which handle the background operations of dealing with metrics. In most cases,
+ * you only want to thave one MetricSystem per application.
+ *
+ * Metrics are generated periodically by a Tick message published on the global event bus. By default this happens once
+ * per second, but it can be configured to any time interval. So while events are being collected as they occur,
+ * compiled metrics (such as rates and histogram percentiles) are generated once per tick.
+ *
+ * @param id The ID of the metrics system
+ * @param namespace the base of the url describing the location of metrics within the system
+ * @param clock an actor which serves as the clock for the metric system
+ * @param database an actor which serves as the database of the metric system
+ * @param snapshot
+ * @param tickPeriod The frequency of the tick message
+ */
 case class MetricSystem(id: MetricSystemId, namespace: MetricAddress, clock: ActorRef, database: ActorRef, snapshot: Agent[MetricMap], tickPeriod: FiniteDuration) {
 
 
@@ -20,6 +31,12 @@ case class MetricSystem(id: MetricSystemId, namespace: MetricAddress, clock: Act
 
   def query(queryString: String): MetricMap = query(MetricFilter(queryString))
 
+  /**
+   * Configures the reporting of the metric system.
+   * @param config The [[MetricReporterConfig]] to use when configuring reporting
+   * @param fact
+   * @return
+   */
   def report(config: MetricReporterConfig)(implicit fact: ActorRefFactory): ActorRef = MetricReporter(config)(this, fact)
 
   def sharedCollection(globalTags: TagMap = TagMap.Empty)(implicit fact: ActorRefFactory) = {
@@ -32,6 +49,14 @@ case class MetricSystem(id: MetricSystemId, namespace: MetricAddress, clock: Act
 }
 
 object MetricSystem {
+  /**
+   * Constructs a metric system
+   * @param namespace the base of the url describing the location of metrics within the system
+   * @param tickPeriod The frequency of the tick message
+   * @param collectSystemMetrics whether to collect metrics from the system as well
+   * @param system the actor system the metric system should use
+   * @return
+   */
   def apply(namespace: MetricAddress, tickPeriod: FiniteDuration = 1.second, collectSystemMetrics: Boolean = true)
   (implicit system: ActorSystem): MetricSystem = {
     import system.dispatcher
@@ -46,7 +71,7 @@ object MetricSystem {
   }
 
   def deadSystem(implicit system: ActorSystem) = {
-    import ExecutionContext.Implicits.global //this is ok since we're using it to create an agent that's never used
+    import scala.concurrent.ExecutionContext.Implicits.global //this is ok since we're using it to create an agent that's never used
     MetricSystem(MetricSystemId(System.nanoTime), Root / "DEAD", system.deadLetters, system.deadLetters, Agent[MetricMap](Map()), 0.seconds)
   }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -11,7 +11,7 @@ case class MetricSystemId(id: Long)
 
 /**
  * The MetricSystem is a set of actors which handle the background operations of dealing with metrics. In most cases,
- * you only want to thave one MetricSystem per application.
+ * you only want to have one MetricSystem per application.
  *
  * Metrics are generated periodically by a Tick message published on the global event bus. By default this happens once
  * per second, but it can be configured to any time interval. So while events are being collected as they occur,

--- a/colossus-metrics/src/main/scala/colossus/metrics/StatReporter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/StatReporter.scala
@@ -15,6 +15,14 @@ trait TagGenerator {
   def tags: TagMap
 }
 
+/**
+ * Configuration class for the metric reporter
+ * @param metricSender A [[MetricSender]] instance that the reporter will use to send metrics
+ * @param globalTags
+ * @param filters
+ * @param frequency
+ * @param includeHostInGlobalTags
+ */
 case class MetricReporterConfig(
   metricSender: MetricSender,
   globalTags: Option[TagGenerator] = None,

--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/LoggerSender.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/LoggerSender.scala
@@ -26,9 +26,9 @@ class LoggerSenderActor(override val formatter:Formatter) extends Actor with Act
 }
 
 class LoggerSender(val formatter:Formatter) extends MetricSender {
-  override def name: String = "logger"
+  def name: String = "logger"
 
-  override def props: Props = Props(classOf[LoggerSenderActor], formatter)
+  def props: Props = Props(classOf[LoggerSenderActor], formatter)
 }
 
 object LoggerSender extends MetricSender {

--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/LoggerSender.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/LoggerSender.scala
@@ -2,11 +2,12 @@ package colossus.metrics
 
 import akka.actor._
 import colossus.metrics.senders.MetricsLogger
+import colossus.metrics.senders.MetricsLogger.Formatter
 
 /**
  * Simple sender that just prints the stats to the log
  */
-class LoggerSenderActor extends Actor with ActorLogging with  MetricsLogger {
+class LoggerSenderActor(override val formatter:Formatter) extends Actor with ActorLogging with  MetricsLogger {
 
   def receive = {
     case s: MetricSender.Send => {
@@ -22,11 +23,18 @@ class LoggerSenderActor extends Actor with ActorLogging with  MetricsLogger {
   override def postStop() {
     log.info("shutting down dummy sender")
   }
+}
 
+class LoggerSender(val formatter:Formatter) extends MetricSender {
+  override def name: String = "logger"
+
+  override def props: Props = Props(classOf[LoggerSenderActor], formatter)
 }
 
 object LoggerSender extends MetricSender {
   def name = "logger"
-  def props = Props(classOf[LoggerSenderActor])
+  def props = Props(classOf[LoggerSenderActor], MetricsLogger.defaultMetricsFormatter)
+
+  def apply(formatter:Formatter) = new LoggerSender(formatter)
 }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/package.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/package.scala
@@ -4,15 +4,19 @@ import akka.actor.ActorLogging
 
 package object senders {
 
-  trait MetricsLogger{ this : ActorLogging =>
+  trait MetricsLogger { this: ActorLogging =>
+    import MetricsLogger.Formatter
+    val formatter: Formatter = MetricsLogger.defaultMetricsFormatter
 
-    def logMetrics(s : MetricSender.Send) {
+    def logMetrics(s: MetricSender.Send): Unit = {
       val frags = s.fragments
-      if (log.isDebugEnabled) {
-        frags.foreach{stat => log.debug(OpenTsdbFormatter.format(stat, s.timestamp).stripLineEnd)}
-      }
-
+      if (log.isDebugEnabled)
+        frags.foreach(stat => log.debug(formatter(stat, s.timestamp)))
     }
   }
 
+  object MetricsLogger {
+    type Formatter = (MetricFragment, Long) => String
+    val defaultMetricsFormatter = (frag: MetricFragment, timestamp: Long) => OpenTsdbFormatter.format(frag, timestamp).stripLineEnd
+  }
 }


### PR DESCRIPTION
I've added scaladoc for some of the metrics api and also expanded the LoggerSender to allow a custom format.