### PR TITLE
Document site fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+source 'https://rubygems.org'
+
 gem 'rake'
 gem 'jekyll'
 gem 'rouge'

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -55,7 +55,7 @@ object Main extends App {
           Callback.successful(TelnetReply("Bye!"))
         }
         case other => {
-          Callback.failed(new IllegalArgumentException($"Invalid command $other"))
+          Callback.failed(new IllegalArgumentException(s"Invalid command $other"))
         }
       }
     }


### PR DESCRIPTION
1. Your Gemfile has no gem server sources. So I added a line like this to your Gemfile:
source 'https://rubygems.org'

2. Fixed syntax error in string interpolation ($ -> s)