### PR TITLE
Removing broken Executor from testkit, new TestExecutor (that works)

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -9,7 +9,8 @@ import akka.actor._
 import akka.testkit.TestProbe
 import akka.testkit.CallingThreadDispatcher
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.duration._
 
 object FakeIOSystem {
   def apply()(implicit system: ActorSystem): IOSystem = {
@@ -29,19 +30,52 @@ object FakeIOSystem {
     (sys, probe)
   }
 
-  /**
-   * Returns an entirely in-thread CallbackExecutor
-   */
-  def callingThreadCallbackExecutor(implicit system: ActorSystem): CallbackExecutor = {
-    class FakeExecutor extends Actor with CallbackExecution {
-      def receive = handleCallback
+  //prevents accidentally spinning up a new executor per test
+  private val exCache: collection.mutable.Map[ActorSystem, CallbackExecutor] = collection.mutable.Map()
+
+  def testExecutor(implicit system: ActorSystem): CallbackExecutor = {
+    exCache.get(system).getOrElse {
+      val ref = system.actorOf(Props[GenericExecutor].withDispatcher("server-dispatcher"))
+      val ex = CallbackExecutor(system.dispatcher, ref)
+      exCache(system) = ex
+      ex
     }
-    val ref = system.actorOf(Props[FakeExecutor].withDispatcher(CallingThreadDispatcher.Id))
-    val executor = new ExecutionContext {
-      def reportFailure(t: Throwable) { t.printStackTrace() }
-      def execute(runnable: Runnable) {runnable.run()}
-    }
-    CallbackExecutor(executor, ref)
   }
 }
 
+
+trait GenericCallback {
+  def execute()
+}
+
+case class CallbackMessage[T](cb: Callback[T]) extends GenericCallback {
+  def execute() {
+    cb.execute()
+  }
+}
+
+class GenericExecutor extends Actor with CallbackExecution {
+  def receive = handleCallback orElse {
+    case g: GenericCallback => {
+      g.execute()
+    }
+  }
+}
+
+
+object CallbackAwait {
+
+  /**
+   * Await the result of a Callback.  This *must* be used whenever Callback.fromFuture is used.  Going forward this may be the only way to
+   * extract the value from a Callback
+   *
+   * The Callback is properly executed inside an Actor running in a PinnedDispatcher.  The calling thread blocks until the Callback finishes
+   * execution or the timeout is reached
+   */
+  def result[T](cb: Callback[T], in: Duration)(implicit ex: CallbackExecutor): T = {
+    val p = Promise[T]()
+    ex.executor ! CallbackMessage(cb.mapTry{t => p.complete(t);t})
+    Await.result(p.future, in)
+  }
+
+}

--- a/colossus-testkit/src/test/scala/colossus/FakeIOSystemSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/FakeIOSystemSpec.scala
@@ -5,17 +5,23 @@ package testkit
 import akka.testkit.TestProbe
 import service._
 import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.duration._
 import ExecutionContext.Implicits.global
 
 
 class FakeIOSystemSpec extends ColossusSpec with CallbackMatchers {
 
-  "FakeExecutor" must {
+  "TestExecutor" must {
     "execute" in {
-      implicit val ex = FakeIOSystem.callingThreadCallbackExecutor
-      val cb = Callback.fromFuture(Future.successful(5)).map{i => i + 1}
-      cb must evaluateTo{x: Int => x must equal(6)}
+      implicit val ex = FakeIOSystem.testExecutor
+
+      val cb = Callback.fromFuture(Future{ 5 }).map{i => i + 1}
+
+      CallbackAwait.result(cb, 1.second) must equal(6)
     }
   }
+
+
+      
 
 }


### PR DESCRIPTION
So after some careful examination, it's clear that the calling-thread callback executor did not properly work.  Furthermore, the Callback Matchers do not correctly handle Callbacks that work with Futures.

Going forward, the new `CallbackAwait` should be the only method to extract the value from a Callback in tests.  I've kept the Callback Matchers for now for backwards compatibility (and they do work with vanilla Callbacks), but i think we'll have to remove them.

Basically it works by spinning up an actual actor in a PinnedDispatcher that executes the callbacks and acts as the `CallbackExecutor`.  This ensures proper behavior when a Callback "jumps" out of thread, executes as a Future, and jumps back in thread via the Executor.