### PR TITLE
fixing bug in Callbacks where exception gets thrown too early

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
@@ -157,6 +157,21 @@ class CallbackSpec extends ColossusSpec {
       val c1 = Callback(func).map{x => a = true;x}.flatMap{i => throw new Exception("LISTEN")}.map{_ => b = true}.execute()
       a must equal(true)
       b must equal(false)
+
+      //double flatmap
+      //from unmapped callback
+      val d = Callback(func).flatMap[Int]{i => throw new Exception("HEY")}.flatMap{i => throw new Exception("B")}.map{_ => j = true}.execute()
+    }
+
+    "failure is propagated through maps and flatMaps" in {
+      var res: Option[Try[Int]] = None
+      val x = Callback.failed(new Exception("HEY")).flatMap{_ => Callback.successful(3)}.flatMap{i => Callback.successful(i)}.execute {r =>
+        res = Some(r)
+      }
+
+      res.get mustBe a[Failure[_]]
+        
+
     }
       
 


### PR DESCRIPTION
Ran into this in another branch.  This is a pretty obscure, but serious issue where if an exception is thrown inside a Callback, and then the callback is flatmapped and then recovered, the exception was not properly propagated through the flatmap into the recover, but instead was thrown.  This was doubly weird since the stack trace on the Exception was totally wrong.

Now if in a `flatMap` operation, a `Failure` is passed into the mapping, the user-passed closure is skipped and the `Failure` is immediately pushed into the next phase of execution.  In other words, if you have `Callback[A].flatMap{a => Callback[B]}.recover{...}` and the first Callback throws an exception during execution, the user's `a => Callback[B]` is properly skipped and the recover method is invoked.