### PR TITLE
Version upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: scala
+scala:
+  - 2.10.4
+  - 2.11.5
 jdk: oraclejdk7
 sudo: false

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -5,7 +5,7 @@ import com.typesafe.sbt.pgp.PgpKeys._
 
 object ColossusBuild extends Build {
 
-  val AKKA_VERSION            = "2.3.6"
+  val AKKA_VERSION            = "2.3.9"
   val SCALATEST_VERSION       = "2.2.0"
 
   val GeneralSettings = Seq[Setting[_]](
@@ -14,8 +14,8 @@ object ColossusBuild extends Build {
     compile <<= (compile in Compile) dependsOn (compile in Test),
     
     organization := "com.tumblr",
-    scalaVersion  := "2.11.4",
-    crossScalaVersions := Seq("2.10.4", "2.11.2"),
+    scalaVersion  := "2.11.5",
+    crossScalaVersions := Seq("2.10.4", "2.11.5"),
     version                   := "0.6.0-M3",
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>


### PR DESCRIPTION
Gonna merge this in right away, mostly doing the PR to get it recorded in the milestone.  This will be the last change before publishing 0.6.0-RC1

Upgrading to scala 2.11.5, Akka 2.3.9.

Also, it appears travis is now properly working for multiple scala versions, so hooray for that!