### PR TITLE
Add support for decoding messages that depend on the connection closing

### DIFF
--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -140,6 +140,35 @@ class CombinatorSuite extends WordSpec with MustMatchers{
       data.remaining must equal(0)
     }
 
+    "bytesUntilEOS" in {
+      val parser = bytesUntilEOS
+      val d1 = ByteString(1, 2, 3)
+      val d2 = ByteString(4, 5, 6)
+      parser.parse(DataBuffer(d1)) must equal(None)
+      parser.parse(DataBuffer(d2)) must equal(None)
+      parser.endOfStream() must equal(Some(ByteString(1, 2, 3, 4, 5, 6)))
+    }
+
+    "bytesUntilEOS as map subject" in {
+      val parser = bytesUntilEOS >> {bytes => bytes.size}
+      val d1 = ByteString(1, 2, 3)
+      val d2 = ByteString(4, 5, 6)
+      parser.parse(DataBuffer(d1)) must equal(None)
+      parser.parse(DataBuffer(d2)) must equal(None)
+      parser.endOfStream() must equal(Some(6))
+    }
+
+    "bytesUntilEOS as flatMap object" in {
+      //notice that using this parser as the subject makes no sense
+      val parser = bytes(3) |> {bytes => bytesUntilEOS}
+      val d1 = ByteString(1, 2, 3)
+      val d2 = ByteString(4, 5, 6)
+      parser.parse(DataBuffer(d1)) must equal(None)
+      parser.parse(DataBuffer(d2)) must equal(None)
+      parser.endOfStream() must equal(Some(ByteString(4,5,6)))
+    }
+      
+
 
   }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
@@ -22,11 +22,13 @@ class BaseHttpClientCodec[T <: BaseHttpResponse](parserFactory: () => Parser[Dec
     parser = parserFactory()
   }
 
+  override def endOfStream() = parser.endOfStream()
+
 }
 
 class HttpClientCodec(maxResponseSize: DataSize = 1.MB) 
-  extends BaseHttpClientCodec[HttpResponse](() => Combinators.maxSize(maxResponseSize, HttpResponseParser.staticBody(true)))
+  extends BaseHttpClientCodec[HttpResponse](() => HttpResponseParser.static(maxResponseSize))
 
 class StreamingHttpClientCodec(dechunk: Boolean = false)
-  extends BaseHttpClientCodec[StreamingHttpResponse](() => HttpResponseParser.streamBody(dechunk))
+  extends BaseHttpClientCodec[StreamingHttpResponse](() => HttpResponseParser.stream(dechunk))
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpCode.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpCode.scala
@@ -3,6 +3,11 @@ package protocols.http
 
 import akka.util.ByteString
 
+/**
+ * This trait mixed in to any codes that do not allow a body in the response
+ */
+trait NoBodyCode
+
 case class HttpCode(code: Int, description: String) {
   val headerSegment = s"$code $description"
   val headerBytes = ByteString(headerSegment)
@@ -13,15 +18,15 @@ object HttpCode {
 
 object HttpCodes {
   //100
-  val CONTINUE = HttpCode(100, "Continue")
-  val SWITCHING_PROTOCOLS = HttpCode(101, "Switching Protocols")
-  val PROCESSING = HttpCode(102, "Processing")
+  val CONTINUE              = new HttpCode(100, "Continue") with NoBodyCode
+  val SWITCHING_PROTOCOLS   = new HttpCode(101, "Switching Protocols") with NoBodyCode
+  val PROCESSING            = new HttpCode(102, "Processing") with NoBodyCode
   //200
   val OK = HttpCode(200, "OK")
   val CREATED = HttpCode(201, "Created")
   val ACCEPTED = HttpCode(202, "Accepted")
   val NON_AUTHORITATIVE_INFORMATION = HttpCode(203, "Non-Authoritative Information")
-  val NO_CONTENT = HttpCode(204, "No Content")
+  val NO_CONTENT = new HttpCode(204, "No Content") with NoBodyCode
   val RESET_CONTENT = HttpCode(205, "Reset Content")
   val PARTIAL_CONTENT = HttpCode(206, "Partial Content")
   val MULTI_STATUS = HttpCode(207, "Multi-Status")
@@ -32,7 +37,7 @@ object HttpCodes {
   val MOVED_PERMANENTLY = HttpCode(301, "Moved Permanently")
   val FOUND = HttpCode(302, "Found")
   val SEE_OTHER = HttpCode(303, "See Other")
-  val NOT_MODIFIED = HttpCode(304, "Not Modified")
+  val NOT_MODIFIED = new HttpCode(304, "Not Modified") with NoBodyCode
   val USE_PROXY = HttpCode(305, "Use Proxy")
   val TEMPORARY_REDIRECT = HttpCode(307, "Temporary Redirect")
   val PERMANENT_REDIRECT = HttpCode(308, "Permanent Redirect")

--- a/colossus/src/main/scala/colossus/service/Codec.scala
+++ b/colossus/src/main/scala/colossus/service/Codec.scala
@@ -40,6 +40,12 @@ trait Codec[Output,Input] {
    */
   def decode(data: DataBuffer): Option[DecodedResult[Input]]
 
+  /** This is only needed for codecs where closing the connection signals the
+   * end of a response (for example, a http response with no content-length and
+   * non-chunked transfer encoding)
+   */
+  def endOfStream(): Option[DecodedResult[Input]] = None
+
   def decodeAll(data: DataBuffer)(onDecode : DecodedResult[Input] => Unit) { if (data.hasUnreadData){
     var done: Option[DecodedResult[Input]] = None
     do {
@@ -74,6 +80,7 @@ trait Codec[Output,Input] {
 
   def reset()
 }
+
 object Codec {
 
   type ServerCodec[Request,Response] = Codec[Response,Request]


### PR DESCRIPTION
This largely only applies for http responses that don't include a content-length, but instead close the connection as a means for signalling that the response is complete.

This requires a new `endOfStream` method in all of the parser combinators, along with a new `bytesUntilEOS` parser that basically aggregates all received data until the method is called.  This is then wired into `InputController` such that the method is called when the connection is closed and any returned message is processed.

Also support is added for responses that do not allow for a body, which also generally do not include a content-length header.