### PR TITLE
Simplify locality

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/ActorMetrics.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/ActorMetrics.scala
@@ -12,7 +12,7 @@ trait ActorMetrics extends Actor with ActorLogging {
 
   def globalTags: TagMap = TagMap.Empty
 
-  val metrics = new LocalCollection(MetricAddress.Root, globalTags)(self)
+  val metrics = new LocalCollection(MetricAddress.Root, globalTags)
 
   def handleMetrics: Receive = {
     case m : MetricEvent => metrics.handleEvent(m) match {

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collector.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collector.scala
@@ -1,16 +1,12 @@
 package colossus.metrics
 
-import java.util.concurrent.ConcurrentHashMap
-
 import akka.actor._
 
-import EventLocality._
+class Collector(val metricSystem: MetricSystem, val collection: LocalCollection) extends Actor with ActorMetrics{
 
-class Collector(val metricSystem: MetricSystem, val collectors: ConcurrentHashMap[MetricAddress, Local[EventCollector]], val gTags: TagMap) extends Actor with ActorMetrics{
+  override def globalTags = collection.globalTags
 
-  override def globalTags = gTags
-
-  override val metrics = new LocalCollection(MetricAddress.Root, globalTags, collectors)(self)
+  override val metrics = collection
 
   def receive = handleMetrics
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
@@ -23,7 +23,7 @@ class MetricDatabase(systemId: MetricSystemId, namespace: MetricAddress, snapsho
   val collectors = new JHashSet[ActorRef]()
 
   //TODO: this name needs to be able to support multiple databases/metric systems.
-  val collectedGauge = new ConcreteGauge(Gauge(namespace / "metric_completion"), self)
+  val collectedGauge = new ConcreteGauge(Gauge(namespace / "metric_completion"))
   //needs to be a float so that incrementCollected won't report 0s
   var tocksCollected : Float = 0
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -20,8 +20,9 @@ object Counter {
 
   def apply(address: MetricAddress) = CounterParams(address)
 
-  implicit object LocalCounterGenerator extends Generator[LocalLocality, Counter, CounterParams] {
-    def apply(params: CounterParams)(implicit collector: ActorRef) = new LocalCounter(params, collector)
+  implicit object CounterGenerator extends Generator[Counter, CounterParams] {
+    def local(params: CounterParams) = new LocalCounter(params)
+    def shared(params: CounterParams)(implicit collector: ActorRef) = new SharedCounter(params, collector)
   }
 
 }
@@ -44,9 +45,8 @@ class BasicCounter(params: CounterParams) {
   }
 }
 
-class LocalCounter(params: CounterParams, collector: ActorRef) extends BasicCounter(params) with Counter with LocalLocality[Counter] {
+class LocalCounter(params: CounterParams) extends BasicCounter(params) with Counter with LocalLocality {
   import Counter._
-  lazy val shared = new SharedCounter(params, collector)
 
   val address = params.address
 
@@ -60,7 +60,7 @@ class LocalCounter(params: CounterParams, collector: ActorRef) extends BasicCoun
 
 }
 
-class SharedCounter(params: CounterParams, collector: ActorRef) extends Counter with SharedLocality[Counter] {
+class SharedCounter(params: CounterParams, collector: ActorRef) extends Counter with SharedLocality {
   def address = params.address
   def Δ(d: Long, tags: TagMap = TagMap.Empty) {
     collector ! Counter.Delta(params.address, d, tags)

--- a/colossus-metrics/src/test/scala/colossus/metrics/GaugeSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/GaugeSpec.scala
@@ -1,6 +1,5 @@
 package colossus.metrics
 
-import akka.actor._
 import org.scalatest._
 import scala.concurrent.duration._
 
@@ -33,7 +32,7 @@ class GaugeSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
   "ConcreteGauge" must {
     "set tagged values" in {
       val params = GaugeParams("/")
-      val g = new ConcreteGauge(params, ActorRef.noSender)
+      val g = new ConcreteGauge(params)
       g.set(4, Map("foo" -> "a"))
       g.set(5, Map("foo" -> "b"))
 
@@ -46,7 +45,7 @@ class GaugeSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
 
     "remove unset values" in {
       val params = GaugeParams("/", expireAfter = 1.second)
-      val g = new ConcreteGauge(params, ActorRef.noSender)
+      val g = new ConcreteGauge(params)
       g.set(4, Map("foo" -> "a"))
       g.set(5, Map("foo" -> "b"))
       g.set(None, Map("foo" -> "a"))
@@ -60,7 +59,7 @@ class GaugeSpec extends WordSpec with MustMatchers with BeforeAndAfterAll {
 
     "remove expired values" in {
       val params = GaugeParams("/", expireAfter = 1.second)
-      val g = new ConcreteGauge(params, ActorRef.noSender)
+      val g = new ConcreteGauge(params)
       g.set(4, Map("foo" -> "a"))
       g.set(5, Map("foo" -> "b"))
       g.tick(500.milliseconds)

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -105,7 +105,7 @@ class MetricSpec extends WordSpec with MustMatchers with BeforeAndAfterAll with 
 
       Thread.sleep(50)
       val c: Future[Set[ActorRef]] = (m1.database ? ListCollectors).mapTo[Set[ActorRef]]
-      c.futureValue must equal (Set(sc1.local.collector, sc2.local.collector))
+      c.futureValue must equal (Set(sc1.collector, sc2.collector))
 
     }
     "remove terminated EventCollectors" in {
@@ -119,12 +119,12 @@ class MetricSpec extends WordSpec with MustMatchers with BeforeAndAfterAll with 
       val sc1 = SharedCollection()
       val sc2 = SharedCollection()
 
-      sc2.local.collector ! PoisonPill
+      sc2.collector ! PoisonPill
 
       Thread.sleep(50)
 
       val c: Future[Set[ActorRef]] = (m1.database ? ListCollectors).mapTo[Set[ActorRef]]
-      c.futureValue must equal (Set(sc1.local.collector))
+      c.futureValue must equal (Set(sc1.collector))
     }
 
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -1,7 +1,5 @@
 package colossus.metrics
 
-import akka.testkit._
-
 import scala.concurrent.duration._
 
 class RateSpec extends MetricIntegrationSpec {
@@ -26,9 +24,8 @@ class RateSpec extends MetricIntegrationSpec {
 
   "ConcreteRate" must {
     "tick for tags" in {
-      val p = TestProbe()
       val params = Rate("/foo", periods = List(1.second))
-      val r = new ConcreteRate(params, p.ref)
+      val r = new ConcreteRate(params)
       r.hit(Map("foo" -> "a"))
       r.hit(Map("foo" -> "a"))
       r.hit(Map("foo" -> "b"))


### PR DESCRIPTION
Fixes #153 

`Locality` no longer has as type-param.  It used to need it in order to support the ability to turn a `E with LocaliLocality[E]` into a `E with SharedLocality[E]`, so Locality itself needed to know the type of event collector it was working with.  Now that we've removed the need for this, it can become just a regular trait.  Creation of shared collectors is now handled by the `Generator` typeclass.

This also allowed me to cleanup a little how `SharedCollection` is created, since previously all local collectors needed access to the shared collector actor, since even though they never used it themselves they needed the reference when using the `.shared` method.  Now that this method has been removed, the whole process has become more streamlined.