### PR TITLE
MetricReporters now use MetricReporterFilter to specify what stats to re...

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/Metric.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Metric.scala
@@ -83,11 +83,3 @@ case class MetricFragment(address: MetricAddress, tags: TagMap, value: RawMetric
 trait MetricProducer {
   def metrics(context: CollectionContext): MetricMap
 }
-
-/**
- * Any metric that needs to be ticked by the external clock
- */
-trait TickedMetric {
-  def tick()
-}
-

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
@@ -163,28 +163,4 @@ class SystemMetricsCollector(namespace: MetricAddress) {
 
     (memoryInfo <+> gcInfo <+> fdInfo)
   }
-
-}
-
-//TODO: only really used by histograms...should we move?
-class TickTracker(period: FiniteDuration) {
-  import TickTracker._
-
-  var tickAccum = 0.seconds
-
-  def tick(amount: FiniteDuration): TickResult = {
-    tickAccum += amount
-    if (tickAccum >= period) {
-      tickAccum -= period
-      Tick
-    } else {
-      NoTick
-    }
-  }
-}
-
-object TickTracker {
-  sealed trait TickResult
-  case object Tick extends TickResult
-  case object NoTick extends TickResult
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricReport.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricReport.scala
@@ -1,4 +1,0 @@
-package colossus.metrics
-
-
-case class MetricReport(globalTags: TagMap, metrics: RawMetricMap.SerializedMetricMap, reportingFreqMillis: Int, timestamp: Long)

--- a/colossus-metrics/src/main/scala/colossus/metrics/StatReporter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/StatReporter.scala
@@ -65,7 +65,6 @@ class MetricReporter(intervalAggregator : ActorRef, config: MetricReporterConfig
   private def filterMetrics(m : MetricMap) : RawMetricMap = {
     filters match {
       case MetricReporterFilter.All => m.toRawMetrics
-      case MetricReporterFilter.None => Map()
       case MetricReporterFilter.WhiteList(x) => {
         m.filterKeys(x.contains).toRawMetrics
       }
@@ -128,10 +127,4 @@ object MetricReporterFilter {
    * @param addresses
    */
   case class BlackList(addresses : Seq[MetricAddress]) extends MetricReporterFilter
-
-  /**
-   * No metrics ever.
-   */
-  case object None extends MetricReporterFilter
-
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/package.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/package.scala
@@ -1,9 +1,5 @@
 package colossus
 
-import akka.pattern.ask
-import akka.util.Timeout
-import scala.concurrent.Future
-
 import net.liftweb.json._
 
 //TODO: break up this whole thing
@@ -186,11 +182,4 @@ package object metrics {
 
 
   }
-
-  type Timestamp = Long
-
-  object Timestamp {
-    def apply(): Timestamp = System.currentTimeMillis / 1000
-  }
-
 }

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricReportFilterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricReportFilterSpec.scala
@@ -1,0 +1,72 @@
+package colossus.metrics
+
+import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.testkit.TestProbe
+import colossus.metrics.IntervalAggregator.ReportMetrics
+import colossus.metrics.MetricValues.SumValue
+
+class MetricReportFilterSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) with MetricSystemMatchers {
+
+  def this() = this(ActorSystem("MetricSpec"))
+
+  implicit val sys = _system
+
+  val metricMap: MetricMap = Map(MetricAddress("/foo")->Map(Map("foo" -> "a")->SumValue(0L)),
+                                  MetricAddress("/bar")->Map(Map("bar" -> "a")->SumValue(1L)))
+
+  "MetricReportFilters" must {
+
+    "Filter nothing if MetricReporterFilter.All is used" in {
+      val expectedRawMetrics: RawMetricMap = Map(MetricAddress("/foo")->Map(Map("foo" -> "a")->0L),
+        MetricAddress("/bar")->Map(Map("bar" -> "a")->1L))
+      testFilter(MetricReporterFilter.All, expectedRawMetrics)
+
+    }
+
+    "Filter everything if MetricReporterFilter.None is used" in {
+      testFilter(MetricReporterFilter.None, Map())
+    }
+
+    "Only include matching MetricAddresses if MetricReporterFilter.WhiteList is used" in {
+      val expectedRawMetrics: RawMetricMap = Map(MetricAddress("/foo")->Map(Map("foo" -> "a")->0L))
+      testFilter(MetricReporterFilter.WhiteList(Seq(MetricAddress("/foo"))), expectedRawMetrics)
+    }
+
+    "Filter out metrics if MetricReporterFilter.BlackList is used" in {
+      val expectedRawMetrics: RawMetricMap = Map(MetricAddress("/bar")->Map(Map("bar" -> "a")->1L))
+      testFilter(MetricReporterFilter.BlackList(Seq(MetricAddress("/foo"))), expectedRawMetrics)
+    }
+  }
+
+  private def testFilter(filter : MetricReporterFilter, expected : RawMetricMap) {
+    val probe = TestProbe()
+
+    val mockAggregator = TestProbe()
+
+    val config = MetricReporterConfig("/sys1", Seq(EchoSender(probe.ref)), None, filter, false)
+
+    val reporter = sys.actorOf(Props(classOf[MetricReporter], mockAggregator.ref, config))
+
+    mockAggregator.send(reporter, ReportMetrics(metricMap))
+
+    val receivedRawMetrics = probe.expectMsgPF(){
+      case MetricSender.Send(rm, g, ms) => rm
+    }
+
+    receivedRawMetrics must be (expected)
+  }
+
+}
+
+
+class EchoSenderActor(ref : ActorRef) extends Actor {
+  override def receive: Receive = {
+    case a => ref ! a
+  }
+}
+
+case class EchoSender(ref : ActorRef) extends MetricSender {
+  override def name: String = "echo-sender"
+
+  override def props: Props = Props(classOf[EchoSenderActor], ref)
+}

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricReportFilterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricReportFilterSpec.scala
@@ -22,11 +22,6 @@ class MetricReportFilterSpec(_system : ActorSystem) extends MetricIntegrationSpe
       testFilter(MetricReporterFilter.All, expectedRawMetrics)
 
     }
-
-    "Filter everything if MetricReporterFilter.None is used" in {
-      testFilter(MetricReporterFilter.None, Map())
-    }
-
     "Only include matching MetricAddresses if MetricReporterFilter.WhiteList is used" in {
       val expectedRawMetrics: RawMetricMap = Map(MetricAddress("/foo")->Map(Map("foo" -> "a")->0L))
       testFilter(MetricReporterFilter.WhiteList(Seq(MetricAddress("/foo"))), expectedRawMetrics)

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -1,6 +1,5 @@
 package colossus.metrics
 
-import akka.util.Timeout
 import colossus.metrics.IntervalAggregator._
 import org.scalatest._
 
@@ -16,12 +15,6 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
   implicit val sys = _system
 
   import akka.testkit._
-
-  implicit val ec = sys.dispatcher
-
-  override protected def afterAll() {
-    TestKit.shutdownActorSystem(sys)
-  }
 
   "MetricAddress" must {
     "startsWith" in {
@@ -95,7 +88,7 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
       val oneDayAgg = m1.metricIntervals.get(1.day).value  //grab an interval
       val tenDayAgg = m1.metricIntervals.get(10.days).value  //grab an interval
 
-      val conf = MetricReporterConfig(Root, Seq(LoggerSender), None, None, false)
+      val conf = MetricReporterConfig(Root, Seq(LoggerSender), None, MetricReporterFilter.All, false)
       val reporter = oneDayAgg.report(conf)
 
       //only one aggregator should have the reporter
@@ -112,7 +105,7 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
       val oneDayAgg = m1.metricIntervals.get(1.day).value  //grab an interval
       val tenDayAgg = m1.metricIntervals.get(10.days).value  //grab an interval
 
-      val conf = MetricReporterConfig(Root, Seq(LoggerSender), None, None, false)
+      val conf = MetricReporterConfig(Root, Seq(LoggerSender), None, MetricReporterFilter.All, false)
       val reporter = oneDayAgg.report(conf)
 
       val expectedReporters = Map(oneDayAgg.intervalAggregator->Set(reporter), tenDayAgg.intervalAggregator->Set[ActorRef]())


### PR DESCRIPTION
...port, no longer uses a Seq[MetricFilter].  Also, removed unused classes.

fixes #175 