### PR TITLE
fixing non-exhaustive matches in controller

### DIFF
--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -37,13 +37,6 @@ sealed trait AliveState extends ConnectionState {
   def endpoint: WriteEndpoint
 }
 
-object AliveState {
-  def unapply(state: ConnectionState): Option[WriteEndpoint] = state match {
-    case a: AliveState => Some(a.endpoint)
-    case _ => None
-  }
-}
-
 object ConnectionState {
   case object NotConnected extends ConnectionState
   case class Connected(endpoint: WriteEndpoint) extends ConnectionState with AliveState
@@ -126,8 +119,8 @@ extends InputController[Input, Output] with OutputController[Input, Output] {
   def disconnect() {
     //this has to be public to be used for clients
     state match {
-      case AliveState(endpoint) => {
-        endpoint.disconnect()
+      case a: AliveState => {
+        a.endpoint.disconnect()
       }
       case _ => {}
     }

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -82,6 +82,7 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
   }
 
   private[controller] def inputOnConnected() {
+    _readsEnabled = true
     inputState = Decoding
   }
 
@@ -94,19 +95,21 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
 
   protected def pauseReads() {
     state match {
-      case AliveState(endpoint) => {
+      case a : AliveState => {
         _readsEnabled = false
-        endpoint.disableReads()
+        a.endpoint.disableReads()
       }
+      case _ => {}
     }
   }
 
   protected def resumeReads() {
     state match {
-      case AliveState(endpoint) => {
+      case a: AliveState => {
         _readsEnabled = true
-        endpoint.enableReads()
+        a.endpoint.enableReads()
       }
+      case _ => {}
     }
   }
 

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -244,7 +244,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
   private def drain(source: Source[DataBuffer]) {
     source.pull{
       case Success(Some(data)) => state match {
-        case AliveState(endpoint) => endpoint.write(data) match {
+        case a: AliveState => a.endpoint.write(data) match {
           case WriteStatus.Complete => drain(source)
           case WriteStatus.Failed  => {
             source.terminate(new NotConnectedException("Connection closed during streaming"))


### PR DESCRIPTION
So apparently using custom extractors in pattern matching of sealed traits breaks exhaustiveness checking, and we had a few places where we weren't exhaustive.  So I switched to plain type checking and patched the leaks.