### PR TITLE
response headers are bytestrings

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -35,9 +35,9 @@ object BenchmarkService {
     }
   }
   val response          = ByteString("Hello, World!")
-  val plaintextHeader   = ("Content-Type", "text/plain")
-  val jsonHeader        = ("Content-Type", "application/json")
-  val serverHeader      = ("Server", "Colossus")
+  val plaintextHeader   = HttpResponseHeader("Content-Type", "text/plain")
+  val jsonHeader        = HttpResponseHeader("Content-Type", "application/json")
+  val serverHeader      = HttpResponseHeader("Server", "Colossus")
 
 
   def start(port: Int)(implicit io: IOSystem) {
@@ -56,10 +56,10 @@ object BenchmarkService {
     val server = Service.serve[Http](serverConfig, serviceConfig) { context =>
 
       ///the ??? is filled in almost immediately
-      var dateHeader = ("Date", "???")
+      var dateHeader = HttpResponseHeader("Date", "???")
 
       context.receive {
-        case ts: String => dateHeader = ("Date", ts)
+        case ts: String => dateHeader = HttpResponseHeader("Date", ts)
       }
       
       context.handle { connection =>

--- a/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
@@ -53,7 +53,7 @@ abstract class HttpServiceSpec extends ServiceSpec[Http] {
   def testGet(url: String, expectedBody: String) {
     val req = get(url)
     val expected = HttpResponse(
-      HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector(("content-length" -> expectedBody.length.toString))), 
+      HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector(HttpResponseHeader("content-length" ,expectedBody.length.toString))), 
       Some(ByteString(expectedBody))
     )
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpResponseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpResponseSpec.scala
@@ -46,7 +46,7 @@ class HttpResponseSpec extends ColossusSpec with TryValues with OptionValues wit
       val payload = "look ma, no hands!"
 
       val expected = StreamingHttpResponse(
-        HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector("content-length"->"18")), 
+        HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector(HttpResponseHeader("content-length", "18"))), 
         Some(Source.one(DataBuffer(ByteString("test conversion"))))
       )
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
@@ -17,6 +17,8 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
   import DecodedResult.Static
 
+  import HttpResponseHeader.Conversions._
+
   "HttpResponseParser" must {
 
     "parse a basic response" in {

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/StreamingHttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/StreamingHttpResponseParserSpec.scala
@@ -15,6 +15,7 @@ class StreamingHttpResponseParserSpec extends ColossusSpec with MustMatchers wit
   implicit val cbe = FakeIOSystem.testExecutor
 
   implicit val duration = 1.second
+  import HttpResponseHeader.Conversions._
 
   "StreamingHttpResponseParser" must {
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -82,9 +82,9 @@ trait HttpHeaderUtils {
    * Be aware that lacking this header may or may not be a valid request,
    * depending if the "transfer-encoding" header is set to "chunked"
    */
-  def contentLength: Option[Int] = headers.collectFirst{case (HttpHeaders.ContentLength, l) => l.toInt}
+  lazy val contentLength: Option[Int] = headers.collectFirst{case (HttpHeaders.ContentLength, l) => l.toInt}
 
-  def transferEncoding : TransferEncoding = singleHeader(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
+  lazy val transferEncoding : TransferEncoding = singleHeader(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
 }
 
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -82,9 +82,9 @@ trait HttpHeaderUtils {
    * Be aware that lacking this header may or may not be a valid request,
    * depending if the "transfer-encoding" header is set to "chunked"
    */
-  val contentLength: Option[Int] = headers.collectFirst{case (HttpHeaders.ContentLength, l) => l.toInt}
+  def contentLength: Option[Int] = headers.collectFirst{case (HttpHeaders.ContentLength, l) => l.toInt}
 
-  val transferEncoding : TransferEncoding = singleHeader(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
+  def transferEncoding : TransferEncoding = singleHeader(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
 }
 
 
@@ -159,8 +159,8 @@ case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, heade
   import HttpHead._
   import HttpHeaders._
 
-  val (host, port, path, query) = parseURL(url)
-  val parameters = parseParameters(query)
+  lazy val (host, port, path, query) = parseURL(url)
+  lazy val parameters = parseParameters(query)
 
 
   def withHeader(header: String, value: String): HttpHead = {

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -8,6 +8,7 @@ case class HttpRequest(head: HttpHead, entity: Option[ByteString]) {
   import HttpCodes._
 
   def respond(code: HttpCode, data: String, headers: List[(String, String)] = Nil) = {
+    import HttpResponseHeader.Conversions._
     HttpResponse(HttpResponseHead(version, code, headers.toVector), Some(ByteString(data)))
   }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -64,7 +64,9 @@ object HttpResponseParser  {
   }
     
 
-  protected def head: Parser[HttpResponseHead] = firstLine ~ headers >> {case version ~ code ~ headers => HttpResponseHead(version, code, headers)}
+  protected def head: Parser[HttpResponseHead] = firstLine ~ headers >> {case version ~ code ~ headers => 
+    HttpResponseHead(version, code, headers.map{case (k,v) => HttpResponseHeader(k,v)})
+  }
 
   protected def firstLine = version ~ code 
 


### PR DESCRIPTION
This significantly improves the performance of writing http responses with several headers.  I plan to do the same thing with request headers, but that'll have to wait for another PR to get merged.

This does introduce a breaking API change, but the migration is pretty easy.  Currently to add headers in the construction of a response, you do:

```scala
HttpResponse(headers = Vector(("name" -> "value")), //...
```

now it's just

```scala
HttpResponse(headers = Vector(HttpResponseHeader("name", "value")), //...
``` 

Doing `.withHeader` on a response is unaffected.