### PR TITLE
Adding exception handling into WriteBuffer

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/WriteBufferSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WriteBufferSpec.scala
@@ -124,6 +124,17 @@ class WriteBufferSpec extends ColossusSpec {
       b.write(data("asf")) must equal(Failed)
     }
 
+    "properly catch CancelledKeyException on key set interest in writes" in {
+      class FailFakeWriter extends FakeWriteBuffer(10) {
+        override def setKeyInterest() {
+          throw new java.nio.channels.CancelledKeyException()
+        }
+      }
+
+      val b = new FailFakeWriter
+      b.write(data("asdfsadf")) must equal(Failed)
+    }
+
 
 
   }

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -295,7 +295,6 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
     val time = System.currentTimeMillis
     while (waitingToSend.size > 0 && waitingToSend.peek.isTimedOut(time)) {
       val expired = waitingToSend.removeFirst()
-      println(s"$time : $expired : $outputState : $queueSize : $state : $writesEnabled")
       expired.postWrite(OutputResult.Cancelled(new RequestTimeoutException))
     }
   }

--- a/colossus/src/main/scala/colossus/core/WriteBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/WriteBuffer.scala
@@ -147,7 +147,7 @@ private[colossus] trait WriteBuffer extends KeyInterestManager {
       }
     } catch {
       case t: CancelledKeyException => {
-        //no cleanup is required since the connection is closed for good
+        //no cleanup is required since the connection is closed for good, 
         Failed
       }
     }
@@ -168,7 +168,9 @@ private[colossus] trait WriteBuffer extends KeyInterestManager {
   }
 
   /**
-   * Drain the internal buffer and perform the actual write to the socket.
+   * Drain the internal buffer and perform the actual write to the socket.  This
+   * is called by the event loop whenever the buffer is subscribed to the
+   * OP_WRITE key interest.
    */
   def handleWrite() {
     if (!drainingInternal) {


### PR DESCRIPTION
If someone attempts to write to a closed connection, the call to `WriteBuffer.write` will currently throw the resulting `CancelledKeyException`, whereas it should just be returning a `Failure` state.  This is something that used to be here, but fell out during the rewrite that's in 0.6.4.

Also added some more docs, including explaining why we intentionally don't catch the same exception in `handleWrite`