### PR TITLE
run publishSigned for the correct scala version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ env:
 before_install:
 - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_aa756c3a201c_key -iv $encrypted_aa756c3a201c_iv -in secrets.tar.enc -out secrets.tar -d; tar xvf secrets.tar; fi
 after_success:
-- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then  sbt publishSigned; fi
+- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then  sbt ++$TRAVIS_SCALA_VERSION publishSigned; fi
 - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then bash <(curl -s https://codecov.io/bash); elif [ "$TRAVIS_BRANCH" = "master" ]; then bash <(curl -s https://codecov.io/bash); fi


### PR DESCRIPTION
Right now travis is publishing artifacts for scala 2.11 in both the 2.10 and 2.11 builds.  This adds the scala version into the sbt command to publish the artifacts.