### PR TITLE
new binary parsers for short, int, long

### DIFF
--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -119,6 +119,28 @@ class CombinatorSuite extends WordSpec with MustMatchers{
       parser.parse(d) must equal(Some(" abc def ghi "))
     }
 
+    "short" in {
+      val parser = short
+      val data = DataBuffer(ByteString(0x1D, 0x76, 0x82, 0x71, 0x55, 0xC2, 0x12, 0x00)) //6 extra bytes
+      parser.parse(data) must equal(Some(7542))
+      data.remaining must equal(6)
+    }
+
+    "int" in {
+      val parser = int
+      val data = DataBuffer(ByteString(0x00, 0x0B, 0x82, 0x71, 0x55, 0xC2, 0x12, 0x00)) //4 extra bytes
+      parser.parse(data) must equal(Some(754289))
+      data.remaining must equal(4)
+    }
+
+    "long" in {
+      val parser = long
+      val data = DataBuffer(ByteString(0x01, 0x0B, 0xF4, 0x3A, 0xE2, 0x64, 0x13, 0xBE))
+      parser.parse(data) must equal(Some(75422352525235134L))
+      data.remaining must equal(0)
+    }
+
+
   }
 
   "combinators" must {

--- a/colossus/src/main/scala/colossus/protocols/http/HttpParse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpParse.scala
@@ -2,8 +2,6 @@ package colossus
 package protocols.http
 
 import akka.util.{ByteString, ByteStringBuilder}
-import colossus.controller.Pipe
-import colossus.core.DataBuffer
 
 import parsing._
 import Combinators._

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -336,6 +336,12 @@ object Combinators {
     }
   }
 
+  def short: Parser[Short] = bytes(2) >> {b => b.asByteBuffer.getShort}
+
+  def int: Parser[Int] = bytes(4) >> {b => b.asByteBuffer.getInt}
+
+  def long: Parser[Long] = bytes(8) >> {b => b.asByteBuffer.getLong}
+
   /** Parse a series of ascii strings seperated by a single-byte delimiter and terminated by a byte
    *
    */


### PR DESCRIPTION
Fixes #129.  3 new parsers for parsing big-endian shorts, ints and longs.  These are different from `intUntil`, which parses an ASCII string as an integer.