### PR TITLE
Metric Clock uses scheduleOnce for ticks instead of schedule

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
@@ -39,6 +39,7 @@ class IntervalAggregator(namespace: MetricAddress, interval: FiniteDuration, sna
       collectors.foreach(_ ! Tick(latestTick, interval))
       finalizeAndReportMetrics()
       resetMetrics()
+      context.system.scheduler.scheduleOnce(interval, self, SendTick)
     }
 
     case Tock(m, v) => {
@@ -110,7 +111,7 @@ class IntervalAggregator(namespace: MetricAddress, interval: FiniteDuration, sna
   }
 
   override def preStart() {
-    context.system.scheduler.schedule(interval, interval, self, SendTick)
+    context.system.scheduler.scheduleOnce(interval, self, SendTick)
   }
 }
 


### PR DESCRIPTION
Fixes #202 .  

This should fix some weirdness we've been seeing where tick messages pile up and lead to race conditions.  By using `scheduleOnce`, we can now guarantee that only ever one message is schedule to be sent at a time.