### PR TITLE
Http refactoring, chunked transfer support

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -37,18 +37,39 @@ object Main extends App {
   val chatServer = ChatExample.start(9005)
 
 
+  import core.DataBuffer
   import service._
   import protocols.http._
+  import HttpMethod._
+  import UrlParsing._
+  import controller._
+  import akka.util.ByteString
+  import Callback.Implicits._
 
   Service.serve[StreamingHttp]("stream-proxy", 9090){ context =>
     context.handle{ connection =>
       connection.become {
-        case req => {
+        case req @ Get on Root => {
           val client = context.clientFor[StreamingHttp]("localhost", 9001)
-          client.send(HttpRequest.get("/")).map{c =>
+          client.send(HttpRequest.get("/")).map{response =>
             client.gracefulDisconnect()
-            c
+            response
           }
+        }
+        case req @ Get on Root / "x" / Integer(num) => {
+          class NumberGenerator extends Generator[DataBuffer] {
+            private var current = 0
+            def generate(): Option[DataBuffer] = {
+              current += 1
+              if (current == num) None else Some(DataBuffer(ByteString(current.toString)))
+            }
+          }
+          val pipe = new ChunkEncodingPipe
+          pipe.feed(new NumberGenerator, true)
+          StreamingHttpResponse(
+            HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector("Transfer-Encoding" -> "chunked")),
+            Some(pipe)
+          )
         }
       }
     }

--- a/colossus-testkit/src/main/scala/colossus-testkit/PipeFoldTester.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/PipeFoldTester.scala
@@ -1,0 +1,58 @@
+package colossus
+package testkit
+
+import akka.util.ByteString
+import core.DataBuffer
+import service.Callback
+import scala.util.{Try, Success, Failure}
+
+
+/**
+ * This can be used to test folding on pipes. {{{
+ val pipe = new InfinitePipe[Int, Int]
+ val foldDB = pipe.fold(0){(a, b) => a + b}
+ val tester = new FoldTester(foldCB)
+ pipe.push(3)
+ pipe.push(4)
+ pipe.complete()
+ tester.expect(7)
+ }}}
+ */
+class PipeFoldTester[T](foldCB: Callback[T]) {
+  private var res: Option[Try[T]] = None
+  foldCB.execute{result => res = Some(result)}
+
+  private def expectRes(r: Try[T] => Unit) { 
+    res.map(r).getOrElse{
+      throw new Exception("Callback did not complete")
+    }
+  }
+
+  def expect(expected: T) {
+    expectRes{
+      case Success(v) => if (v != expected) throw new Exception(s"Callback expected $expected, got $v")
+      case Failure(err) => throw new Exception(s"Expected $expected, but callback failed with $err")
+    }
+  }
+
+  def expectFailure() {
+    expectRes{
+      case Success(v) => throw new Exception("Expected Callback failure, but it completed with $v")
+      case Failure(_) => {}
+    }
+  }
+
+  def expectIncomplete() {
+    res.foreach{value =>
+      throw new Exception(s"Expected incomplete folding, but folding has completed with value $value")
+    }
+  }
+
+}
+
+object PipeFoldTester {
+
+  def byteFolder(buffer: DataBuffer, build: ByteString) = build ++ ByteString(buffer.takeAll)
+
+
+}

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -25,7 +25,7 @@ class TestCodec(pipeSize: Int = 3) extends Codec[TestOutput, TestInput]{
   def decode(data: DataBuffer): Option[DecodedResult[TestInput]] = {
     val res = parser.parse(data)
     res.map { x =>
-      DecodedResult.Streamed(x, x.source)
+      DecodedResult.Stream(x, x.source)
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpPipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpPipeSpec.scala
@@ -45,7 +45,7 @@ class HttpPipeSuite extends WordSpec with MustMatchers{
 
     }
 
-    "terminate the pipe on parsing exception" ignore {
+    "terminate the pipe on parsing exception" in {
       val p = new ChunkPassThroughPipe
       val c = foldTester(p)
       p.push(DataBuffer(badChunkedBody)) mustBe a[PushResult.Error]

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpPipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpPipeSpec.scala
@@ -1,0 +1,72 @@
+package colossus
+package protocols.http
+
+import core._
+import controller.Pipe
+import controller.PushResult
+import testkit.PipeFoldTester
+
+import org.scalatest._
+
+import akka.util.ByteString
+
+import service.Callback
+import scala.util.{Try, Success, Failure}
+
+
+
+
+class HttpPipeSuite extends WordSpec with MustMatchers{
+    
+  val chunkedBody = ByteString("3\r\nfoo\r\nb\r\n12345678901\r\n0\r\n\r\n")
+  val badChunkedBody = ByteString("3\r\nfoo\r\n1WHATTT\r\n12345678901\r\n0\r\n\r\n")
+
+
+  def foldTester[A](p: Pipe[A, DataBuffer]): PipeFoldTester[ByteString] = new PipeFoldTester(p.fold(ByteString())(PipeFoldTester.byteFolder))
+
+  "ChunkPassthroughPipe" must {
+
+    "leave the data untouched" in {
+      val p = new ChunkPassThroughPipe
+      val c = foldTester(p)
+      p.push(DataBuffer(chunkedBody)) must equal(PushResult.Complete)
+      c.expect(chunkedBody)
+    }
+
+    "properly detect the end of the stream" in {
+      val p = new ChunkPassThroughPipe
+      val c = foldTester(p)
+
+      val extra = ByteString("ADSFASDFASDF")
+      val data = DataBuffer(chunkedBody ++ extra)
+      p.push(data) must equal(PushResult.Complete)
+      c.expect(chunkedBody)
+      data.remaining must equal(extra.size)
+
+    }
+
+    "terminate the pipe on parsing exception" ignore {
+      val p = new ChunkPassThroughPipe
+      val c = foldTester(p)
+      p.push(DataBuffer(badChunkedBody)) mustBe a[PushResult.Error]
+      c.expectFailure()
+    }
+
+
+  }
+
+  "ChunkDecodingPipe" must {
+
+    "Process a chunked body" in {
+      val expected = ByteString("foo12345678901")
+      val p = new ChunkDecodingPipe
+      val c = foldTester(p)
+      p.push(DataBuffer(chunkedBody)) must equal(PushResult.Complete)
+      c.expect(expected)
+    }
+
+
+  }
+
+
+}

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -1,12 +1,12 @@
 package colossus
+package protocols.http
 
 
-import colossus.core.{DataBuffer, DataStream}
+import core._
 import org.scalatest._
 
 import akka.util.ByteString
 
-import protocols.http._
 
 class HttpSpec extends WordSpec with MustMatchers{
 
@@ -44,9 +44,9 @@ class HttpSpec extends WordSpec with MustMatchers{
   "http response" must {
     "encode basic response" in {
       val content = "Hello World!"
-      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Nil, ByteString(content))
+      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Vector(), ByteString(content))
       val expected = s"HTTP/1.1 200 OK\r\nContent-Length: ${content.length}\r\n\r\n$content"
-      val res = HttpResponseDataReader(response)
+      val res = response.encode()
       res match {
         case x : DataBuffer => {
           val received = ByteString(x.takeAll).utf8String
@@ -58,9 +58,9 @@ class HttpSpec extends WordSpec with MustMatchers{
 
     "encode a basic response as a stream" in {
       val content = "Hello World!"
-      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Nil, ByteString(content))
+      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Vector(), ByteString(content))
       val expected = s"HTTP/1.1 200 OK\r\nContent-Length: ${content.length}\r\n\r\n$content"
-      val stream: DataStream = StreamedResponseBuilder(StreamingHttpResponse.fromStatic(response))
+      val stream: DataReader = StreamingHttpResponse.fromStatic(response).encode()
     }
   }
 }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
@@ -15,13 +15,15 @@ import parsing.DataSize._
 
 class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
+  import DecodedResult.Static
+
   "HttpResponseParser" must {
 
     "parse a basic response" in {
       val res = ByteString("HTTP/1.1 200 OK\r\n\r\n")
-      val parser = HttpResponseParser.static(res.size.bytes)
+      val parser = new HttpResponseParser(res.size.bytes)
       val data = DataBuffer(res)
-      parser.parse(data) must equal(Some(HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Nil, ByteString())))
+      parser.parse(data) must equal(Some(Static(HttpResponse(HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector()), None))))
       data.remaining must equal(0)
     }
 
@@ -29,12 +31,13 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
     "parse a response with no body" in {
 
       val res = "HTTP/1.1 200 OK\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nAuthorization: Basic XXX\r\nAccept-Encoding: gzip, deflate\r\n\r\n"
-      val parser = HttpResponseParser.static()
+      val parser = new HttpResponseParser()
 
-      val expected = HttpResponse(HttpVersion.`1.1`,
+      val expected = Static(HttpResponse(
+        HttpVersion.`1.1`,
         HttpCodes.OK,
-        List("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate"),
-        ByteString(""))
+        Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate")
+      ))
       parser.parse(DataBuffer(ByteString(res))).toList must equal(List(expected))
 
     }
@@ -43,13 +46,13 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       val content = "{some : json}"
       val size = content.getBytes.size
       val res = s"HTTP/1.1 200 OK\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nAuthorization: Basic XXX\r\nAccept-Encoding: gzip, deflate\r\nContent-Length: $size\r\n\r\n{some : json}"
-      val parser = HttpResponseParser.static()
+      val parser = new HttpResponseParser()
 
-      val expected = HttpResponse(HttpVersion.`1.1`,
+      val expected = Static(HttpResponse(HttpVersion.`1.1`,
         HttpCodes.OK,
-        List("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate", "content-length"->size.toString),
+        Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate", "content-length"->size.toString),
         ByteString("{some : json}")
-        )
+      ))
       val data = DataBuffer(ByteString(res))
       parser.parse(data).toList must equal(List(expected))
       data.remaining must equal(0)
@@ -57,20 +60,21 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
 
     "decode a response that was encoded by colossus with no body" in {
-      val sent = HttpResponse(HttpVersion.`1.1`,
+      val sent = HttpResponse(
+        HttpVersion.`1.1`,
         HttpCodes.OK,
-        List("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate"),
-        ByteString(""))
+        Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate")
+      )
 
-      val expected = DecodedResult.Static(sent.copy(headers = ("content-length"->"0") +: sent.headers))
+      val expected = Some(DecodedResult.Static(sent.withHeader("content-length", "0")))
 
-      val serverProtocol = HttpServerCodec.static
-      val clientProtocol = HttpClientCodec.static()
+      val serverProtocol = new HttpServerCodec
+      val clientProtocol = new HttpClientCodec
 
       val encodedResponse = serverProtocol.encode(sent).asInstanceOf[DataBuffer]
 
       val decodedResponse = clientProtocol.decode(encodedResponse)
-      decodedResponse.toList must equal(List(expected))
+      decodedResponse must equal(expected)
       encodedResponse.remaining must equal(0)
     }
 
@@ -78,32 +82,34 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       val content = "{some : json}"
       val size = content.getBytes.size
 
-      val sent = HttpResponse(HttpVersion.`1.1`,
+      val sent = HttpResponse(
+        HttpVersion.`1.1`,
         HttpCodes.OK,
-        List("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate"),
-        ByteString("{some : json}"))
+        Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate"),
+        ByteString("{some : json}")
+      )
 
-      val expected = DecodedResult.Static(sent.copy(headers = ("content-length"->size.toString) +: sent.headers ))
+      val expected = Some(DecodedResult.Static(sent.withHeader("content-length", size.toString)))
 
-      val serverProtocol = HttpServerCodec.static
-      val clientProtocol = HttpClientCodec.static()
+      val serverProtocol = new HttpServerCodec
+      val clientProtocol = new HttpClientCodec
 
       val encodedResponse = serverProtocol.encode(sent).asInstanceOf[DataBuffer]
 
       val decodedResponse = clientProtocol.decode(encodedResponse)
-      decodedResponse.toList must equal(List(expected))
+      decodedResponse must equal(expected)
       encodedResponse.remaining must equal(0)
     }
 
     "accept a response under the size limit" in {
       val res = ByteString("HTTP/1.1 200 OK\r\n\r\n")
-      val parser = HttpResponseParser.static(res.size.bytes)
-      parser.parse(DataBuffer(res)) must equal(Some(HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Nil, ByteString())))
+      val parser = new HttpResponseParser(res.size.bytes)
+      parser.parse(DataBuffer(res)) must equal(Some(Static(HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Vector()))))
     }
 
     "reject a response over the size limit" in {
       val res = ByteString("HTTP/1.1 200 OK\r\n\r\n")
-      val parser = HttpResponseParser.static((res.size - 1).bytes)
+      val parser = new HttpResponseParser((res.size - 1).bytes)
       intercept[ParseException] {
         parser.parse(DataBuffer(res))
       }
@@ -111,10 +117,10 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
     "parse a response with chunked transfer encoding" in {
       val res = "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n3\r\nfoo\r\ne\r\n123456789abcde\r\n0\r\n\r\n"
-      val parser = HttpResponseParser.static()
+      val parser = new HttpResponseParser
 
       val parsed = parser.parse(DataBuffer(ByteString(res))).get
-      parsed.data must equal (ByteString("foo123456789abcde"))
+      parsed.value.body.get must equal (ByteString("foo123456789abcde"))
     }
       
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -85,7 +85,7 @@ class ServiceServerSpec extends ColossusSpec {
         }
         withServer(server) { 
           val client = AsyncServiceClient[Http]("localhost", TEST_PORT)
-          Await.result(client.send(HttpRequest.get("/")), 1.second).data must equal(ByteString("Hello World"))
+          Await.result(client.send(HttpRequest.get("/")), 1.second).body.get must equal(ByteString("Hello World"))
         }
       }
     }

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -108,7 +108,7 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
 
     inputState match {
       case Decoding => codec.decode(data) match {
-        case Some(DecodedResult.Streamed(msg, sink)) => {
+        case Some(DecodedResult.Stream(msg, sink)) => {
           inputState = ReadingStream(sink)
           processAndContinue(msg, data)
         }

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -189,6 +189,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
       }
       if (timedOut.size > 0) {
         log.debug(s"Terminated ${timedOut.size} idle connections")
+        //TODO: Tick Metric
       }
     }
     case WorkerManager.RegisterServer(server, factory, timesTried) => if (!delegators.contains(server.server)){
@@ -230,6 +231,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
         rejectedConnections.hit(tags = Map("server" -> delegator.server.name.idString))
       }
     }.getOrElse{
+      //TODO: do something with the connection
       log.error("Received connection from unregistered server!!!")
     }
     case Terminated(handler) => {

--- a/colossus/src/main/scala/colossus/metrics/JsonMetricSender.scala
+++ b/colossus/src/main/scala/colossus/metrics/JsonMetricSender.scala
@@ -28,13 +28,13 @@ class JsonMetricSenderActor(io: IOSystem, host: String, port: Int, path: String)
   implicit val timeout = Timeout(1.seconds)
   import context.dispatcher
 
-  val client = AsyncServiceClient(config, HttpClientCodec.static())
+  val client = AsyncServiceClient(config, new HttpClientCodec)
 
   def receive = {
     case Send(map, gtags, timestamp) => {
       val body = compact(render(map.addTags(gtags).toJson))
       val request = HttpRequest(HttpMethod.Post, path, Some(body))
-      client.send(request).map{response => response.code match {
+      client.send(request).map{response => response.head.code match {
         case HttpCodes.OK => {}
         case other => log.warning(s"got error from aggregator: $response")
       }}      

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -63,19 +63,28 @@ trait HttpHeaderUtils {
 
   def headers : Seq[(String, String)]
 
-  def getHeader(key : String) : Option[String] = {
-    headers.collectFirst{case (`key`, value) => value}
+
+  def singleHeader(name: String): Option[String] = {
+    val l = name.toLowerCase
+    headers.collectFirst{ case (`l`, v) => v}
   }
 
-  def getHeader(key : String, orElse : String) : String = {
-    headers.collectFirst{case (`key`, value) => value}.getOrElse(orElse)
+  def multiHeader(name: String): Seq[String] = {
+    val l = name.toLowerCase
+    headers.collect{ case (`l`, v) => v}
   }
 
-  def getContentLength : Option[Int] = {
-    getHeader(HttpHeaders.ContentLength).map(_.toInt)
-  }
+  //TODO: These vals are probably inefficient, should be generated as the
+  //headers are being parsed.  Benchmark before changing
 
-  def getEncoding : TransferEncoding = getHeader(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
+  /** Returns the value of the content-length header, if it exists.
+   * 
+   * Be aware that lacking this header may or may not be a valid request,
+   * depending if the "transfer-encoding" header is set to "chunked"
+   */
+  val contentLength: Option[Int] = headers.collectFirst{case (HttpHeaders.ContentLength, l) => l.toInt}
+
+  val transferEncoding : TransferEncoding = singleHeader(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
 }
 
 
@@ -113,25 +122,40 @@ object TransferEncoding {
     val value = "chunked"
   }
 
-  case object Gzip extends TransferEncoding {
-    val value = "gzip"
-  }
-
-  case object Deflate extends TransferEncoding {
-    val value = "deflate"
-  }
-
-  case object Compressed extends TransferEncoding {
-    val value = "compressed"
-  }
-
-  private val all = Seq(Identity, Chunked, Gzip, Deflate, Compressed)
+  private val all = Seq(Identity, Chunked)
   def unapply(str : String) : Option[TransferEncoding] = {
     all.find(_.value == str.toLowerCase)
   }
 }
 
-case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, headers: Seq[(String, String)]) {
+sealed trait ContentEncoding {
+  def value: String
+}
+object ContentEncoding {
+
+  case object Identity extends ContentEncoding {
+    val value = "identity"
+  }
+
+  case object Gzip extends ContentEncoding {
+    val value = "gzip"
+  }
+
+  case object Deflate extends ContentEncoding {
+    val value = "deflate"
+  }
+
+  case object Compressed extends ContentEncoding {
+    val value = "compressed"
+  }
+
+  private val all = Seq(Gzip, Deflate, Compressed, Identity)
+  def unapply(str : String) : Option[ContentEncoding] = {
+    all.find(_.value == str.toLowerCase)
+  }
+}
+
+case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, headers: Seq[(String, String)]) extends HttpHeaderUtils {
   import HttpHead._
   import HttpHeaders._
 
@@ -142,25 +166,6 @@ case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, heade
   def withHeader(header: String, value: String): HttpHead = {
     copy(headers = (header -> value) +: headers)
   }
-
-  def singleHeader(name: String): Option[String] = {
-    val l = name.toLowerCase
-    headers.collectFirst{ case (`l`, v) => v}
-  }
-
-  def multiHeader(name: String): Seq[String] = {
-    val l = name.toLowerCase
-    headers.collect{ case (`l`, v) => v}
-  }
-
-
-  /** Returns the value of the content-length header, if it exists.
-   * 
-   * Be aware that lacking this header may or may not be a valid request,
-   * depending if the "transfer-encoding" header is set to "chunked"
-   */
-  val contentLength: Option[Int] = headers.collectFirst{case (ContentLength, l) => l.toInt}
-
 
   lazy val cookies: Seq[Cookie] = multiHeader(CookieHeader).flatMap{Cookie.parseHeader}
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
@@ -1,69 +1,32 @@
 package colossus
 package protocols.http
 
-import colossus.controller.{FiniteBytePipe, Pipe, InfinitePipe, Sink}
 import colossus.core._
 import colossus.parsing.DataSize
-import colossus.service.Codec.ClientCodec
 import colossus.service._
+import Codec.ClientCodec
+import parsing._
+import Combinators.Parser
+import DataSize._
 
-trait HttpClientCodec[T <: HttpResponseHeader, U <: HttpResponseHeader] extends Codec.ClientCodec[HttpRequest, T] {
+class BaseHttpClientCodec[T <: BaseHttpResponse](parserFactory: () => Parser[DecodedResult[T]]) extends ClientCodec[HttpRequest, T] {
 
-  def parser : HttpResponseParser[U]
+  private var parser : Parser[DecodedResult[T]] = parserFactory()
 
-  override def encode(out: HttpRequest): DataBuffer = DataBuffer(out.bytes)
 
-  override def decode(data: DataBuffer): Option[DecodedResult[T]]
+  override def encode(out: HttpRequest): DataReader = DataBuffer(out.bytes)
 
-  override def reset(): Unit = { parser.reset() }
+  override def decode(data: DataBuffer): Option[DecodedResult[T]] = parser.parse(data)
+
+  override def reset(): Unit = { 
+    parser = parserFactory()
+  }
 
 }
 
-object HttpClientCodec {
+class HttpClientCodec(maxResponseSize: DataSize = 1.MB) 
+  extends BaseHttpClientCodec[HttpResponse](() => Combinators.maxSize(maxResponseSize, HttpResponseParser.staticBody(true)))
 
-  def static(maxSize : DataSize = HttpResponseParser.DefaultMaxSize) : ClientCodec[HttpRequest, HttpResponse] = {
-    new HttpClientCodec[HttpResponse, HttpResponse] {
-      val parser: HttpResponseParser[HttpResponse] = HttpResponseParser.static(maxSize)
+class StreamingHttpClientCodec(dechunk: Boolean = false)
+  extends BaseHttpClientCodec[StreamingHttpResponse](() => HttpResponseParser.streamBody(dechunk))
 
-      override def decode(data: DataBuffer): Option[DecodedResult[HttpResponse]] = {
-        parser.parse(data).map(DecodedResult.Static(_))
-      }
-    }
-  }
-
-  def streaming(maxSize : DataSize = HttpResponseParser.DefaultMaxSize,
-                streamingQueueSize : Int = HttpResponseParser.DefaultQueueSize) : ClientCodec[HttpRequest, StreamingHttpResponse] = {
-    new HttpClientCodec[StreamingHttpResponse, StreamingHttpResponseHeaderStub] {
-      val parser: HttpResponseParser[StreamingHttpResponseHeaderStub] = HttpResponseParser.streaming(maxSize, streamingQueueSize)
-
-      override def decode(data: DataBuffer): Option[DecodedResult[StreamingHttpResponse]] = {
-        parser.parse(data).map{ x=>
-          val rs = x.getEncoding match {
-            case TransferEncoding.Chunked => createChunkedReponse(x)
-            case _ => createNonChunkedReponse(x)
-          }
-          DecodedResult.Streamed(rs.response, rs.sink)
-        }
-      }
-
-      private def createChunkedReponse(headers : StreamingHttpResponseHeaderStub) : ResponseAndSink = {
-        val combinator = StreamingHttpChunkPipe(new InfinitePipe[DataBuffer], new InfinitePipe[DataBuffer])
-        val res = StreamingHttpResponse(headers.version, headers.code, headers.headers, combinator)
-        ResponseAndSink(res, combinator)
-      }
-
-      private def createNonChunkedReponse(headers : StreamingHttpResponseHeaderStub) : ResponseAndSink = {
-        val sink =  createNonChunkedPipe(headers)
-        val res = StreamingHttpResponse(headers.version, headers.code, headers.headers, sink)
-        ResponseAndSink(res, sink)
-      }
-
-      private def createNonChunkedPipe(headers : StreamingHttpResponseHeaderStub) : Pipe[DataBuffer, DataBuffer] = {
-        val length = headers.getContentLength.getOrElse(0)
-        new FiniteBytePipe(length)
-      }
-    }
-  }
-
-  private case class ResponseAndSink(response : StreamingHttpResponse, sink : Sink[DataBuffer])
-}

--- a/colossus/src/main/scala/colossus/protocols/http/HttpCode.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpCode.scala
@@ -7,6 +7,10 @@ case class HttpCode(code: Int, description: String) {
   val headerSegment = s"$code $description"
   val headerBytes = ByteString(headerSegment)
 }
+object HttpCode {
+  def apply(code: Int): HttpCode = HttpCodes(code)
+}
+
 object HttpCodes {
   //100
   val CONTINUE = HttpCode(100, "Continue")

--- a/colossus/src/main/scala/colossus/protocols/http/HttpParse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpParse.scala
@@ -13,7 +13,7 @@ object HttpParse {
   val NEWLINE = ByteString("\r\n")
 
   //common parsers
-  def headers: Parser[Seq[(String, String)]]    = repeatUntil(header, '\r') <~ byte
+  def headers: Parser[Vector[(String, String)]]    = repeatUntil(header, '\r') <~ byte
   def header: Parser[(String, String)]     = {
     stringUntil(':', toLower = true, allowWhiteSpace = false) ~ 
     stringUntil('\r', allowWhiteSpace = true, ltrim = true) <~ 
@@ -25,38 +25,6 @@ object HttpParse {
   private def chunkedBodyBuilder(builder: ByteStringBuilder): Parser[ByteString] = intUntil('\r', 16) <~ byte |> {
     case 0 => bytes(2) >> {_ => builder.result}
     case n => bytes(n.toInt) <~ bytes(2) |> {bytes => chunkedBodyBuilder(builder.append(bytes))}
-  }
-}
-
-object StreamingHttpChunkPipe {
-
-  private val chunkedBodyParser: Parser[ByteString] = intUntil('\r', 16) <~ byte |> {
-    case 0 => bytes(2) >> { _ => ByteString("")}
-    case n => bytes(n.toInt) <~ bytes(2) >> { bytes => bytes}
-  }
-
-  private val streamTerminator = ByteString("")
-
-  def convertChunks(buffer : DataBuffer): Seq[DataBuffer] = {
-    val builder = new ByteStringBuilder()
-    var chunks : Vector[DataBuffer] = Vector()
-    var bodyFinished : Boolean = false
-    while (buffer.hasUnreadData && !bodyFinished) { //should buffer have a fold function?
-      val res = chunkedBodyParser.parse(buffer)
-      res match {
-        case Some(`streamTerminator`) => {
-          chunks = chunks :+ DataBuffer(builder.result())
-          bodyFinished = true
-        }
-        case Some(x) => builder.append(x)
-        case None => {}
-      }
-    }
-    chunks
-  }
-
-  def apply(src : Pipe[DataBuffer, DataBuffer], sink : Pipe[DataBuffer, DataBuffer]) : Pipe[DataBuffer, DataBuffer] = {
-    src.join(sink)(convertChunks)
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -7,7 +7,9 @@ case class HttpRequest(head: HttpHead, entity: Option[ByteString]) {
   import head._
   import HttpCodes._
 
-  def respond(code: HttpCode, data: String, headers: List[(String, String)] = Nil) = HttpResponse(version, code, headers, ByteString(data))
+  def respond(code: HttpCode, data: String, headers: List[(String, String)] = Nil) = {
+    HttpResponse(HttpResponseHead(version, code, headers.toVector), Some(ByteString(data)))
+  }
 
   def ok(data: String, headers: List[(String, String)] = Nil)              = respond(OK, data, headers)
   def notFound(data: String = "", headers: List[(String, String)] = Nil)   = respond(NOT_FOUND, data, headers)

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -1,77 +1,152 @@
 package colossus
 package protocols.http
 
-import akka.util.ByteString
-import colossus.controller.{FiniteBytePipe, Source}
+import akka.util.{ByteString, ByteStringBuilder}
+import colossus.controller.Source
 import colossus.core.DataBuffer
+import core._
+import service.Callback
+import controller._
+import HttpParse._
 
-trait HttpResponseHeader extends HttpHeaderUtils{
-  def version : HttpVersion
-  def code : HttpCode
-  def headers : Seq[(String, String)]
 
-}
+case class HttpResponseHead(version : HttpVersion, code : HttpCode, headers : Vector[(String, String)] = Vector()) extends HttpHeaderUtils {
 
-case class HttpResponse(version : HttpVersion, code : HttpCode, headers : Seq[(String, String)] = Nil, data : ByteString) extends HttpResponseHeader {
+  def appendHeaderBytes(builder : ByteStringBuilder) {
+    builder append version.messageBytes
+    builder putByte ' '
+    builder append code.headerBytes
+    builder append NEWLINE
+    headers.foreach{case (key, value) =>
+      builder putBytes key.getBytes
+      builder putBytes ": ".getBytes
+      builder putBytes value.getBytes
+      builder append NEWLINE
+    }
+  }
 
   def withHeader(key: String, value: String) = copy(headers = headers :+ (key, value))
 
-  override def equals(other: Any) = other match {
-    case HttpResponse(v, c, h, b) => v == version && c == code && b == data && h.toSet == headers.toSet
-    case _ => false
-  }
 }
 
-object HttpResponse {
+sealed trait BaseHttpResponse { 
 
-  def fromValue[T : ByteStringLike](version : HttpVersion, code : HttpCode, headers : List[(String, String)] = Nil, data : T) : HttpResponse = {
-    HttpResponse(version, code, headers, implicitly[ByteStringLike[T]].toByteString(data))
-  }
+  type Encoded <: DataReader
+
+  def head: HttpResponseHead
+
+  /**
+   * Resolves the body into a bytestring.  This operation completes immediately
+   * for static responses.  For streaming responses, this only completes when
+   * all data has been received.  Be aware if the response is an infinite
+   * stream of data (using chunked transfer encoding), this will never
+   * complete.
+   */
+  def resolveBody(): Option[Callback[ByteString]]
+
+  def encode(): Encoded
+
+  //def withHeader(key: String, value: String): self.type
+
 }
 
-case class StreamingHttpResponse(version : HttpVersion, code : HttpCode, headers : Seq[(String, String)] = Nil, stream : Source[DataBuffer]) extends HttpResponseHeader {
-  def withHeader(key: String, value: String) = copy(headers = headers :+ (key, value))
-  
+//TODO: We need to make some headers like Content-Length, Transfer-Encoding,
+//first-class citizens and separate them from the other headers.  This would
+//prevent things like creating a response with the wrong content length
 
-  override def equals(other: Any) = other match {
-    case StreamingHttpResponse(v, c, h, s) => v == version && c == code && h.toSet == headers.toSet
-    case _ => false
+case class HttpResponse(head: HttpResponseHead, body: Option[ByteString]) extends BaseHttpResponse {
+
+  type Encoded = DataBuffer
+
+  def encode() : DataBuffer = {
+    val builder = new ByteStringBuilder
+    val dataSize = body.map{_.size}.getOrElse(0)
+    builder.sizeHint(100 + dataSize)
+    head.appendHeaderBytes(builder)
+    builder putBytes s"Content-Length: ${dataSize}".getBytes
+    builder append NEWLINE
+    builder append NEWLINE
+    body.foreach{b => 
+      builder append b
+    }
+    DataBuffer(builder.result())
   }
+
+  def resolveBody(): Option[Callback[ByteString]] = body.map{data => Callback.successful(data)}
+
+  def withHeader(key: String, value: String) = copy(head = head.withHeader(key,value))
+
 }
 
-object StreamingHttpResponse {
-
-  def fromStatic(response : HttpResponse) : StreamingHttpResponse = {
-    val buffer = response.data.asByteBuffer
-    val data = new DataBuffer(buffer)
-    val strippedHeaders = response.headers.filterNot{_._1 == HttpHeaders.ContentLength}
-    val finalHeaders = strippedHeaders :+ (HttpHeaders.ContentLength, response.data.size.toString)
-    StreamingHttpResponse(response.version, response.code, finalHeaders, Source.one(data))
-  }
-
-  def fromValue[T : ByteStringLike](version : HttpVersion = HttpVersion.`1.1`, code : HttpCode, headers :Seq[(String, String)] = Nil, value : T) : StreamingHttpResponse = {
-    val byteString = implicitly[ByteStringLike[T]].toByteString(value)
-    val strippedHeaders = headers.filterNot{_._1 == HttpHeaders.ContentLength}
-    val finalHeaders = strippedHeaders :+ (HttpHeaders.ContentLength, byteString.size.toString)
-    StreamingHttpResponse(version, code, finalHeaders, Source.one(DataBuffer(byteString)))
-  }
-}
-
+/**
+  * Converter typeclass for bytestrings.  Default implementations are in package.scala
+  */
 trait ByteStringLike[T] {
 
   def toByteString(t : T) : ByteString
 
 }
 
-trait ByteStringConverters {
+object HttpResponse {
 
-  implicit object ByteStringLikeString extends ByteStringLike[String] {
-    override def toByteString(t: String): ByteString = ByteString(t)
+  def apply[T : ByteStringLike](version : HttpVersion, code : HttpCode, headers : Vector[(String, String)] , data : T) : HttpResponse = {
+    HttpResponse(HttpResponseHead(version, code, headers), Some(implicitly[ByteStringLike[T]].toByteString(data)))
   }
 
-  implicit object ByteStringLikeByteString extends ByteStringLike[ByteString] {
-    override def toByteString(t: ByteString): ByteString = t
+
+  def apply(version : HttpVersion, code : HttpCode, headers : Vector[(String, String)]) : HttpResponse = {
+    HttpResponse(HttpResponseHead(version, code, headers), None)
   }
+
 }
 
-object ByteStringConverters extends ByteStringConverters
+
+/**
+ * Be aware, at the moment when the response is encoded, there is no processing
+ * on the response body, and no headers are added in.  This means if the
+ * transfer-encoding is "chunked", the header must already exist and the stream
+ * must already be prepending chunk headers to the data.
+ */
+case class StreamingHttpResponse(head: HttpResponseHead, body: Option[Source[DataBuffer]]) extends BaseHttpResponse {
+
+  type Encoded = DataReader
+
+  def encode() : DataReader = {
+    val builder = new ByteStringBuilder
+    builder.sizeHint(100)
+    head.appendHeaderBytes(builder)
+    builder append NEWLINE
+
+    val headerBytes = DataBuffer(builder.result())
+    body.map{stream => 
+      DataStream(new DualSource[DataBuffer](Source.one(headerBytes), stream))
+    }.getOrElse(headerBytes)
+
+  }
+
+  def resolveBody: Option[Callback[ByteString]] = body.map{data => 
+    data.fold(new ByteStringBuilder){(buffer: DataBuffer, builder: ByteStringBuilder) => builder.putBytes(buffer.takeAll)}.map{_.result}
+  }
+
+  def withHeader(key: String, value: String) = copy(head = head.withHeader(key,value))
+
+}
+
+object StreamingHttpResponse {
+
+  def fromStatic(resp: HttpResponse): StreamingHttpResponse = {
+    StreamingHttpResponse(resp.head.withHeader(HttpHeaders.ContentLength, resp.body.map{_.size}.getOrElse(0).toString), resp.body.map{b => Source.one(DataBuffer(b))})
+  }
+
+  def apply[T : ByteStringLike](version : HttpVersion, code : HttpCode, headers : Vector[(String, String)] = Vector(), data : T) : StreamingHttpResponse = {
+    fromStatic(HttpResponse(
+      HttpResponseHead(version, code, headers), 
+      Some(implicitly[ByteStringLike[T]].toByteString(data))
+    ))
+  }
+
+}
+
+
+
+

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -3,68 +3,231 @@ package protocols.http
 
 import core._
 
-import akka.util.ByteString
+import akka.util.{ByteString, ByteStringBuilder}
 
 import colossus.parsing._
 import HttpParse._
 import Combinators._
 import DataSize._
+import controller._
+import service.DecodedResult
+import scala.language.higherKinds
 
+sealed trait ResponseResult 
+object ResponseResult {
+  case class StaticResponse(response: HttpResponse) extends ResponseResult
+  case class StreamResponse(sink: Sink[DataBuffer], response: HttpResponse) extends ResponseResult
+}
 
-object HttpResponseParser {
-
+object HttpResponseParser  {
   val DefaultMaxSize: DataSize = 10.MB
 
-  val DefaultQueueSize : Int = 100
+  //TODO: eliminate duplicate code
+  //TODO: Dechunk on static
 
-  //not totally in love with this extra object allocation, but feel its more straightforward than extractors
-  case class ParsedHeaders(headers : Seq[(String, String)]) extends HttpHeaderUtils
-
-  def static(size: DataSize = DefaultMaxSize) : HttpResponseParser[HttpResponse] = {
-    new HttpResponseParser[HttpResponse](() => maxSize(size, staticResponse))
-  }
-
-  def streaming(size : DataSize = DefaultMaxSize, streamBufferSize : Int = DefaultQueueSize) : HttpResponseParser[StreamingHttpResponseHeaderStub] = {
-    new HttpResponseParser[StreamingHttpResponseHeaderStub](() => maxSize(size, streamedResponse(streamBufferSize)))
-  }
-
-  def staticResponse: Parser[HttpResponse] = firstLine ~ headers |> {case (version, code) ~ headers =>
-    val pHeaders = ParsedHeaders(headers)
-    val clength =  pHeaders.getContentLength
-    val encoding = pHeaders.getEncoding
-    encoding match {
-      case TransferEncoding.Identity => clength match {
-        case Some(0) | None => const(HttpResponse(version, code, headers, ByteString()))
-        case Some(n) => bytes(n) >> {body => HttpResponse(version, code, headers, body)}
+  def staticBody(dechunk: Boolean): Parser[DecodedResult.Static[HttpResponse]] = head |> {parsedHead =>
+    parsedHead.transferEncoding match {
+      case TransferEncoding.Identity => parsedHead.contentLength match {
+        case Some(0) | None => const(DecodedResult.Static(HttpResponse(parsedHead, None)))
+        case Some(n) => bytes(n) >> {body => DecodedResult.Static(HttpResponse(parsedHead, Some(body)))}
       }
-      case _  => chunkedBody >> {body => HttpResponse(version, code, headers, body)}
+      case _  => chunkedBody >> {body => DecodedResult.Static(HttpResponse(parsedHead, Some(body)))}
     }
   }
 
-  private def streamedResponse(streamBufferSize : Int) : Parser[StreamingHttpResponseHeaderStub] =
-    firstLine ~ headers >> {case (version, code) ~ headers =>
-      StreamingHttpResponseHeaderStub(version, code, headers)
+  def streamBody(dechunk: Boolean): Parser[DecodedResult[StreamingHttpResponse]] = head >> {parsedHead =>
+    parsedHead.transferEncoding match {
+      case TransferEncoding.Identity => parsedHead.contentLength match {
+        case Some(0) | None => DecodedResult.Static(StreamingHttpResponse(parsedHead, None))
+        case Some(n) => streamingResponse(parsedHead, Some(n), false)
+      }
+      case _  => streamingResponse(parsedHead, None, dechunk)
     }
+  }
 
-  protected def firstLine: Parser[(HttpVersion, HttpCode)] = version ~ code >> {case v ~ c => (HttpVersion(v), HttpCodes(c.toInt))}
+  private def streamingResponse(head: HttpResponseHead, contentLength: Option[Int], dechunk: Boolean) = {
+    val pipe: Pipe[DataBuffer, DataBuffer] = contentLength match {
+      case Some(n)  => new FiniteBytePipe(n)
+      case None     => if (dechunk) new ChunkDecodingPipe else new ChunkPassThroughPipe
+    }
+    DecodedResult.Stream(StreamingHttpResponse(head, Some(pipe)), pipe)
+  }
+    
 
-  protected def version = stringUntil(' ')
+  protected def head: Parser[HttpResponseHead] = firstLine ~ headers >> {case version ~ code ~ headers => HttpResponseHead(version, code, headers)}
 
-  protected def code = intUntil(' ') <~ stringUntil('\r') <~ byte
+  protected def firstLine = version ~ code 
+
+  protected def version = stringUntil(' ') >> {v => HttpVersion(v)}
+
+  protected def code = intUntil(' ') <~ stringUntil('\r') <~ byte >> {c => HttpCode(c.toInt)}
 
 }
 
-class HttpResponseParser[T <: HttpResponseHeader](f : () => Parser[T]) {
+/** The base class used for both the static and streaming response parsers
+ * @tparam D This simply lets the static version have its return type DecodedResult.Static
+ * @tparam T The type of HttpResponse the parser will return
+ */
+class BaseHttpResponseParser[D[_] <: DecodedResult[_], T <: BaseHttpResponse](parserFactory:() => Parser[D[T]]) {
 
-  private def parser : Parser[T] = f()
+  private var current : Parser[D[T]] = parserFactory()
 
-  private var current : Parser[T] = parser
-
-  def parse(data : DataBuffer) : Option[T] = current.parse(data)
+  def parse(data : DataBuffer) : Option[D[T]] = current.parse(data)
 
   def reset() {
-    current = parser
+    current = parserFactory()
   }
 }
 
-case class StreamingHttpResponseHeaderStub(version : HttpVersion, code : HttpCode, headers : Seq[(String, String)]) extends HttpResponseHeader
+class HttpResponseParser(maxResponseSize: DataSize = HttpResponseParser.DefaultMaxSize) 
+  extends BaseHttpResponseParser[DecodedResult.Static, HttpResponse](() => maxSize(maxResponseSize, HttpResponseParser.staticBody(true)))
+
+
+/**
+ * @param dechunkBody if a response is sent using chunked transfer-encoding,
+ * the chunk headers will be removed from the data before being pushed into the
+ * pipe.  This should genrally be set to true if you are directly processing
+ * the incoming data, and should be false if you are going to be proxying the
+ * response somewhere else.
+ */
+class StreamingHttpResponseParser(dechunkBody: Boolean) 
+  extends BaseHttpResponseParser[DecodedResult, StreamingHttpResponse](() => HttpResponseParser.streamBody(dechunkBody))
+
+object HttpChunk {
+  
+  def wrap(data: DataBuffer): DataBuffer = {
+    val builder = new ByteStringBuilder
+    builder.sizeHint(data.size + 25)
+    builder.putBytes(data.size.toHexString.getBytes)
+    builder.append(HttpParse.NEWLINE)
+    builder.putBytes(data.takeAll)
+    builder.append(HttpParse.NEWLINE)
+    DataBuffer(builder.result)
+  }
+}
+
+/** A Pipe that will take raw DataBuffers and add a http chunk header.  This is
+ * needed if you are streaming out a response that is not also being streamed
+ * in (like in a proxy)
+ *
+ * Right now this ends up copying the DataBuffer.
+ * 
+ */
+class ChunkEncodingPipe extends InfinitePipe[DataBuffer] {
+
+  override def push(data: DataBuffer) = whenPushable {
+    super.push(HttpChunk.wrap(data))
+  }
+
+  override def complete() {
+    super.push(DataBuffer(ByteString("0\r\n\r\n"))) match {
+      case PushResult.Full(trig) => trig.fill(complete)
+      case _ => super.complete()
+    }
+  }
+
+}
+
+
+/**
+ * A Pass-through pipe that parses chunk headers in the data stream and closes
+ * the pipe when the stream ends.  This pipe does not remove any header/footer
+ * information, making it ideal for use in a proxy
+ */
+class ChunkPassThroughPipe extends InfinitePipe[DataBuffer] {
+
+  //this parser is used to follow along with the chunks so we know when to
+  //close the stream, but we don't actually parse out the data since we're just
+  //passing everything through
+  private val chunkParser = intUntil('\r', 16) <~ byte |>{
+    case 0   => const(0) //notice there's no second \r\n, this is according to spec
+    case len => skip(len.toInt) <~ bytes(2) >> {_ => len.toInt}
+  }
+
+  private val trailerParser = bytes(2)
+
+  private var parsingTrailer = false
+
+  override def push(data: DataBuffer): PushResult = whenPushable {
+    val (done, bytesRead) = data.peek{d => 
+      try {
+        if (!parsingTrailer) {
+          var chunkSize = Int.MaxValue
+          while(d.hasUnreadData && chunkSize != 0) {
+            chunkParser.parse(d).foreach{len =>
+              chunkSize = len
+            }
+          }
+          parsingTrailer = if (chunkSize == 0) true else false
+        }
+        if (parsingTrailer) {
+          if (trailerParser.parse(d).isDefined) {
+            true
+          } else {
+            false
+          }
+        } else {
+          false
+        }        
+      } catch {
+        case p: ParseException => {
+          terminate(p)
+          false //this will result in a push failure
+        }
+      }
+    }
+    if (done) {
+      super.push(DataBuffer(data.take(bytesRead)))
+      complete()
+      PushResult.Complete
+    } else {
+      super.push(data)
+    }
+  }
+
+}
+
+/** A pipe designed to accept a chunked http body.
+ *
+ * The pipe will scan the chunk headers and auto-close itself when it hits the
+ * end of the stream (reading a 0 length chunk).  It also strips all chunk
+ * headers from the data, so the output stream is the raw data
+ *  
+ */
+class ChunkDecodingPipe extends InfinitePipe[DataBuffer] {
+
+  
+  private val chunkParser = intUntil('\r', 16) <~ byte |> {
+    case 0 => const(ByteString())
+    case n => bytes(n.toInt) <~ bytes(2)
+  }
+
+  private val trailerParser = bytes(2)
+
+  private var parsingTrailer = false
+
+  override def push(data: DataBuffer): PushResult = whenPushable {
+    if (parsingTrailer) {
+      if (trailerParser.parse(data).isDefined) {
+        complete()
+        PushResult.Complete
+      } else {
+        PushResult.Ok
+      }
+    } else {
+      chunkParser.parse(data) match {
+        case Some(fullChunk)  => if (fullChunk.size > 0) {
+          super.push(DataBuffer(fullChunk))
+          push(data)
+        } else {
+          //terminal chunk
+          parsingTrailer = true
+          push(data)
+        }
+        case None => PushResult.Ok
+      }
+    }
+  }
+
+}
+    

--- a/colossus/src/main/scala/colossus/protocols/http/HttpServerCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpServerCodec.scala
@@ -3,16 +3,16 @@ package protocols.http
 
 
 import akka.util.ByteStringBuilder
-import colossus.controller.{DualSource, Source}
 import core._
 import service._
+import parsing._
+import DataSize._
 
-//TODO: add chunked transfer support
-class HttpServerCodec[T <: HttpResponseHeader] extends Codec.ServerCodec[HttpRequest, T] {
+class BaseHttpServerCodec[T <: BaseHttpResponse](maxSize: DataSize = 1.MB) extends Codec.ServerCodec[HttpRequest, T] {
 
-  private var parser = HttpRequestParser()
+  private var parser = HttpRequestParser(maxSize)
 
-  def encode(response: T): DataReader = HttpResponseDataReader(response)
+  def encode(response: T): DataReader = response.encode()
 
   def decode(data: DataBuffer): Option[DecodedResult[HttpRequest]] = DecodedResult.static(parser.parse(data))
 
@@ -21,76 +21,7 @@ class HttpServerCodec[T <: HttpResponseHeader] extends Codec.ServerCodec[HttpReq
   }
 }
 
-object HttpServerCodec {
-  def static : HttpServerCodec[HttpResponse] = new HttpServerCodec[HttpResponse]
-  def streaming : HttpServerCodec[StreamingHttpResponse] = new HttpServerCodec[StreamingHttpResponse]
-}
+class HttpServerCodec(maxSize: DataSize = 1.MB) extends BaseHttpServerCodec[HttpResponse]
 
+class StreamingHttpServerCodec(maxSize: DataSize = 1.MB) extends BaseHttpServerCodec[StreamingHttpResponse]
 
-trait HttpResponseDataReaderBuilder {
-
-  import colossus.protocols.http.HttpParse._
-
-  def generatedHeaders : Seq[String]
-
-  def appendHeaderBytes(response : HttpResponseHeader, builder : ByteStringBuilder) {
-    builder append response.version.messageBytes
-    builder putByte ' '
-    builder append response.code.headerBytes
-    builder append NEWLINE
-    response.headers.foreach{case (key, value) =>
-      if(!generatedHeaders.contains(key.toLowerCase)) {
-        builder putBytes key.getBytes
-        builder putBytes ": ".getBytes
-        builder putBytes value.getBytes
-        builder append NEWLINE
-      }
-    }
-  }
-}
-
-object HttpResponseDataReader {
-
-  def apply(response: HttpResponseHeader): DataReader = {
-    response match {
-      case a: StreamingHttpResponse => StreamedResponseBuilder(a)
-      case b: HttpResponse => StaticResponseBuilder(b)
-    }
-  }
-}
-
-object StaticResponseBuilder extends HttpResponseDataReaderBuilder{
-
-  import colossus.protocols.http.HttpParse._
-
-  val generatedHeaders = Seq("content-length")
-
-  def apply(response : HttpResponse) : DataBuffer = {
-    val builder = new ByteStringBuilder
-    builder.sizeHint(100 + response.data.size)
-    appendHeaderBytes(response, builder)
-    builder putBytes s"Content-Length: ${response.data.size}".getBytes
-    builder append NEWLINE
-    builder append NEWLINE
-    builder append response.data
-    DataBuffer(builder.result())
-  }
-}
-
-object StreamedResponseBuilder extends HttpResponseDataReaderBuilder {
-
-  import colossus.protocols.http.HttpParse._
-
-  val generatedHeaders = Seq.empty
-
-  def apply(response : StreamingHttpResponse) : DataStream = {
-    val builder = new ByteStringBuilder
-    builder.sizeHint(100)
-    appendHeaderBytes(response, builder)
-    builder append NEWLINE
-
-    val headerSource: Source[DataBuffer] = Source.one(DataBuffer(builder.result()))
-    DataStream(new DualSource[DataBuffer](headerSource, response.stream))
-  }
-
-}

--- a/colossus/src/main/scala/colossus/service/Codec.scala
+++ b/colossus/src/main/scala/colossus/service/Codec.scala
@@ -20,7 +20,7 @@ sealed trait DecodedResult[+T]
 object DecodedResult {
 
   case class Static[T](value : T) extends DecodedResult[T] //this is what is formerly the Some(Input) in a Codec
-  case class Streamed[T](t : T, s : Sink[DataBuffer]) extends DecodedResult[T]
+  case class Stream[T](value : T, s : Sink[DataBuffer]) extends DecodedResult[T]
 
   def static[T](value : Option[T]) : Option[DecodedResult[T]] = value.map(x => Static(x))
 


### PR DESCRIPTION
There's still work to be done, but this PR is getting pretty big and basically everything pre-existing works.

A whole bunch of changes are made here to better work with chunked transfer encoding in streaming http.  In particular we're beginning to address the issue that sometimes you want the body of a chunked request to be "dechunked" into just the raw data while other times (such as in a proxy) you want to leave the body totally untouched.  As the proxy situation is more relevant to our immediate needs, I focused on that use case for now, though getting the dechunking streams to work should not be much more work.

* Moved a whole bunch of stuff around to better organize things.  In particular there's now a proper `HttpResponseHead` similar to the `HttpHead` (soon to be renamed) for `HttpRequest`.  Also we had mixed up transfer-encodings with content-encodings, so those are now properly separated.
* There's now more of a separation between the Http and Streaming http codecs.  There's probably room to merge some stuff together, but right now it's much easier to iterate if we keep everything separated for now.
* `DataBuffer` has a new `peek` method which allows you to read from the buffer inside a closure, and afterwards the buffer is reset to the state before the closure began.  This is primarily needed for the next point...
* By default now, a streaming HttpClient will not dechunk the body.  This is enabled with the new `ChunkPassThroughPipe` which is able to parse the chunk headers to keep track of when the stream ends, but doesn't actually consume any data.

things that still need to be done (I'll move these into one or more issues) :

* Implement the pipe that that will dechunk the http body.
* Possibly indicate -- either as a new field in `HttpResponse` or possibly as a wrapper ADT around `DataBuffer` -- whether the attached `Source` is being dechunked or not.
* Probably move the `Transfer-Encoding`, `Content-Length`, and `Content-Encoding` headers into some kind of first-class value on `HttpResponseHead`.  This will make it easier (and probably faster) to figure out exactly what the body of the Response looks like.
* Generalize all the above to work for `HttpRequest` as well.