### PR TITLE
rates, histograms can prune empty values

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -11,7 +11,7 @@ trait Rate extends EventCollector {
   def hit(tags: TagMap = TagMap.Empty, num: Int = 1)
 }
 
-case class RateParams(address: MetricAddress) extends MetricParams[Rate, RateParams] {
+case class RateParams(address: MetricAddress, pruneEmpty: Boolean) extends MetricParams[Rate, RateParams] {
   def transformAddress(f: MetricAddress => MetricAddress) = copy(address = f(address))
 }
 
@@ -19,7 +19,7 @@ object Rate {
 
   case class Hit(address: MetricAddress, tags: TagMap, count: Int = 1) extends MetricEvent
 
-  def apply(address: MetricAddress): RateParams = RateParams(address)
+  def apply(address: MetricAddress, pruneEmpty: Boolean = false): RateParams = RateParams(address, pruneEmpty)
 
   implicit object RateGenerator extends Generator[Rate, RateParams] {
     def local(params: RateParams, config: CollectorConfig): Local[Rate] = new ConcreteRate(params, config)
@@ -33,20 +33,22 @@ object Rate {
 class BasicRate {
 
   private var _total: Long = 0L
-  private var current: Long = 0L
+  private var _current: Long = 0L
   private var lastFullValue = 0L
 
   def total = _total
 
   def hit(num: Int = 1) {
     _total += num
-    current += num
+    _current += num
   }
 
   def tick() {
     lastFullValue = current
-    current = 0
+    _current = 0
   }
+
+  def current = _current
 
   def value = lastFullValue
 
@@ -67,35 +69,42 @@ class SharedRate(val params: RateParams, collector: ActorRef) extends Rate with 
 
 //notice this rate is not the actual core rate, since it handles tags
 class ConcreteRate(params: RateParams, config: CollectorConfig) extends Rate with LocalLocality with TickedCollector {
-  import collection.mutable.{Map => MutMap}
+  import collection.mutable.{ArrayBuffer, Map => MutMap}
 
-  private val rates = MutMap[TagMap, MutMap[FiniteDuration, BasicRate]]()
+  private val rates = MutMap[FiniteDuration, MutMap[TagMap, BasicRate]]()
+  config.intervals.foreach{i => rates += (i -> MutMap[TagMap, BasicRate]())}
 
   def hit(tags: TagMap = TagMap.Empty, num: Int = 1){
-    if (!rates.contains(tags)) {
-      val r = MutMap[FiniteDuration, BasicRate]()
-      config.intervals.foreach{p =>
-        r(p) = new BasicRate
+    rates.foreach{ case (interval, tagrates) =>
+      if (!tagrates.contains(tags)) {
+        tagrates(tags) = new BasicRate
       }
-      rates(tags) = r
+      tagrates(tags).hit(num)
     }
-    rates(tags).foreach{_._2.hit(num)}
   }
 
   def address = params.address
 
   def tick(tickPeriod: FiniteDuration){
-    rates.foreach{ case (tags, intervalValues) => intervalValues(tickPeriod).tick()}
+    val toRemove = ArrayBuffer[TagMap]()
+    rates(tickPeriod).foreach{ case (tags, rate) => 
+      if (rate.current == 0 && params.pruneEmpty) {
+        toRemove += tags
+      } else {
+        rate.tick()
+      }
+    }
+    toRemove.foreach{tags => rates(tickPeriod) -= tags}
   }
 
   def metrics(context: CollectionContext): MetricMap = {
     import MetricValues._
-    val values = rates.map{case (tags, values) => 
-      (tags ++ context.globalTags) -> SumValue(values(context.interval).value)
+    val values = rates(context.interval).map{case (tags, rate) => 
+      (tags ++ context.globalTags) -> SumValue(rate.value)
     }
     //totals are the same for each period
-    val totals = rates.map{case (tags, values) => 
-      (context.globalTags ++ tags, SumValue(values.head._2.total))
+    val totals = rates(context.interval).map{case (tags, rate) => 
+      (context.globalTags ++ tags, SumValue(rate.total))
     }
     Map(params.address -> values.toMap, (params.address / "count") ->  totals.toMap)
   }

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -66,6 +66,19 @@ class RateSpec extends MetricIntegrationSpec {
       check(1.minute, 3)
     }
 
+    "prune empty values" in {
+      val r = new ConcreteRate(Rate("/foo", true), CollectorConfig(List(1.second, 1.minute)))
+      r.hit(Map("foo" -> "a"))
+      r.hit(Map("foo" -> "b"))
+      r.tick(1.second)
+      r.metrics(CollectionContext(Map(), 1.second))("/foo").contains(Map("foo" -> "a")) must equal(true)
+      r.metrics(CollectionContext(Map(), 1.second))("/foo").contains(Map("foo" -> "b")) must equal(true)
+      r.hit(Map("foo" -> "a"))
+      r.tick(1.second)
+      r.metrics(CollectionContext(Map(), 1.second))("/foo").contains(Map("foo" -> "a")) must equal(true)
+      r.metrics(CollectionContext(Map(), 1.second))("/foo").contains(Map("foo" -> "b")) must equal(false)
+    }
+
 
   }
 


### PR DESCRIPTION
Fixes #187 

Rates and Histograms have a new `PruneEmpty` option that when true, if a rate/histogram value for a set of tags received no hits during an interval, the value will be totally removed instead of being reported as zero.  