### PR TITLE
Specify metric system without supplying # of workers

### DIFF
--- a/colossus/src/main/scala/colossus/core/IOSystem.scala
+++ b/colossus/src/main/scala/colossus/core/IOSystem.scala
@@ -28,6 +28,11 @@ object IOSystem {
 
   def apply(name: String, numWorkers: Int)(implicit system: ActorSystem): IOSystem = apply(name, numWorkers, MetricSystem.deadSystem)
 
+  def apply(name: String, metrics: MetricSystem)(implicit  system: ActorSystem): IOSystem = {
+    val numWorkers = Runtime.getRuntime.availableProcessors()
+    apply(name, numWorkers, metrics)
+  }
+
   def apply(name: String = "iosystem", numWorkers: Option[Int] = None)(implicit sys: ActorSystem = ActorSystem(name)): IOSystem = {
     val workers = numWorkers.getOrElse (Runtime.getRuntime.availableProcessors())
     val metrics = MetricSystem(MetricAddress.Root / name)


### PR DESCRIPTION
Added a new apply method with name & metric system only, # of workers default to available processors.