### PR TITLE
new repeatEOS parser, upping TestClient timeouts

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -69,14 +69,14 @@ object TestClient {
 
   def waitForStatus[I,O](client: AsyncServiceClient[I, O], status: ConnectionStatus, maxTries: Int = 5) {
     var tries = maxTries
-    var last = Await.result(client.connectionStatus, 500.milliseconds)
+    var last = Await.result(client.connectionStatus, 2.seconds)
     while (last != status) {
       Thread.sleep(100)
       tries -= 1
       if (tries == 0) {
         throw new Exception(s"Test client failed to achieve status $status, last status was $last")
       }
-      last = Await.result(client.connectionStatus, 500.milliseconds)
+      last = Await.result(client.connectionStatus, 2.seconds)
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -202,6 +202,15 @@ class CombinatorSuite extends WordSpec with MustMatchers{
       val d = data("3:aabbccdd")
       parser.parse(d) must equal (Some(Vector(ByteString("aa"), ByteString("bb"), ByteString("cc"))))
     }
+
+    "repeatUntilEOS" in {
+      val parser = repeatUntilEOS(bytes(2))
+      val d1 = data("aabb")
+      val d2 = data("cc")
+      parser.parse(d1) must equal(None)
+      parser.parse(d2) must equal(None)
+      parser.endOfStream() must equal(Some(Vector(ByteString("aa"), ByteString("bb"), ByteString("cc"))))
+    }
   }
 
 }

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -654,6 +654,30 @@ object Combinators {
     }
   }
 
+  /**
+   * Create a parser that will repeat the given parser forever until
+   * `endOfStream()` is called.  The results from each call to the given parser
+   * are accumulated and returned at the end of the stream.
+   */
+  def repeatUntilEOS[T](parser: Parser[T]): Parser[Seq[T]] = new Parser[Seq[T]] {
+    var build = collection.mutable.ArrayBuffer[T]()
+    def parse(data: DataBuffer) = { 
+      while (data.hasNext) {
+        parser.parse(data).foreach{t =>
+          build += t
+        }
+      }
+      None
+    }
+
+    override def endOfStream() = {
+      val res = Some(build)
+      build = collection.mutable.ArrayBuffer[T]()
+      res
+    }
+  }
+
+
   //this is just a tuple that allows for cleaner pattern matching
   case class ~[+A,+B](a: A, b: B)
 


### PR DESCRIPTION
@dangermike 

This adds a new parser that will repeat another parser forever until the end of stream is reached.  

Also upping some timeouts in the tests.