### PR TITLE
fixing bug with respecting sentBuffer max size

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
@@ -63,6 +63,14 @@ class MockWriteBuffer(val maxWriteSize: Int, handler: Option[ConnectionHandler] 
     assert(call == data, s"expected '${data.utf8String}', got '${call.utf8String}'")
   }
 
+  /**
+   * Expect exactly `num` writes
+   */
+  def expectNumWrites(num: Int) {
+    assert(writeCalls.size == num, s"expected exactly $num writes, but ${writeCalls.size} writes occurred")
+    writeCalls.clear()
+  }
+
   def expectOneWrite(data: ByteString) {
     assert(writeCalls.size == 1, s"expected exactly one write, but ${writeCalls.size} writes occurred")
     expectWrite(data)


### PR DESCRIPTION
Service clients have two configurable buffer sizes:

* `sentBufferSize` - how many sent requests can be currently waiting for a response
* `pendingBufferSize` - how many requests can be waiting to be sent.

The expected behavior is that when the sent buffer maxes out, subsequent calls to `send` don't send the requests but instead add them to the pending buffer.  Once responses for the currently sent requests start coming in, the client dequeues requests from the pending buffer and sends them until the sent buffer fills up again.

However a bug caused the client to totally ignore the max sent buffer size when dequeuing from the pending buffer, so the entire pending buffer is then sent.

this PR fixes that bug and ensures that the sent buffer max size is respected even when draining the pending buffer.