### PR TITLE
changing some IntervalAggregator warnings to debugs

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
@@ -61,10 +61,10 @@ class IntervalAggregator(namespace: MetricAddress, interval: FiniteDuration, sna
 
     case Terminated(child) => {
       if(collectors.contains(child)){
-        log.warning(s"oh no!  We lost an EventCollector $child. Removing from registered collectors.")
+        log.debug(s"oh no!  We lost an EventCollector $child. Removing from registered collectors.")
         collectors.remove(child)
       }else if(reporters.contains(child)){
-        log.warning(s"oh no!  We lost a MetricReporter $child. Removing from registered reporters.")
+        log.debug(s"oh no!  We lost a MetricReporter $child. Removing from registered reporters.")
         reporters.remove(child)
       }else{
         log.warning(s"someone: $child died..for which there is no reporter or collector registered")


### PR DESCRIPTION
A collector or reporter being terminated is not necessarily an error condition (in fact it is part of a services normal shutdown process), so let's not warn about it.