### PR TITLE
fixing memory leak with failed connections, other changes

### DIFF
--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -336,6 +336,14 @@ object DisconnectCause {
     def tagString = "closed"
     def logString = "Closed by remote host"
   }
+
+  /**
+   * A client connection failed to connect
+   */
+  case class ConnectFailed(error: Throwable) extends DisconnectError {
+    def tagString = "connectfailed"
+    def logString = "Failed to Connect"
+  }
 }
 
 

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -90,14 +90,9 @@ trait ServerConnectionHandler extends ConnectionHandler {
 
 
 /**
- * ClientConnectionHandler is a trait meant to be used with outgoing connections.  It provides a call back function
- * connectionFailed, which is called when a connection to an external system could not be established.
+ * ClientConnectionHandler is a trait meant to be used with outgoing connections.  
  */
 trait ClientConnectionHandler extends ConnectionHandler {
-  /**
-   * Event handler for when a connection failed.
-   */
-  def connectionFailed()
 
   /**
    * If no data is either sent or received in this amount of time, the connection is closed.  Defaults to Duration.Inf but handlers can override it

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,7 @@ object ColossusBuild extends Build {
     organization := "com.tumblr",
     scalaVersion  := "2.11.6",
     crossScalaVersions := Seq("2.10.4", "2.11.6"),
-    version                   := "0.6.4-RC2",
+    version                   := "0.6.4-RC2-DAN1-SNAPSHOT",
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>
       val default = List(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -16,7 +16,7 @@ object ColossusBuild extends Build {
     organization := "com.tumblr",
     scalaVersion  := "2.11.6",
     crossScalaVersions := Seq("2.10.4", "2.11.6"),
-    version                   := "0.6.4-RC2-DAN1-SNAPSHOT",
+    version                   := "0.6.4-RC3-SNAPSHOT",
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>
       val default = List(


### PR DESCRIPTION
When a client connection failed to connect, the connection was never removed from the worker's map of live connections.  This was never noticed because the memory overhead was very low, but now that every connection allocates its own buffer it's more apparent.

This fix resulted in some further refactoring about how client connection failures are handled

* adding new `ConnectFailed` `DisconnectError`
* removing `connectionFailed` method from `ClientConnectionHandler`
* minor logging fixups