### PR TITLE
adding EOS support for pair parser

### DIFF
--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -174,6 +174,14 @@ class CombinatorSuite extends WordSpec with MustMatchers{
       parser.parse(DataBuffer(d2)) must equal(None)
       parser.endOfStream() must equal(Some(ByteString(4,5,6)))
     }
+
+    "EOS with pairing" in {
+      val parser = bytes(3) ~> repeatUntilEOS(bytes(2))
+      val d1 = ByteString("aaabbccdd")
+      val expected = Some(Vector(ByteString("bb"), ByteString("cc"), ByteString("dd")))
+      parser.parse(DataBuffer(d1)) must equal(None)
+      parser.endOfStream() must equal(expected)
+    }
       
 
 

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -209,6 +209,18 @@ object Combinators {
             }
           }
         }
+        override def endOfStream(): Option[~[T,B]] = {
+          if (!donea.isDefined) {
+            donea = a.endOfStream()
+          }
+          if (!doneb.isDefined) {
+            doneb = b.endOfStream()
+          }
+          (donea, doneb) match {
+            case (Some(ra), Some(rb)) => Some(new ~(ra, rb))
+            case _ => None
+          }
+        }
       }
     }
     def andThen[B](b: Parser[B]): Parser[~[T,B]] = this.~(b)


### PR DESCRIPTION
If `endOfStream`was called on any parser using one of the `~`, `~>`, or `<~` parsers, the end of stream signal was not propagated.
