### PR TITLE
better handling around http query string parameters

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
@@ -1,9 +1,8 @@
-package colossus
+package colossus.protocols.http
 
 
 import org.scalatest._
 
-import protocols.http._
 
 class HttpHeadSuite extends WordSpec with MustMatchers{
 
@@ -57,6 +56,21 @@ class HttpHeadSuite extends WordSpec with MustMatchers{
         Cookie("bar", "true", None)
       )
       head.cookies must equal(expected)
+    }
+
+    "parse query string parameter with no value" in {
+      val head = HttpHead(HttpMethod.Get, "/foo?a=&b=c", HttpVersion.`1.1`, Nil)
+      head.parameters("a") must equal("")
+
+      val head2 = HttpHead(HttpMethod.Get, "/foo?a&b=c", HttpVersion.`1.1`, Nil)
+      head2.parameters("a") must equal("")
+    }
+
+    "correctly handle = in query string parameter values" in {
+      val head = HttpHead(HttpMethod.Get, "/foo?a=b&b=c=d&e=f=", HttpVersion.`1.1`, Nil)
+      head.parameters("a") must equal("b")
+      head.parameters("b") must equal("c=d")
+      head.parameters("e") must equal("f=")
     }
   }
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -201,15 +201,19 @@ case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, heade
 object HttpHead {
 
   import java.net.URI
-  //todo, this throws exceptions on malformed URLS, should catch and return 400 instead
+  // Notice, parameters with no value are legal, in which case we fill in with an empty string
   def parseParameters(q: String): Map[String, String] = {
     if (q != null && q.length > -1) {
       val params = scala.collection.mutable.HashMap[String, String]()
       val unparsedArgs = q.split('&')
 
       for (str <- unparsedArgs) {
-        val unparsedArg = str.split('=')
-        params += unparsedArg(0) -> unparsedArg(1)
+        val unparsedArg = str.split("=", 2)
+        if (unparsedArg.size == 2) {
+          params += unparsedArg(0) -> unparsedArg(1)
+        } else {
+          params += unparsedArg(0) -> ""
+        }
       }
       collection.immutable.Map(params.toList: _*)
     } else {


### PR DESCRIPTION
fixes #203 

* Properly handle `=` in parameter values
* Properly handle parameters with no value