### PR TITLE
improving error propagation, fixing bug with disabled writes

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -69,14 +69,14 @@ object TestClient {
 
   def waitForStatus[I,O](client: AsyncServiceClient[I, O], status: ConnectionStatus, maxTries: Int = 5) {
     var tries = maxTries
-    var last = Await.result(client.connectionStatus, 2.seconds)
+    var last = Await.result(client.connectionStatus, 10.seconds)
     while (last != status) {
       Thread.sleep(100)
       tries -= 1
       if (tries == 0) {
         throw new Exception(s"Test client failed to achieve status $status, last status was $last")
       }
-      last = Await.result(client.connectionStatus, 2.seconds)
+      last = Await.result(client.connectionStatus, 10.seconds)
     }
   }
 

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -271,7 +271,10 @@ private[core] class ClientConnection(id: Long, key: SelectionKey, channel: Socke
 
 }
 
-private[core] sealed trait RootDisconnectCause
+private[core] sealed trait RootDisconnectCause {
+  def tagString: String
+  def logString: String
+}
 
 /**
  * Messages representing why a disconnect occurred.  These can be either normal disconnects
@@ -289,31 +292,49 @@ object DisconnectCause {
   //unhandled is private because it only occurs in situations where a
   //connection handler doesn't exist yet, so it doesn't make sense to force
   //handlers to handle a cause they will, by definition, never see
-  private[core] case object Unhandled extends RootDisconnectCause
+  private[core] case object Unhandled extends RootDisconnectCause {
+    def tagString = "unhandled"
+    def logString = "No Connection Handler Provided"
+  }
 
   /**
    * We initiated the disconnection on our end
    */
-  case object Disconnect extends DisconnectCause
+  case object Disconnect extends DisconnectCause {
+    def tagString = "disconnect"
+    def logString = "Closed by local host"
+  }
   /**
    * The IO System is being shutdown
    */
-  case object Terminated extends DisconnectCause
+  case object Terminated extends DisconnectCause {
+    def tagString = "terminated"
+    def logString = "IO System is shutting down"
+  }
 
   /**
    * The connection was idle and timed out
    */
-  case object TimedOut extends DisconnectError
+  case object TimedOut extends DisconnectError {
+    def tagString = "timedout"
+    def logString = "Timed out"
+  }
 
   /**
    * Unknown Error was encountered
    */
-  case class Error(error: Throwable) extends DisconnectError
+  case class Error(error: Throwable) extends DisconnectError {
+    def tagString = "error"
+    def logString = s"Error: $error"
+  }
 
   /**
    * The connection was closed by the remote end
    */
-  case object Closed extends DisconnectError
+  case object Closed extends DisconnectError {
+    def tagString = "closed"
+    def logString = "Closed by remote host"
+  }
 }
 
 

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -194,7 +194,7 @@ private[colossus] class Server(io: IOSystem, config: ServerConfig, stateAgent : 
   def closeConnection(cause: RootDisconnectCause) {
     openConnections -= 1
     connections.decrement()
-    closed.hit(tags = Map("cause" -> cause.toString))
+    closed.hit(tags = Map("cause" -> cause.tagString))
     updateServerConnectionState()
   }
 

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -58,7 +58,10 @@ class PermutationGenerator[T : ClassTag](val seedlist: List[T]) extends Iterator
 }
   
 class LoadBalancingClientException(message: String) extends Exception(message)  
-class SendFailedException(tries: Int, finalCause: Throwable) extends Exception(s"Failed after ${tries} tries", finalCause)
+class SendFailedException(tries: Int, finalCause: Throwable) extends Exception(
+  s"Failed after ${tries} tries, error on last try: ${finalCause.getMessage}", 
+  finalCause
+)
 
 
 


### PR DESCRIPTION
This PR has several bug fixes and improvements

* Fixing a bug where if a client loses its connection after it disables writes, when the connection is re-established writes are never re-enabled, and the client refuses to send any requests.
* Improving the propagation of client connection errors to pending and outstanding requests.  Before if a service client lost its connection, any pending and outstanding requests would be completed with a generic error.  Now the actual error that caused the connection to be lost is included.
* Fixing #201 .  Now every `DisconnectCause` has both a name for the tag and a human-readable string
* Increasing the default sent buffer size for service-clients.  The value is still somewhat arbitrary but 20 was definitely too low and probably leading to unnecessary bottlenecking