### PR TITLE
Connection: close means close the connection

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -38,7 +38,79 @@ class HttpSpec extends WordSpec with MustMatchers{
 
       request.bytes.utf8String must equal(expected)
     }
-      
+
+    "want to close HTTP/1.0 requests without the Connection header" in {
+      val head = HttpHead(
+        version = HttpVersion.`1.0`,
+        url = "/hello",
+        method = HttpMethod.Post,
+        headers = List("foo" -> "bar")
+      )
+      val request = HttpRequest(head, None)
+
+      request.head.persistConnection must equal(false)
+    }
+
+    "want to close HTTP/1.0 requests without keep-alive in the Connection header" in {
+      val head = HttpHead(
+        version = HttpVersion.`1.0`,
+        url = "/hello",
+        method = HttpMethod.Post,
+        headers = List("connection" -> "bar")
+      )
+      val request = HttpRequest(head, None)
+
+      request.head.persistConnection must equal(false)
+    }
+
+    "want to persist HTTP/1.0 requests with keep-alive in the Connection header" in {
+      val head = HttpHead(
+        version = HttpVersion.`1.0`,
+        url = "/hello",
+        method = HttpMethod.Post,
+        headers = List("connection" -> "keep-alive")
+      )
+      val request = HttpRequest(head, None)
+
+      request.head.persistConnection must equal(true)
+    }
+
+    "want to persist HTTP/1.1 requests without the Connection header" in {
+      val head = HttpHead(
+        version = HttpVersion.`1.1`,
+        url = "/hello",
+        method = HttpMethod.Post,
+        headers = List("foo" -> "bar")
+      )
+      val request = HttpRequest(head, None)
+
+      request.head.persistConnection must equal(true)
+    }
+
+    "want to persist HTTP/1.1 requests without close in the Connection header" in {
+      val head = HttpHead(
+        version = HttpVersion.`1.1`,
+        url = "/hello",
+        method = HttpMethod.Post,
+        headers = List("connection" -> "bar")
+      )
+      val request = HttpRequest(head, None)
+
+      request.head.persistConnection must equal(true)
+    }
+
+    "want to close HTTP/1.1 requests with close in the Connection header" in {
+      val head = HttpHead(
+        version = HttpVersion.`1.1`,
+        url = "/hello",
+        method = HttpMethod.Post,
+        headers = List("connection" -> "close")
+      )
+      val request = HttpRequest(head, None)
+
+      request.head.persistConnection must equal(false)
+    }
+
   }
 
   "http response" must {

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -60,13 +60,7 @@ package object http {
   extends BasicServiceHandler[D](config, worker, provider, initializer) {
 
     override def processRequest(input: D#Input): Callback[D#Output] = super.processRequest(input).map{response =>
-      if ((
-          input.head.version == HttpVersion.`1.1` &&
-          input.head.singleHeader("Connection").contains("close")
-        ) || response.head.version == HttpVersion.`1.0`
-      ) {
-        gracefulDisconnect()
-      }
+      if(!input.head.persistConnection) gracefulDisconnect()
       response
     }
     

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -60,7 +60,11 @@ package object http {
   extends BasicServiceHandler[D](config, worker, provider, initializer) {
 
     override def processRequest(input: D#Input): Callback[D#Output] = super.processRequest(input).map{response =>
-      if (response.head.version == HttpVersion.`1.0`) {
+      if ((
+          input.head.version == HttpVersion.`1.1` &&
+          input.head.singleHeader("Connection").contains("close")
+        ) || response.head.version == HttpVersion.`1.0`
+      ) {
         gracefulDisconnect()
       }
       response


### PR DESCRIPTION
Support for the HTTP/1.1 `Connection: close` header ([spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.10)). Not a lot going on here other than checking that the request was HTTP/1.1 and that the `Connection` header is actually set to `close`.