### PR TITLE
Connection info now available to services, fixiing initialization

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteEndpoint.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteEndpoint.scala
@@ -31,4 +31,12 @@ class MockWriteEndpoint(maxBufferSize: Int, workerProbe: TestProbe,handler: Opti
   val worker: ActorRef = workerProbe.ref
 
   def isWritable = connection_status == ConnectionStatus.Connected && bytesAvailable > 0
+
+  def remoteAddress = None
+
+  def lastTimeDataReceived = 0
+
+  def bytesReceived = 0
+
+  def timeOpen = 0
 }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -74,7 +74,7 @@ class ServiceDSLSpec extends ColossusSpec {
             }
             connection.become{
               case x if (x == ByteString("PING")) => {
-                context.worker.worker ! core.WorkerCommand.Message(connection.connectionId, "PING")
+                context.worker.worker ! core.WorkerCommand.Message(connection.connectionInfo.get.id, "PING")
                 Callback.successful(ByteString("WHATEVER"))
               }
             }

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -101,6 +101,14 @@ extends InputController[Input, Output] with OutputController[Input, Output] {
     inputOnConnected()
   }
 
+  /**
+   * Returns a read-only trait containing live information about the connection.
+   */
+  def connectionInfo: Option[ConnectionInfo] = state match {
+    case a: AliveState => Some(a.endpoint)
+    case _ => None
+  }
+
   private def onClosed() {
     state = NotConnected
     inputOnClosed()

--- a/colossus/src/main/scala/colossus/core/ConnectionSnapshot.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionSnapshot.scala
@@ -16,7 +16,7 @@ import java.net.InetAddress
  * @param bytesSent The amount of bytes that this Connection has sent
  * @param bytesReceived The amount of bytes that this Connection has received
  */
-case class ConnectionInfo(
+case class ConnectionSnapshot(
   domain: String, //either a server name or client
   host: InetAddress, //this is not a string because looking up the hostname takes time
   port: Int,
@@ -35,7 +35,7 @@ case class ConnectionInfo(
   def itemValues = List(id.toString, domain, host.getHostName, timeOpen.toString, timeIdle.toString, bytesSent.toString, bytesReceived.toString)
 }
 //NOTE:  This feels weird here and is used in conjunction with the PageRenderer used for stats.  Should be moved to the metrics pkg
-object ConnectionInfo {
+object ConnectionSnapshot {
   val items = List("id", "domain", "host", "ms-alive", "ms-idle", "b-sent", "b-received")
   val consoleHeader = {
     String.format(items.map{_ => "%-10s"}.mkString(" "), items:_*)

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -518,7 +518,7 @@ object Worker {
   private[core] case object ConnectionSummaryRequest
   private[core] case object CheckIdleConnections
 
-  case class ConnectionSummary(infos: Seq[ConnectionInfo])
+  case class ConnectionSummary(infos: Seq[ConnectionSnapshot])
 
   /** Sent from Servers
    * @param sc the underlying socketchannel of the connection

--- a/colossus/src/main/scala/colossus/core/WorkerManager.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerManager.scala
@@ -57,7 +57,7 @@ private[colossus] class WorkerManager(config: WorkerManagerConfig) extends Actor
   //this is used when the manager receives a Connect request to round-robin across workers
   var nextConnectIndex = 0
 
-  var latestSummary: Seq[ConnectionInfo] = Nil
+  var latestSummary: Seq[ConnectionSnapshot] = Nil
   var latestSummaryTime = 0L
 
 

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -37,16 +37,17 @@ package object http {
       case other => request.error(reason.toString)
     }
 
-    override def provideHandler(config: ServiceConfig, worker: WorkerRef)(implicit ex: ExecutionContext): DSLHandler[Http] = {
-      new HttpServiceHandler(config, worker, this)
+    override def provideHandler(config: ServiceConfig, worker: WorkerRef, initializer: CodecDSL.HandlerGenerator[Http])(implicit ex: ExecutionContext): DSLHandler[Http] = {
+      new HttpServiceHandler(config, worker, this, initializer)
     }
 
   }
 
   implicit object DefaultHttpProvider extends HttpProvider
 
-  class HttpServiceHandler[D <: BaseHttp](config: ServiceConfig, worker: WorkerRef, provider: CodecProvider[D])(implicit ex: ExecutionContext) 
-  extends BasicServiceHandler(config, worker, provider) {
+  class HttpServiceHandler[D <: BaseHttp]
+  (config: ServiceConfig, worker: WorkerRef, provider: CodecProvider[D], initializer: CodecDSL.HandlerGenerator[D])(implicit ex: ExecutionContext) 
+  extends BasicServiceHandler(config, worker, provider, initializer) {
 
     override def processRequest(input: D#Input): Callback[D#Output] = super.processRequest(input).map{response =>
       if (response.head.version == HttpVersion.`1.0`) {
@@ -64,8 +65,8 @@ package object http {
       case other => toStreamed(request.error(reason.toString))
     }
 
-    override def provideHandler(config: ServiceConfig, worker: WorkerRef)(implicit ex: ExecutionContext): DSLHandler[StreamingHttp] = {
-      new HttpServiceHandler(config, worker, this)
+    override def provideHandler(config: ServiceConfig, worker: WorkerRef, initializer: CodecDSL.HandlerGenerator[StreamingHttp])(implicit ex: ExecutionContext): DSLHandler[StreamingHttp] = {
+      new HttpServiceHandler(config, worker, this, initializer)
     }
 
     private def toStreamed(response : HttpResponse) : StreamingHttpResponse = {


### PR DESCRIPTION
Two main things in here:

1.  There's a new ConnectionInfo trait that contains a bunch of low-level read-only values which is now exposed to all layers of a server connection handler.  There was already a `ConnectionInfo` class, which I renamed to `ConnectionSnapshot`which is more descriptive of what it is.

2.  Fixed a bug where basically the connection handler initialization in the service DSL was occurring before the connection handler actually was fully connected.  So if someone tried to grab the connection info it would have come back as None.  So now the initializer is invoked through the handler's connected method.