### PR TITLE
fixing weighted average, actor metrics initialization

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
@@ -23,7 +23,7 @@ object HttpExample {
     
     def invalidReply(reply: Reply) = s"Invalid reply from redis $reply"    
 
-    val handler: PartialFunction[HttpRequest, Callback[HttpResponse]] = {
+    def handler: PartialFunction[HttpRequest, Callback[HttpResponse]] = {
       case req @ Get on Root => req.ok("Hello World!")
 
       case req @ Get on Root / "get"  / key => redis.send(Commands.Get(ByteString(key))).map{

--- a/colossus-metrics/src/main/scala/colossus/metrics/ActorMetrics.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/ActorMetrics.scala
@@ -8,11 +8,11 @@ import LocalCollection._
 import IntervalAggregator._
 
 trait ActorMetrics extends Actor with ActorLogging {
-  val metricSystem: MetricSystem
+  def metricSystem: MetricSystem
 
   def globalTags: TagMap = TagMap.Empty
 
-  val metrics = new LocalCollection(MetricAddress.Root, globalTags)
+  lazy val metrics = new LocalCollection(MetricAddress.Root, globalTags, metricSystem.metricIntervals.keys.toSeq)
 
   def handleMetrics: Receive = {
     case m : MetricEvent => metrics.handleEvent(m) match {

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -45,7 +45,11 @@ object MetricValues {
     def +(other: MetricValue) = other match {
       case WeightedAverageValue(v, w) => {
         val wsum = weight + w
-        WeightedAverageValue((value * (weight / wsum)) + (v * (w / wsum)), wsum)
+        if (wsum > 0) {
+          WeightedAverageValue((value * (weight / wsum)) + (v * (w / wsum)), wsum)
+        } else {
+          WeightedAverageValue(0, 0)
+        }
       }
       case _ => wrongType(this, other)
     }

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collector.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collector.scala
@@ -6,7 +6,7 @@ class Collector(val metricSystem: MetricSystem, val collection: LocalCollection)
 
   override def globalTags = collection.globalTags
 
-  override val metrics = collection
+  override lazy val metrics = collection
 
   def receive = handleMetrics
 


### PR DESCRIPTION
Two fixes here:

1.  Avoiding a divide by zero when two empty weighted averages are combined

2.  LocalCollections in the ActorMetrics trait were not being given the list of global aggregation intervals.