### PR TITLE
Timeout requests in flight

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -457,15 +457,16 @@ class ServiceClientSpec extends ColossusSpec {
 
     "shutdown the connection when an in-flight request times out" in {
       val command = Command(CMD_GET, "foo")
-      val (endpoint, client, probe) = newClient(requestTimeout = 10.milliseconds, connectionAttempts = PollingDuration.NoRetry)
+      val (endpoint, client, probe) = newClient(requestTimeout = 10.milliseconds)
       var failed = true
       val cb = client.send(command).map{
         case wat => failed = false
       }
       endpoint.expectNoWrite()
       cb.execute()
+      endpoint.expectOneWrite(command.raw)
 
-      Thread.sleep(1000)
+      Thread.sleep(150)
       client.idleCheck(100.milliseconds)
 
       failed must equal(true)

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -297,7 +297,6 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
       val expired = waitingToSend.removeFirst()
       expired.postWrite(OutputResult.Cancelled)
     }
-
   }
 
 }

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -308,6 +308,11 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
           unregisterConnection(con, DisconnectCause.Disconnect)
         }
       }
+      case Kill(connectionId, errorCause) => {
+        connections.get(connectionId).foreach{con =>
+          unregisterConnection(con, errorCause)
+        }
+      }
       case Connect(address, id) => {
         getWorkerItem(id).map{
           case handler: ClientConnectionHandler => try {
@@ -546,5 +551,11 @@ object WorkerCommand {
   case class Schedule(in: FiniteDuration, message: Any) extends WorkerCommand
   case class Message(id: Long, message: Any) extends WorkerCommand
   case class Disconnect(id: Long) extends WorkerCommand
+
+  //similar to Disconnect, this will shut down a connection, however it will
+  //treat the disconnect as an error and forward the error cause to the
+  //handler.  In the case of a client connection, this can be a way to
+  //forcefully kill the connection and trigger a reconnect
+  case class Kill(id: Long, error: DisconnectError) extends WorkerCommand
 }
 

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -306,7 +306,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, config
 
     if (sentBuffer.size > 0 && sentBuffer.front.isTimedOut(System.currentTimeMillis)) {
       // the oldest sent message has expired with no response - shutdown the connection
-
+      disconnect()
     }
   }
 }

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -123,8 +123,12 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, config
   private val latency = worker.metrics.getOrAdd(Histogram(name / "latency", periods = List(60.seconds), sampleRate = 0.10, percentiles = List(0.75,0.99)))
   lazy val log = Logging(worker.system.actorSystem, s"client:$address")
 
+  private val responseTimeoutMillis: Long = config.requestTimeout.toMillis
+
   case class SourcedRequest(message: I, handler: ResponseHandler) {
     val start: Long = System.currentTimeMillis
+
+    def isTimedOut(now: Long) = now > (start + responseTimeoutMillis)
   }
 
 
@@ -298,7 +302,11 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, config
 
 
   override def idleCheck(period: Duration) {
-    // note: be careful, idleCheck could be defined in multiple super classes so check what super works out as :)
     super.idleCheck(period)
+
+    if (sentBuffer.size > 0 && sentBuffer.front.isTimedOut(System.currentTimeMillis)) {
+      // the oldest sent message has expired with no response - shutdown the connection
+
+    }
   }
 }

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -305,8 +305,9 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, config
     super.idleCheck(period)
 
     if (sentBuffer.size > 0 && sentBuffer.front.isTimedOut(System.currentTimeMillis)) {
-      // the oldest sent message has expired with no response - shutdown the connection
-      disconnect()
+      // the oldest sent message has expired with no response - kill the connection
+      // sending the Kill message instead of disconnecting will trigger the reconnection logic
+      worker ! Kill(id.get, DisconnectCause.TimedOut)
     }
   }
 }

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -149,7 +149,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, config
    */
   def connectionStatus: ConnectionStatus = if (isConnected) {
     ConnectionStatus.Connected 
-  } else if (canReconnect) {
+  } else if (canReconnect && !manuallyDisconnected) {
     ConnectionStatus.Connecting
   } else {
     ConnectionStatus.NotConnected


### PR DESCRIPTION
Added an idleCheck to ServiceClient which looks at the head of the sent buffer, and if that request has expired, kills the connection. 

@DanSimon can you confirm this is the right way to close the connection? I found a number of possibilities but this seemed best

@nsauro PR to master as Dan wants to put this stuff on 0.6.0 RC3