### PR TITLE
making compiledGlobalTags a function to always get latest tags

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/StatReporter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/StatReporter.scala
@@ -43,7 +43,7 @@ class MetricReporter(intervalAggregator : ActorRef, config: MetricReporterConfig
 
   private var reporters = Seq[ActorRef]()
 
-  private val compiledGlobalTags = {
+  private def compiledGlobalTags() = {
     val userTags = globalTags.map{_.tags}.getOrElse(Map())
     val added = if (includeHostInGlobalTags) Map("host" -> localHostname) else Map()
     userTags ++ added
@@ -52,7 +52,7 @@ class MetricReporter(intervalAggregator : ActorRef, config: MetricReporterConfig
   def receive = {
 
     case ReportMetrics(m) => {
-      val s = MetricSender.Send(filterMetrics(m), compiledGlobalTags, System.currentTimeMillis())
+      val s = MetricSender.Send(filterMetrics(m), compiledGlobalTags(), System.currentTimeMillis())
       sendToReporters(s)
     }
     case ResetSender => {


### PR DESCRIPTION
The point of a `TagGenerator` is to generate a set of tags applied to every metric.  These tags are not immutable and may change during the course of an application's life.  Currently though, we only get the tags once when the reporter actor is created, and never fetch them again.  This fixes that.