### PR TITLE
fixing a bug where data in internal buffer could be overwritten

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/WriteBufferSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WriteBufferSpec.scala
@@ -74,6 +74,7 @@ class WriteBufferSpec extends ColossusSpec {
       b.handleWrite()
       b.expectChannelWrite("90")
       b.writeReadyEnabled must equal(false)
+      b.expectClearCalled()
     }
 
     "properly drain buffer when socket is full" in {
@@ -86,6 +87,20 @@ class WriteBufferSpec extends ColossusSpec {
       b.handleWrite()
       b.expectChannelWrite("56")
       b.writeReadyEnabled must equal(false)
+      b.expectClearCalled()
+    }
+
+    "add to partial buffer when drainingInternal is true" in {
+      val b = new FakeWriteBuffer(4, 2)
+      b.write(data("1234")) must equal(Complete)
+      b.handleWrite()
+      b.expectChannelWrite("12")
+      b.write(data("56")) must equal(Partial)
+      b.handleWrite()
+      b.expectChannelWrite("34")
+      b.handleWrite()
+      b.expectChannelWrite("56")
+      b.expectClearCalled()
     }
 
     "reject more writes while draining when buffer filled" in {


### PR DESCRIPTION
If the internal buffer is in the process of being written out to the socket, and no PartialBuffer is set, a subsequent call to `write` could overwrite the data being written out.

This would occur under the following circumstances:

1. The service is under heavy load 
2. Several request/response message are written to a connection in a single event-loop iteration.  The internal buffer is not filled so the Partial buffer remains empty
3.  When the WriteBuffer tries to write the data to the socket, the socket only accepts part of the write.
4.  On the next event loop iteration, an additional request/response is written to the socket.  Since Partial buffer is empty, the data is copied into the internal buffer, overwriting the data that wasn't fully written out before.