### PR TITLE
setting ServiceServer output timeout to infinite

### DIFF
--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -73,10 +73,8 @@ object OutputResult {
 trait OutputController[Input, Output] extends MasterController[Input, Output] {
   import OutputState._
 
-  private val sendTimeoutMillis: Long = controllerConfig.sendTimeout.toMillis
-
   case class QueuedItem(item: Output, postWrite: OutputResult => Unit, creationTimeMillis: Long) {
-    def isTimedOut(now: Long) = now > (creationTimeMillis + sendTimeoutMillis)
+    def isTimedOut(now: Long) = controllerConfig.sendTimeout.isFinite && now > (creationTimeMillis + controllerConfig.sendTimeout.toMillis)
   }
 
   private[controller] var outputState: OutputState = Dequeueing

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -47,7 +47,7 @@ class DroppedReply extends Error("Dropped Reply")
 abstract class ServiceServer[I,O]
   (codec: ServerCodec[I,O], config: ServiceConfig, worker: WorkerRef)
   (implicit ex: ExecutionContext, tagDecorator: TagDecorator[I,O] = TagDecorator.default[I,O]) 
-extends Controller[I,O](codec, ControllerConfig(50, config.requestTimeout)) {
+extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) {
   import ServiceServer._
   import WorkerCommand._
   import config._


### PR DESCRIPTION
I just realized for servers we never want to timeout anything in the output buffer, since we cannot just drop a response if the request has timed out, otherwise the client will end up getting the wrong responses for requests.