### PR TITLE
fixing a bug where calling gracefulDisconnect in a callback threw an exception

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -366,6 +366,22 @@ class ServiceClientSpec extends ColossusSpec {
       probe.expectMsg(100.milliseconds, WorkerCommand.UnbindWorkerItem(client.id.get))
     }
 
+    "graceful disconnect inside a callback" in {
+      val (endpoint, client, probe) = newClient(true, 10, connectionAttempts = PollingDuration.NoRetry)
+      val cmd = Command("BAH")
+      val reply = StatusReply("WAT")
+      client.send(Command("BAH")).map{r =>
+        client.gracefulDisconnect()
+        r
+      }.execute()
+      endpoint.expectOneWrite(cmd.raw)
+      client.receivedData(reply.raw)
+      endpoint.connection_status = ConnectionStatus.NotConnected
+    }
+
+
+      
+
 
     //blocked on https://github.com/tumblr/colossus/issues/19
     "attempts to reconnect when server closes connection" in {

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -288,7 +288,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize)) with 
   }
 
   private def checkGracefulDisconnect() {
-    if (disconnecting && sentBuffer.size == 0) {
+    if (isConnected && disconnecting && sentBuffer.size == 0) {
       super.gracefulDisconnect()
     }
   }


### PR DESCRIPTION
Basically what is happening is the client is trying to disconnect twice, leading to an invalid state.  It's possible we should change the state logic as well, but this fixes the immediate issue.