### PR TITLE
CallbackMatcher now correctly propagates thrown exceptions

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/CallbackMatchers.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/CallbackMatchers.scala
@@ -22,12 +22,15 @@ trait CallbackMatchers {
             case (t : Throwable) => println(s"creating error") ; error = Some(t)
           }
         }
-        case (Failure(x)) => error = Some(x)
+        case (Failure(x)) => {
+          executed = true
+          error = Some(x)
+        }
       }
       if(!executed) {
-        MatchResult(false, "Callback never executed", "Callback never executed")
+        MatchResult(false, "Callback did not complete", "Callback did not complete")
       }else{
-        val errorMsg = error.fold("")(_.getMessage)
+        val errorMsg = error.fold("")(e => s"Callback failed execution with error: ${e}")
         MatchResult(error.isEmpty, errorMsg, errorMsg)
       }
     }

--- a/colossus-testkit/src/test/scala/colossus/CallbackMatchersSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/CallbackMatchersSpec.scala
@@ -59,6 +59,19 @@ class CallbackMatchersSpec extends WordSpec with MustMatchers{
       execd must equal(true)
     }
 
+    "report the error for a failed callback" in {
+      val cb = Callback.successful("YAY").map{t => throw new Exception("NAY")}
+      var execd = false
+      val eval = (a: String) => {
+        execd = true
+        a must equal("YAY")
+      }
+      val result = new CallbackEvaluateTo[String](eval).apply(cb)
+      result.matches must equal(false)
+      execd must equal(false)
+      result.failureMessage.contains("NAY") must equal(true)
+    }
+
 
   }
 


### PR DESCRIPTION
@nsauro @dangermike 

Previously if a Callback threw an error somewhere in its execution, the matcher would simply say that the callback never executed, when it fact it did execute and complete, albeit with an error.  Now the match correctly indicates when the callback completes with an error vs never completing.