### PR TITLE
Service Server Output backpressure

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
@@ -47,7 +47,7 @@ class MockWriteBuffer(val maxWriteSize: Int, handler: Option[ConnectionHandler] 
       bytesAvailable -= raw.remaining
       val data = ByteString(raw.takeAll)
       writeCalls.enqueue(data)
-      if (bytesAvailable < 0) {
+      if (bytesAvailable <= 0) {
         bytesAvailable = 0
         WriteStatus.Partial
       } else {

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
@@ -80,17 +80,6 @@ class MockWriteBuffer(val maxWriteSize: Int, handler: Option[ConnectionHandler] 
     assert(writeCalls.size == 0, s"Expected no write, but data '${writeCalls.head.utf8String}' was written")
   }
 
-  /*
-  def expectBufferCleared() {
-    assert(bufferCleared == true, "Expected write buffer to be cleared, but it was no")
-    bufferCleared = false
-  }
-
-  def expectBufferNotCleared() {
-    assert(bufferCleared == false, "Expected write buffer to not be cleared, but it was")
-  }
-  */
-
   def withExpectedWrite(f: ByteString => Unit) {
     assert(writeCalls.size > 0, "expected write, but no write occurred")
     val call = writeCalls.dequeue()

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -90,6 +90,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
   private val waitingToSend = new java.util.LinkedList[QueuedItem]
 
   def queueSize = waitingToSend.size()
+  def outputQueueFull: Boolean = queueSize == controllerConfig.outputBufferSize
 
   private[controller] def outputOnConnected() {
     _writesEnabled = true

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -103,6 +103,7 @@ extends Controller[I,O](codec, ControllerConfig(config.requestBufferSize, Durati
   }
 
   private val requestBuffer = new java.util.LinkedList[SyncPromise]()
+  def currentRequestBufferSize = requestBuffer.size
   private var numRequests = 0
 
   override def idleCheck(period: Duration) {


### PR DESCRIPTION
This fixes a bug where responses could get dropped if a service server connection's output buffer backs up.  Now we don't drop any responses and instead keep the corresponding request/response in the request buffer until the output buffer opens up.