### PR TITLE
making worker constructor private, new fakeExecutorWorkerRef

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -17,11 +17,24 @@ object FakeIOSystem {
     IOSystem(system.deadLetters, IOSystemConfig("FAKE", 0), MetricSystem.deadSystem, system)
   }
 
+  /**
+   * Returns a WorkerRef with a TestProbe as the underlying actor.  Returns the probe with the WorkerRef.
+   *
+   * Important: This WorkerRef's callbackExecutor does NOT work, use `fakeExecutorWorkerRef` instead
+   */
   def fakeWorkerRef(implicit system: ActorSystem): (TestProbe, WorkerRef) = {
     val probe = TestProbe()
     implicit val aref = probe.ref
     val ref = WorkerRef(0, new LocalCollection, probe.ref, apply())
     (probe, ref)
+  }
+
+  /**
+   * Returns a WorkerRef that is able to properly execute callbacks
+   */
+  def fakeExecutorWorkerRef(implicit system: ActorSystem): WorkerRef = {
+    val ex = testExecutor
+    WorkerRef(0, new LocalCollection, testExecutor.executor, FakeIOSystem())
   }
 
   def withManagerProbe()(implicit system: ActorSystem): (IOSystem, TestProbe) = {

--- a/colossus-testkit/src/test/scala/colossus/FakeIOSystemSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/FakeIOSystemSpec.scala
@@ -21,6 +21,16 @@ class FakeIOSystemSpec extends ColossusSpec with CallbackMatchers {
     }
   }
 
+  "fakeExecutorWorkerRef" must {
+    "execute a callback" in {
+      val worker = FakeIOSystem.fakeExecutorWorkerRef
+      import worker.callbackExecutor
+      val cb = Callback.fromFuture(Future{ 5 }).map{i => i + 1}
+      CallbackAwait.result(cb, 1.second) must equal(6)
+    }
+  }
+
+
 
       
 

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -90,7 +90,7 @@ case class ServerConfig(
  * @param system The IOSystem to which this Server belongs
  * @param serverStateAgent The current state of the Server.
  */
-case class ServerRef(config: ServerConfig, server: ActorRef, system: IOSystem, private val serverStateAgent : Agent[ServerState]) {
+case class ServerRef private[colossus] (config: ServerConfig, server: ActorRef, system: IOSystem, private val serverStateAgent : Agent[ServerState]) {
   def name = config.name
 
   def serverState = serverStateAgent.get()

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -37,7 +37,7 @@ case class WorkerConfig(
  * @param worker The ActorRef of the Worker
  * @param system The IOSystem to which this Worker belongs
  */
-case class WorkerRef(id: Int, metrics: LocalCollection, worker: ActorRef, system: IOSystem) {
+case class WorkerRef private[colossus](id: Int, metrics: LocalCollection, worker: ActorRef, system: IOSystem) {
   /**
    * Send this Worker a message
    * @param message The message to send


### PR DESCRIPTION
Having a fake CallbackExecutor is nice, but it's also good to be able to create `WorkerRef` objects that are fake, yet can still execute callbacks.