### PR TITLE
making the const parser return its value on endOfStream

### DIFF
--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -33,6 +33,13 @@ class CombinatorSuite extends WordSpec with MustMatchers{
       val d = data("12:abcdefghijklmn")
       parser.parse(d) must equal (Some(bstr("abcdefghijkl")))
     }
+    "const is const" in {
+      val d = data("abcdefg")
+      val parser = const(1)
+      parser.parse(d) must equal (Some(1))
+      parser.parse(d) must equal (Some(1))
+      parser.endOfStream() must equal (Some(1))
+    }
     "repeat" in {
       val parser = repeat(3, bytes(2))
       val d = data("abcdefgh")

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -263,7 +263,9 @@ object Combinators {
    * any data.  Useful when flatMapping parsers
    */
   def const[T](t: T): Parser[T] = new Parser[T] {
-    def parse(data: DataBuffer) = Some(t)
+    val result = Some(t)
+    def parse(data: DataBuffer) = result
+    override def endOfStream() = result
   }
 
   def literal(lit: ByteString): Parser[ByteString] = new Parser[ByteString] {


### PR DESCRIPTION
Allow parsers that match on endOfStream to play nice with parsers that just end on a parse.