### PR TITLE
Numerous optimizations and fixes

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -1,0 +1,98 @@
+package colossus.examples
+
+
+import java.util.Date
+import java.text.SimpleDateFormat
+
+import colossus._
+import colossus.core.{ServerRef, ServerSettings}
+import service._
+import protocols.http._
+
+import net.liftweb.json._
+import JsonDSL._
+import akka.actor._
+import akka.util.ByteString
+import scala.concurrent.duration._
+
+import UrlParsing._
+import HttpMethod._
+
+
+object BenchmarkService {
+
+  class Timestamp(server: ServerRef) extends Actor {
+        
+    val sdf = new SimpleDateFormat("EEE, MMM d yyyy HH:MM:ss z")
+    case object Tick
+    import context.dispatcher
+
+    override def preStart() {
+      self ! Tick
+    }
+
+    def receive = {
+      case Tick => {
+        server.delegatorBroadcast(sdf.format(new Date()))
+        context.system.scheduler.scheduleOnce(1.second, self, Tick)
+      }
+    }
+  }
+  val response          = ByteString("Hello, World!")
+  val plaintextHeader   = ("Content-Type", "text/plain")
+  val jsonHeader        = ("Content-Type", "application/json")
+  val serverHeader      = ("Server", "Colossus")
+
+
+  def start(port: Int)(implicit io: IOSystem) {
+
+    val serverConfig = ServerSettings(
+      port = port,
+      maxConnections = 16384,
+      tcpBacklogSize = Some(1024)
+    )
+    val serviceConfig = ServiceConfig(
+      name = "/sample",
+      requestTimeout = Duration.Inf
+    )
+
+    val server = Service.serve[Http](serverConfig, serviceConfig) { context =>
+
+      ///the ??? is filled in almost immediately
+      var dateHeader = ("Date", "???")
+
+      context.receive {
+        case ts: String => dateHeader = ("Date", ts)
+      }
+      
+      context.handle { connection =>
+        connection.become{ case request =>
+          if (request.head.url == "/plaintext") {
+            val res = HttpResponse(
+              version  = HttpVersion.`1.1`,
+              code    = HttpCodes.OK,
+              data    = response,
+              headers = Vector(plaintextHeader, serverHeader, dateHeader)
+            )
+            Callback.successful(res)
+          } else if (request.head.url == "/json") {
+            val json = ("message" -> "Hello, World!")
+            val res = HttpResponse(
+              version  = HttpVersion.`1.1`,
+              code    = HttpCodes.OK,
+              data    = compact(render(json)),
+              headers = Vector(jsonHeader, serverHeader, dateHeader)
+            )
+            Callback.successful(res)
+          } else {
+            Callback.successful(request.notFound("invalid path"))
+          }
+        }
+      }
+    }
+
+    val timestamp = io.actorSystem.actorOf(Props(classOf[Timestamp], server))
+  }
+
+}
+

--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -36,4 +36,6 @@ object Main extends App {
   //chat server using the controller layer
   val chatServer = ChatExample.start(9005)
 
+  val benchmarkServer = BenchmarkService.start(9007)
+
 }

--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -35,3 +35,5 @@ object Main extends App {
 
   //chat server using the controller layer
   val chatServer = ChatExample.start(9005)
+
+}

--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -25,15 +25,15 @@ object Main extends App {
   val telnetServer = TelnetExample.start(9000)
 
   //http service which communicates with a key/value store over the redis protocol
-  //val httpServer = HttpExample.start(9001, new InetSocketAddress("localhost", 9002))
+  val httpServer = HttpExample.start(9001, new InetSocketAddress("localhost", 9002))
 
   //and here's the key/value store itself
-  //val keyvalServer = KeyValExample.start(9002)
+  val keyvalServer = KeyValExample.start(9002)
 
   //an echo server built only on the core layer
-  //val echoServer = EchoExample.start(9003)
+  val echoServer = EchoExample.start(9003)
 
   //chat server using the controller layer
-  //val chatServer = ChatExample.start(9005)
+  val chatServer = ChatExample.start(9005)
 
 }

--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -19,10 +19,10 @@ object Main extends App {
 
   implicit val actorSystem = ActorSystem("COLOSSUS")
 
-  implicit val ioSystem = IOSystem()//"examples", numWorkers = Some(1))
+  implicit val ioSystem = IOSystem()
 
   //the simplest example, an echo server over telnet
-  //val telnetServer = TelnetExample.start(9000)
+  val telnetServer = TelnetExample.start(9000)
 
   //http service which communicates with a key/value store over the redis protocol
   val httpServer = HttpExample.start(9001, new InetSocketAddress("localhost", 9002))
@@ -31,80 +31,7 @@ object Main extends App {
   val keyvalServer = KeyValExample.start(9002)
 
   //an echo server built only on the core layer
-  //val echoServer = EchoExample.start(9003)
+  val echoServer = EchoExample.start(9003)
 
   //chat server using the controller layer
-  //val chatServer = ChatExample.start(9005)
-import java.util.Date
-import java.text.SimpleDateFormat
-
-import colossus._
-import colossus.core.ServerRef
-import service._
-import protocols.http._
-
-import net.liftweb.json._
-import JsonDSL._
-import akka.actor._
-import akka.util.ByteString
-import scala.concurrent.duration._
-
-class Timestamp(server: ServerRef) extends Actor {
-      
-  val sdf = new SimpleDateFormat("EEE, MMM d yyyy HH:MM:ss z")
-  case object Tick
-  import context.dispatcher
-
-  override def preStart() {
-    self ! Tick
-  }
-
-  def receive = {
-    case Tick => {
-      server.delegatorBroadcast(sdf.format(new Date()))
-      context.system.scheduler.scheduleOnce(1.second, self, Tick)
-    }
-  }
-}
-  val response          = "Hello, World!"
-  val plaintextHeader   = ("Content-Type", "text/plain")
-  val jsonHeader        = ("Content-Type", "application/json")
-  val serverHeader      = ("Server", "Colossus")
-
-  val server = Service.serve[Http]("sample", 9007) { context =>
-
-    var dateHeader = ("Date", "???")
-
-    context.receive {
-      case ts: String => dateHeader = ("Date", ts)
-    }
-    
-    context.handle { connection =>
-      connection.become{ case request =>
-        if (request.head.url == "/plaintext") {
-          val res = HttpResponse(
-            version  = HttpVersion.`1.1`,
-            code    = HttpCodes.OK,
-            data    = response,
-            headers = Vector(plaintextHeader, serverHeader, dateHeader)
-          )
-          Callback.successful(res)
-        } else if (request.head.url == "/json") {
-          val json = ("message" -> "Hello, World!")
-          val res = HttpResponse(
-            version  = HttpVersion.`1.1`,
-            code    = HttpCodes.OK,
-            data    = compact(render(json)),
-            headers = Vector(jsonHeader, serverHeader, dateHeader)
-          )
-          Callback.successful(res)
-        } else {
-          Callback.successful(request.notFound("invalid path"))
-        }
-      }
-    }
-  }
-
-  val timestamp = ioSystem.actorSystem.actorOf(Props(classOf[Timestamp], server))
-
-}
+  val chatServer = ChatExample.start(9005)

--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -19,10 +19,10 @@ object Main extends App {
 
   implicit val actorSystem = ActorSystem("COLOSSUS")
 
-  implicit val ioSystem = IOSystem("examples", numWorkers = Some(4))
+  implicit val ioSystem = IOSystem()//"examples", numWorkers = Some(1))
 
   //the simplest example, an echo server over telnet
-  val telnetServer = TelnetExample.start(9000)
+  //val telnetServer = TelnetExample.start(9000)
 
   //http service which communicates with a key/value store over the redis protocol
   val httpServer = HttpExample.start(9001, new InetSocketAddress("localhost", 9002))
@@ -31,9 +31,9 @@ object Main extends App {
   val keyvalServer = KeyValExample.start(9002)
 
   //an echo server built only on the core layer
-  val echoServer = EchoExample.start(9003)
+  //val echoServer = EchoExample.start(9003)
 
   //chat server using the controller layer
-  val chatServer = ChatExample.start(9005)
+  //val chatServer = ChatExample.start(9005)
 
 }

--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -25,15 +25,15 @@ object Main extends App {
   val telnetServer = TelnetExample.start(9000)
 
   //http service which communicates with a key/value store over the redis protocol
-  val httpServer = HttpExample.start(9001, new InetSocketAddress("localhost", 9002))
+  //val httpServer = HttpExample.start(9001, new InetSocketAddress("localhost", 9002))
 
   //and here's the key/value store itself
-  val keyvalServer = KeyValExample.start(9002)
+  //val keyvalServer = KeyValExample.start(9002)
 
   //an echo server built only on the core layer
-  val echoServer = EchoExample.start(9003)
+  //val echoServer = EchoExample.start(9003)
 
   //chat server using the controller layer
-  val chatServer = ChatExample.start(9005)
+  //val chatServer = ChatExample.start(9005)
 
 }

--- a/colossus-testkit/src/test/scala/colossus/MockWriteBufferSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/MockWriteBufferSpec.scala
@@ -1,0 +1,49 @@
+package colossus
+package testkit
+
+import core.{DataBuffer, WriteStatus}
+import akka.util.ByteString
+
+import org.scalatest.{MustMatchers, WordSpec}
+
+import scala.util.Try
+
+class MockWriteBufferSpec extends WordSpec with MustMatchers{
+
+  "MockWriteBuffer" must {
+
+    "write" in {
+      val m = new MockWriteBuffer(10)
+      m.write(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Complete)
+
+      m.expectOneWrite(ByteString("abcd"))
+    }
+
+    "return partial when exceeds size" in {
+      val m = new MockWriteBuffer(2)
+      m.write(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
+      m.expectOneWrite(ByteString("abcd"))
+    }
+
+    "return zero when full" in {
+      val m = new MockWriteBuffer(2)
+      m.write(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
+      m.write(DataBuffer(ByteString("1234"))) must equal(WriteStatus.Zero)
+      m.expectOneWrite(ByteString("abcd"))
+      m.expectNoWrite()
+    }
+
+    "clear buffer" in {
+      val m = new MockWriteBuffer(2)
+      m.write(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
+      m.expectOneWrite(ByteString("abcd"))
+      m.clearBuffer()
+      m.write(DataBuffer(ByteString("1234"))) must equal(WriteStatus.Partial)
+      m.expectOneWrite(ByteString("1234"))
+    }
+
+      
+  }
+}
+
+

--- a/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
@@ -43,10 +43,9 @@ class OutputControllerSpec extends ColossusSpec {
       controller.testPush(message){_ must equal (OutputResult.Success)}
       controller.testPush(message2){_ must equal (OutputResult.Success)}
       controller.testGracefulDisconnect()
-      endpoint.expectOneWrite(data.take(endpoint.maxWriteSize))
+      endpoint.expectOneWrite(data)
       endpoint.disconnectCalled must equal(false)
       endpoint.clearBuffer()
-      endpoint.expectWrite(data.drop(endpoint.maxWriteSize))
       endpoint.expectWrite(data2)
       endpoint.disconnectCalled must equal(true)  
     }

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
@@ -12,40 +12,6 @@ import scala.concurrent.duration._
 
 class ConnectionSpec extends ColossusSpec with MockitoSugar{
 
-  "WriteBuffer" must {
-    "write some bytes" in {
-      val m = new MockWriteBuffer(10)
-      m.write(DataBuffer(ByteString("hello"))) must equal (WriteStatus.Complete)
-      m.bytesAvailable must equal(5)
-      m.readsEnabled must equal(true)
-      m.writeReadyEnabled must equal(false)
-      m.expectBufferNotCleared
-      m.expectOneWrite(ByteString("hello"))
-    }
-
-    "partially buffer large data on overwrite" in {
-      val m = new MockWriteBuffer(10)
-      m.write(DataBuffer(ByteString("a1a2a3a4a5b1b2b3b4b5"))) must equal(WriteStatus.Partial)
-      m.bytesAvailable must equal(0)
-      m.readsEnabled must equal(true)
-      m.writeReadyEnabled must equal(true)
-      m.expectBufferNotCleared()
-      m.expectOneWrite(ByteString("a1a2a3a4a5"))
-      m.clearBuffer()
-      m.readsEnabled must equal(true)
-      m.writeReadyEnabled must equal(false)
-      m.expectBufferCleared()
-      m.expectOneWrite(ByteString("b1b2b3b4b5"))
-    }
-
-    "reject write calls when data is partially buffered" in {
-      val m = new MockWriteBuffer(10)
-      m.write(DataBuffer(ByteString("a1a2a3a4a5b1b2b3b4b5"))) must equal(WriteStatus.Partial)
-      m.write(DataBuffer(ByteString("waaaatttt"))) must equal(WriteStatus.Zero)
-    }
-    
-
-  }
 
   "ClientConnection" must {
     "timeout idle connection" in {

--- a/colossus-tests/src/test/scala/colossus/core/WriteBufferSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WriteBufferSpec.scala
@@ -1,0 +1,131 @@
+package colossus
+package core
+
+import testkit._
+import org.scalatest.mock.MockitoSugar
+
+import akka.testkit.TestProbe
+import akka.util.ByteString
+
+import WriteStatus._
+
+class WriteBufferSpec extends ColossusSpec {
+
+  class FakeWriteBuffer(val internalBufferSize: Int) extends WriteBuffer {
+  
+    protected var writes = collection.mutable.Queue[ByteString]()
+    
+    protected var clearCalled = false
+    def onBufferClear() {
+      clearCalled = true
+    }
+
+    def channelWrite(data: DataBuffer): Int = {
+      val d = ByteString(data.takeAll)
+      writes.enqueue(d)
+      d.size
+    }
+
+    def expectChannelWrite(expected: String) {
+      writes.dequeue must equal(ByteString(expected))
+    }
+
+    def expectClearCalled() {
+      clearCalled must equal(true)
+    }
+    def expectNoClearCalled() {
+      clearCalled must equal(false)
+    }
+
+    protected def setKeyInterest() {}
+
+  }
+
+  def data(s: String) = DataBuffer(ByteString(s))
+
+
+  "WriteBuffer" must {
+    "buffer some data and clear it" in {
+      val b = new FakeWriteBuffer(20)
+      b.write(data("hello")) must equal(Complete)
+      b.write(data(" world")) must equal(Complete)
+      b.handleWrite()
+      b.expectChannelWrite("hello world")
+      b.expectNoClearCalled()
+    }
+
+    "properly set write key interest" in {
+      val b = new FakeWriteBuffer(20)
+      b.writeReadyEnabled must equal(false)
+      b.write(data("hello"))
+      b.writeReadyEnabled must equal(true)
+      b.handleWrite()
+      b.writeReadyEnabled must equal(false)
+    }
+
+    "buffer and drain data too large for internal buffer" in {
+      val b = new FakeWriteBuffer(4)
+      b.write(data("1234567890")) must equal(Partial)
+      b.handleWrite()
+      b.expectChannelWrite("1234")
+      b.writeReadyEnabled must equal(true)
+      b.handleWrite()
+      b.expectChannelWrite("5678")
+      b.handleWrite()
+      b.expectChannelWrite("90")
+      b.writeReadyEnabled must equal(false)
+    }
+
+    "reject more writes while draining when buffer filled" in {
+      val b = new FakeWriteBuffer(4)
+      b.write(data("12345678")) must equal(Partial)
+      b.write(data("90")) must equal(Zero)
+    }
+    
+    "allow writes after buffer drained" in {
+      val b = new FakeWriteBuffer(4)
+      b.write(data("12345678")) must equal(Partial)
+      b.handleWrite()
+      b.expectChannelWrite("1234")
+      b.write(data("90")) must equal(Partial)
+      b.handleWrite()
+      b.expectChannelWrite("5678")
+      b.write(data("ab")) must equal(Complete)
+      b.handleWrite()
+      b.expectChannelWrite("90ab")
+    }
+
+    "immediately call disconnect callback when no data buffered" in {
+      val b = new FakeWriteBuffer(4)
+      b.write(data("hello"))
+      b.handleWrite()
+      b.handleWrite()
+      b.writeReadyEnabled must equal(false)
+      var called = false
+      b.disconnectBuffer(() => {called = true})
+      called must equal(true)
+    }
+
+    "call disconnect callback when internal buffer drained" in {
+      val b = new FakeWriteBuffer(4)
+      b.write(data("12345678"))
+      var called = false
+      b.disconnectBuffer(() => {called = true})
+      called must equal(false)
+      b.handleWrite()
+      called must equal(false)
+      b.handleWrite()
+      called must equal(true)
+    }
+
+    "disallow more writes after disconnect callback has been set" in {
+      val b = new FakeWriteBuffer(4)
+      b.disconnectBuffer(() => ())
+      b.write(data("asf")) must equal(Failed)
+    }
+
+
+
+  }
+}
+

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -366,7 +366,7 @@ class ServiceClientSpec extends ColossusSpec {
       //TODO: is this test unfinished?
     }
 
-    "attempts to reconnect when server closes connection" taggedAs(org.scalatest.Tag("test")) in {
+    "attempts to reconnect when server closes connection" in {
       //try it for real (reacting to a bug with NIO interaction)
       withIOSystem{implicit sys => 
         import protocols.redis._

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -282,7 +282,7 @@ class ServiceClientSpec extends ColossusSpec {
       var failed = false
       val cb = client.send(command)
       endpoint.expectNoWrite()
-      endpoint.connection_status = ConnectionStatus.NotConnected
+      endpoint.disrupt()
       cb.execute{
         case Success(wat) => println("HERE");throw new Exception("NOPE")
         case Failure(yay) => println("THER");failed = true
@@ -356,7 +356,6 @@ class ServiceClientSpec extends ColossusSpec {
       val (endpoint, client, probe) = newClient(true, 10)
       client.send(cmd1).execute()
       client.gracefulDisconnect()
-      endpoint.connection_status = ConnectionStatus.NotConnected
       endpoint.disrupt()
       probe.expectMsg(100.milliseconds, WorkerCommand.UnbindWorkerItem(client.id.get))
     }
@@ -377,7 +376,7 @@ class ServiceClientSpec extends ColossusSpec {
       }.execute()
       endpoint.expectOneWrite(cmd.raw)
       client.receivedData(reply.raw)
-      endpoint.connection_status = ConnectionStatus.NotConnected
+      //TODO: is this test unfinished?
     }
 
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -392,10 +392,8 @@ class ServiceClientSpec extends ColossusSpec {
           TestClient.waitForConnected(client)
           TestUtil.expectServerConnections(server, 1)
           Await.result(client.send(Command("bye")), 500.milliseconds) must equal(reply)
-          println("========== 1")
           TestUtil.expectServerConnections(server, 1)
           TestClient.waitForConnected(client)
-          println("========== 2")
           Await.result(client.send(Command("00000000000")), 500.milliseconds) must equal(StatusReply("ok"))
         }
       }

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -206,8 +206,9 @@ private[core] abstract class Connection(val id: Long, val key: SelectionKey, _ch
   }
 
   def disconnect() {
-
-    sender ! WorkerCommand.Disconnect(id)
+    disconnectBuffer{() => 
+      sender ! WorkerCommand.Disconnect(id)
+    }
   }
 
   /**

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -87,7 +87,7 @@ class WorkerItemManager(worker: WorkerRef, log: LoggingAdapter) {
    */
   def bind(workerItem: WorkerItem) {
     if (workerItem.isBound) {
-      log.error(s"Attempted to bind worker ${workerItem.binding} that was already bound")
+      log.error(s"Attempted to bind worker ${workerItem} that was already bound")
     } else {
       val id = newId()
       workerItems(id) = workerItem
@@ -256,7 +256,11 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
     import IOCommand._
     cmd match {
       case BindWorkerItem(itemFactory) => {
-        workerItems.bind(itemFactory(me))
+        val item = itemFactory(me)
+        //the item may have already bound itself
+        if (!item.isBound) {
+          workerItems.bind(item)
+        }
       }
       case BindAndConnectWorkerItem(address, itemFactory) => {
         val item = itemFactory(me)

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -410,7 +410,6 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
     val it = selectedKeys.iterator()
     while (it.hasNext) {
       val key : SelectionKey = it.next
-      it.remove()
       if (!key.isValid) {
         log.error("KEY IS INVALID")
       } else if (key.isConnectable) {
@@ -485,7 +484,8 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
             }
           }
         }
-        if (key.isWritable) {
+        //have to test for valid here since it could have just been cancelled above
+        if (key.isValid && key.isWritable) {
           key.attachment  match {
             case c: Connection => try {
               c.handleWrite()
@@ -501,6 +501,8 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorMet
           }
         }
       }
+      it.remove()
+
     }
   }
 

--- a/colossus/src/main/scala/colossus/core/WriteBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/WriteBuffer.scala
@@ -74,7 +74,10 @@ private[colossus] trait WriteBuffer extends KeyInterestManager {
 
   def isDataBuffered: Boolean = partialBuffer.isDefined
 
-  private val internal = DataBuffer(ByteBuffer.allocate(1024 * 64))
+  //TODO: This buffer size is probably fine, but either do some more
+  //experimentation or make it configurable.  Easier said than done as no config
+  //is passed into this trait right now
+  private val internal = DataBuffer(ByteBuffer.allocateDirect(1024 * 64))
   private def copyInternal(src: ByteBuffer) {
     val oldLimit = src.limit()
     val newLimit = if (src.remaining > internal.remaining) {

--- a/colossus/src/main/scala/colossus/core/WriteBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/WriteBuffer.scala
@@ -94,10 +94,12 @@ private[colossus] trait WriteBuffer extends KeyInterestManager {
 
   def isDataBuffered: Boolean = partialBuffer.isDefined
 
-  //TODO: This buffer size is probably fine, but either do some more
-  //experimentation or make it configurable.  Easier said than done as no config
-  //is passed into this trait right now
+  //all writes are initially written to this internal buffer.  The buffer is
+  //then drained at most once per event loop.  This ends up being much faster
+  //than attempting to directly write to the socket each time
   private val internal = DataBuffer(ByteBuffer.allocateDirect(internalBufferSize))
+
+  //copy as much data as possible from src into the internal buffer
   private def copyInternal(src: ByteBuffer) {
     val oldLimit = src.limit()
     val newLimit = if (src.remaining > internal.remaining) {

--- a/colossus/src/main/scala/colossus/core/WriteBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/WriteBuffer.scala
@@ -146,6 +146,7 @@ private[colossus] trait WriteBuffer extends KeyInterestManager {
       internal.data.flip //prepare for reading
     }
     val wrote = channelWrite(internal)
+    //println(s"wrote $wrote")
     _bytesSent += wrote
     if (internal.remaining == 0) {
       //hooray! we wrote all the data, now we can accept more

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -65,7 +65,9 @@ class ClientProxy(config: ClientConfig, system: IOSystem, handlerFactory: ActorR
       worker ! Disconnect(connectionId)
       context.become(dying)
     }
-    //case Worker.MessageDeliveryFailed   <--- add that in later
+    case m: Worker.MessageDeliveryFailed => {
+      println(s"received failed message delivery $m")
+    }
     case x => worker ! Message(connectionId, x)
   }
 

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -273,6 +273,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, config
       //don't allow any new requests, appear as if we're dead
       s.handler(Failure(new NotConnectedException("Not Connected")))
     } else if (isConnected || !failFast) {
+      println(s"PUSHING ${s.message}")
       val pushed = push(s.message, s.start){
         case OutputResult.Success         => sentBuffer.enqueue(s)
         case OutputResult.Failure(err)    => s.handler(Failure(err))

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -273,7 +273,6 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, config
       //don't allow any new requests, appear as if we're dead
       s.handler(Failure(new NotConnectedException("Not Connected")))
     } else if (isConnected || !failFast) {
-      println(s"PUSHING ${s.message}")
       val pushed = push(s.message, s.start){
         case OutputResult.Success         => sentBuffer.enqueue(s)
         case OutputResult.Failure(err)    => s.handler(Failure(err))

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -160,6 +160,7 @@ extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) with ServerCo
           case OutputResult.Success => {}
           case _ => println("dropped reply")
         }
+        checkGracefulDisconnect()
       }
       case other => {
         val promise = new SyncPromise(request)
@@ -196,6 +197,8 @@ extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) with ServerCo
   override def gracefulDisconnect() {
     pauseReads()
     disconnecting = true
+    //notice - checkGracefulDisconnect must NOT be called here, since this is called in the middle of processing a request, it would end up
+    //disconnecting before we have a change to finish processing and write the response
 
   }
 

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -131,6 +131,7 @@ extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) with ServerCo
 
   protected def processMessage(request: I) {
     numRequests += 1
+    val startTime = System.currentTimeMillis
     /**
      * Notice, if the request buffer is full we're still adding to it, but by skipping
      * processing of requests we can hope to alleviate overloading
@@ -153,9 +154,9 @@ extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) with ServerCo
           case Success(yay) => yay
           case Failure(err) => handleFailure(request, err)
         }
-        //val tags = tagDecorator.tagsFor(request, done)
-        //requests.hit(tags = tags)
-        //latency.add(tags = tags, value = (System.currentTimeMillis - done.creationTime).toInt)
+        val tags = tagDecorator.tagsFor(request, done)
+        requests.hit(tags = tags)
+        latency.add(tags = tags, value = (System.currentTimeMillis - startTime).toInt)
         push(done) {
           case OutputResult.Success => {}
           case _ => println("dropped reply")

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -85,16 +85,16 @@ extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) with ServerCo
 
   }
 
-  private val requestBuffer = collection.mutable.Queue[SyncPromise]()
+  private val requestBuffer = new java.util.LinkedList[SyncPromise]()
   private var numRequests = 0
 
   override def idleCheck(period: Duration) {
     super.idleCheck(period)
 
     val time = System.currentTimeMillis
-    while (requestBuffer.size > 0 && requestBuffer.head.isTimedOut(time)) {
+    while (requestBuffer.size > 0 && requestBuffer.peek.isTimedOut(time)) {
       //notice - completing the response will call checkBuffer which will write the error immediately
-      requestBuffer.head.complete(handleFailure(requestBuffer.head.request, new TimeoutError))
+      requestBuffer.peek.complete(handleFailure(requestBuffer.peek.request, new TimeoutError))
 
     }
   }
@@ -103,8 +103,8 @@ extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) with ServerCo
    * Pushes the completed responses down to the controller so they can be returned to the client.
    */
   private def checkBuffer() {
-    while (isConnected && requestBuffer.size > 0 && requestBuffer.head.isComplete) {
-      val done = requestBuffer.dequeue()
+    while (isConnected && requestBuffer.size > 0 && requestBuffer.peek.isComplete) {
+      val done = requestBuffer.remove()
       val comp = done.response
       val tags = tagDecorator.tagsFor(done.request, comp)
       requests.hit(tags = tags)
@@ -131,9 +131,6 @@ extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) with ServerCo
 
   protected def processMessage(request: I) {
     numRequests += 1
-    val promise = new SyncPromise(request)
-    requestBuffer.enqueue(promise)
-    concurrentRequests.increment()
     /**
      * Notice, if the request buffer is full we're still adding to it, but by skipping
      * processing of requests we can hope to alleviate overloading
@@ -149,10 +146,33 @@ extends Controller[I,O](codec, ControllerConfig(50, Duration.Inf)) with ServerCo
     } else {
       Callback.successful(handleFailure(request, new RequestBufferFullException))
     }
-    response.execute{
-      case Success(res) => promise.complete(res)
-      case Failure(err) => promise.complete(handleFailure(promise.request, err))
+    response match {
+      case ConstantCallback(v) if (requestBuffer.size == 0) => {
+        //println("const!")
+        val done = v match {
+          case Success(yay) => yay
+          case Failure(err) => handleFailure(request, err)
+        }
+        //val tags = tagDecorator.tagsFor(request, done)
+        //requests.hit(tags = tags)
+        //latency.add(tags = tags, value = (System.currentTimeMillis - done.creationTime).toInt)
+        push(done) {
+          case OutputResult.Success => {}
+          case _ => println("dropped reply")
+        }
+      }
+      case other => {
+        val promise = new SyncPromise(request)
+        requestBuffer.add(promise)
+        concurrentRequests.increment()
+        other.execute{
+          case Success(res) => promise.complete(res)
+          case Failure(err) => promise.complete(handleFailure(promise.request, err))
+        }
+
+      }
     }
+
   }
 
   private def handleFailure(request: I, reason: Throwable): O = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,7 @@ object ColossusBuild extends Build {
     organization := "com.tumblr",
     scalaVersion  := "2.11.6",
     crossScalaVersions := Seq("2.10.4", "2.11.6"),
-    version                   := "0.6.4-BENCH",
+    version                   := "0.6.4-BENCH2-SNAPSHOT",
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>
       val default = List(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,7 @@ object ColossusBuild extends Build {
     organization := "com.tumblr",
     scalaVersion  := "2.11.6",
     crossScalaVersions := Seq("2.10.4", "2.11.6"),
-    version                   := "0.6.3",
+    version                   := "0.6.4-BENCH",
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>
       val default = List(


### PR DESCRIPTION
This is a pretty large set of changes that result in significantly improved performance, especially with pipelined requests.

* Every connection now allocates its own `ByteBuffer` for writes.  This allows us to optimize such that every connection only performs at most one socket write per event loop iteration.  The buffer size right now is 64KB, so with many connections there is a significant increase in memory but its worth the improvement in throughput.  Going forward we can try to be smarter about using a pool or something.
* There is a new `ConstantCallback` which is now used when `Callback.successful` or `Callback.failed` are used.  The service layer pattern matches on these which in some cases lets it completely skip the request buffering process.
* Fixed a spot in the `InputController` where we were using recursion instead of a regular loop
* Fixed a bug that's been around since day 1 where a selection key with only the `OP_WRITE` interest would not be properly removed from the interest set iterator.  
* Fixed a bug where the connection handler for an `AsyncServiceClient` was attempting to bind to the worker twice.
* Added a new `BenchmarkService` example which is the optimized version of the service that we'll submit to the techempower benchmarks.

There is one other optimization I'm going to do, which will be to allow you to fully disable metrics (which actually has a much larger impact that we've previously thought), but I can do that in another PR.