### PR TITLE
Executing a callback sequence with an empty sequence succeeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+.idea/

--- a/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
@@ -77,13 +77,18 @@ class CallbackSpec extends ColossusSpec {
       value2 must equal(9)
       value3 must equal(16)
     }
+    "empty sequence" in {
+      var value1 = false
+      val emptySeq = Callback.sequence(List()).map{i => value1 = true }
+      emptySeq.execute()
+      value1 must equal(true)
+    }
     "successful" in {
       var value1 = 0
       val c = Callback.successful(5).map{i => value1 = i}
       c.execute()
       value1 must equal(5)
     }
-
     "failed" in {
       var value1 = 0
       val c = Callback.failed(new Exception("XXX")).map{i => value1 = i}

--- a/colossus/src/main/scala/colossus/service/Callback.scala
+++ b/colossus/src/main/scala/colossus/service/Callback.scala
@@ -240,8 +240,12 @@ object Callback {
     }
 
     def execute() {
-      callbacks.zipWithIndex.foreach{ case (cb,index) =>
-        cb.execute(result => finish(index, result))
+      if (callbacks.isEmpty) {
+        callback(Success(Nil))
+      } else {
+        callbacks.zipWithIndex.foreach {
+          case (cb, index) => cb.execute(result => finish(index, result))
+        }
       }
     }
   }


### PR DESCRIPTION
For issue: https://github.com/tumblr/colossus/issues/211

Fills in with `callback(Success(Nil))`

@DanSimon 