### PR TITLE
fixing exception-catching holes in ConstantCallback

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
@@ -369,6 +369,36 @@ class CallbackSpec extends ColossusSpec {
 
   }
 
+  "ConstantCallback" must {
+
+    "catch exception thrown during mapTry" in {
+      ConstantCallback(Success(4)).mapTry{
+        case _ => throw new Exception("Fail")
+      }.execute{
+        case Success(_) => fail("this should never occur")
+        case Failure(t) => {}
+      }
+    }
+
+    "catch exception thrown during map" in {
+      ConstantCallback(Success(4)).map{i =>
+        throw new Exception("Fail")
+      }.execute{
+        case Success(_) => fail("this should never occur")
+        case Failure(t) => {}
+      }
+    }
+
+    "catch exception thrown during flatMap" in {
+      ConstantCallback(Success(4)).flatMap{i =>
+        throw new Exception("Fail")
+      }.execute{
+        case Success(_) => fail("this should never occur")
+        case Failure(t) => {}
+      }
+    }
+  }
+
 
   "CallbackPromise" must {
     "execute when it gets a value" in {


### PR DESCRIPTION
This fixes a few places where if an exception was thrown when composing a constant callback, the exception wouldn't be properly captured.  This is extremely unlikely in the wild since you don't generally compose on a `Callback.successful`, but it popped up in testing something else.