### PR TITLE
new faster http request head parser

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -30,7 +30,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "accept" -> "*/*",
           "authorization" -> "Basic XXX",
           "accept-encoding" -> "gzip, deflate"
-        )
+        ).reverse
       ), None)        
       
       parser.parse(DataBuffer(ByteString(req))).toList must equal(List(expected))
@@ -49,7 +49,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "accept" -> "*/*",
           "authorization" -> "Basic XXX",
           "accept-encoding" -> "gzip, deflate"
-        )
+        ).reverse
       ), None)        
 
       (0 until req.length).foreach{splitIndex =>
@@ -77,7 +77,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "host" -> "api.foo.bar:444",
           "accept" ->  "*/*",
           "content-length" -> len.toString
-        )
+        ).reverse
       ), Some(body))        
 
       val parser = requestParser
@@ -95,7 +95,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "host" -> "api.foo.bar:444",
           "accept" -> "*/*",
           "content-length" -> "0"
-        )
+        ).reverse
       ), None)        
 
       val parser = requestParser

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -5,6 +5,7 @@ import akka.util.ByteString
 import com.github.nscala_time.time.Imports._
 
 import scala.collection.immutable.HashMap
+import parsing.ParseException
 
 
 sealed abstract class HttpMethod(val name: String)
@@ -22,7 +23,7 @@ object HttpMethod {
   val methods: List[HttpMethod] = List(Get, Post, Put, Delete, Head, Options, Trace, Connect, Patch)
 
   def apply(str: String): HttpMethod = methods.find{_.name == str.toUpperCase}.getOrElse(
-    throw new HttpParsingException(s"Invalid http method $str")
+    throw new ParseException(s"Invalid http method $str")
   )
 }
 
@@ -35,7 +36,7 @@ object HttpVersion {
   case object `1.1` extends HttpVersion("1.1")
 
   def apply(str: String): HttpVersion = {
-    if (str == "HTTP/1.1") `1.1` else if (str=="HTTP/1.0") `1.0` else throw new parsing.ParseException(s"Invalid http version '$str'")
+    if (str == "HTTP/1.1") `1.1` else if (str=="HTTP/1.0") `1.0` else throw new ParseException(s"Invalid http version '$str'")
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
@@ -7,17 +7,17 @@ import core.DataBuffer
 import parsing._
 import DataSize._
 import HttpParse._
+import Combinators._
 
 object HttpRequestParser {
-  import Combinators._
 
   val DefaultMaxSize: DataSize = 1.MB
 
   def apply(size: DataSize = DefaultMaxSize) = maxSize(size, httpRequest)
 
-  protected def httpRequest: Parser[HttpRequest] = httpHead |> {head => 
-    head.singleHeader(HttpHeaders.TransferEncoding) match { 
-      case None | Some("identity") => head.contentLength match {
+  protected def httpRequest: Parser[HttpRequest] = httpHead |> {case HeadResult(head, contentLength, transferEncoding) => 
+    transferEncoding match { 
+      case None | Some("identity") => contentLength match {
         case Some(0) | None => const(HttpRequest(head, None))
         case Some(n) => bytes(n) >> {body => HttpRequest(head, Some(body))}
       }
@@ -25,13 +25,152 @@ object HttpRequestParser {
     } 
   }
 
-  protected def httpHead = firstline ~ headers >> {case method ~ path ~ version ~ headers => 
-    HttpHead(HttpMethod(method), path, HttpVersion(version), headers)
-  }
+  protected def httpHead = new HttpHeadParser
   
-  protected def firstline  = stringUntil(' ', minSize = Some(1), allowWhiteSpace = false) ~ 
-    stringUntil(' ', minSize = Some(1), allowWhiteSpace = false) ~ 
-    stringUntil('\r', minSize = Some(1), allowWhiteSpace = false) <~ byte
+}
+
+case class HeadResult(head: HttpHead, contentLength: Option[Int], transferEncoding: Option[String] )
+
+/**
+ * This parser is optimized to reduce the number of operations per character
+ * read
+ */
+class HttpHeadParser extends Parser[HeadResult]{
+
+  class RBuilder {
+    var method: String = ""
+    var path: String = ""
+    var version: String = ""
+    var headers: List[(String, String)] = Nil
+    var contentLength: Option[Int] = None
+    var transferEncoding: Option[String] = None
+    var body: Option[ByteString] = None
+
+    def addHeader(rawName: String, rawValue: String) {
+      val name = rawName.toLowerCase
+      val value = rawValue.trim
+      headers = (name, value) :: headers
+      if (name == HttpHeaders.ContentLength) {
+        contentLength = Some(value.toInt)
+      } else if (name == HttpHeaders.TransferEncoding) {
+        transferEncoding = Some(value)
+      }
+    }
+
+    def build: HeadResult = {
+      val r = HeadResult(HttpHead(HttpMethod(method), path, HttpVersion(version), headers), contentLength, transferEncoding)
+      reset()
+      r
+    }
+
+    def reset() {
+      headers = Nil
+      contentLength = None
+      transferEncoding = None
+      body = None
+    }
+  }
+  var requestBuilder = new RBuilder
+  var headerState = 0 //incremented when parsing \r\n\r\n
+
+
+  trait MiniParser {
+    def parse(c: Char)
+    def end()
+  }
+
+  class FirstLineParser extends MiniParser {
+    val STATE_METHOD  = 0
+    val STATE_PATH    = 1
+    val STATE_VERSION = 2
+    var state = STATE_METHOD
+    val builder = new StringBuilder
+    def parse(c: Char) {
+      if (c == ' ') {
+        val res = builder.toString
+        builder.setLength(0)
+        state match {
+          case STATE_METHOD => {
+            requestBuilder.method = res
+            state = STATE_PATH
+          }
+          case STATE_PATH   => {
+            requestBuilder.path = res
+            state = STATE_VERSION
+          }
+          case _ => {
+            throw new ParseException("invalid content in header first line")
+          }
+        }
+      } else {
+        builder.append(c)
+      }
+    }
+    def end() {
+      val res = builder.toString
+      builder.setLength(0)
+      requestBuilder.version = res
+      state = STATE_METHOD
+    }
+  }
+
+  class HeaderParser extends MiniParser {
+    val STATE_KEY   = 0
+    val STATE_VALUE = 1
+    var state = STATE_KEY
+    val builder = new StringBuilder
+    var builtKey = ""
+    def parse(c: Char) {
+      if (c == ':' && state == STATE_KEY) {
+        builtKey = builder.toString
+        builder.setLength(0)
+        state = STATE_VALUE
+      } else {
+        builder.append(c)
+      }
+    }
+    def end() {
+      requestBuilder.addHeader(builtKey, builder.toString)
+      builder.setLength(0)
+      state = STATE_KEY
+    }
+  }
+
+  val fparser = new FirstLineParser
+  val hparser = new HeaderParser
+        
+  var currentParser: MiniParser = fparser
+
+
+  def parse(d: DataBuffer): Option[HeadResult] = {
+    while (d.hasUnreadData) {
+      val b = d.next.toChar
+      if (b == '\r') {
+        headerState += 1
+      } else if (b == '\n') {
+        headerState += 1
+        if (headerState == 2) {
+          //finished reading in a line
+          currentParser.end()
+          if (currentParser == fparser) {
+            currentParser = hparser
+          }
+        } else if (headerState == 4) {
+          //two consecutive \r\n indicates the end of the request head
+          currentParser = fparser
+          headerState = 0
+          return Some(requestBuilder.build)
+        }
+      } else {
+        currentParser.parse(b)
+        headerState = 0
+      }
+    }
+    None
+
+  }
+
+
 }
 
 

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -11,8 +11,6 @@ import scala.concurrent.ExecutionContext
 
 package object http {
 
-  class HttpParsingException(message: String) extends Exception(message)
-
   class InvalidRequestException(message: String) extends Exception(message)
 
   trait BaseHttp extends CodecDSL {


### PR DESCRIPTION
This significantly improves the performance of parsing HTTP requests.  Unfortunately I had to drop the parser combinators in parsing the head, though they're still being used in attaching the head to the body.  There's probably room to make this code a bit more functional but this should serve as a benchmark in terms of performance.

The new parser is more line-based and is designed to minimize the number of branches per input character.  It basically uses two sub-parsers to parse the first line and headers of the request head.  Furthermore, it parses `transfer-encoding`and `content-length` in the same pass as parsing all the headers.

All existing tests pass, but I think I might add a couple more to verify correctness before merging this in.