### PR TITLE
Remove unused dispatchers

### DIFF
--- a/colossus/src/main/resources/application.conf
+++ b/colossus/src/main/resources/application.conf
@@ -1,36 +1,12 @@
-  stats-dispatcher {
-    type = Dispatcher
-    executor = "fork-join-executor"
-    fork-join-executor {
-      parallelism-min = 2
-      parallelism-factor = 2.0
-      parallelism-max = 2
-    }
-    thread-pool-executor {
-      core-pool-size-min = 2
-      core-pool-size-factor = 2.0
-      core-pool-size-max = 2
-    }
-    throughput = 100
-  }
+server-dispatcher {
+  executor = "thread-pool-executor"
+  type = PinnedDispatcher
+}
 
-  server-dispatcher {
-    executor = "thread-pool-executor"
-    type = PinnedDispatcher
-
-  }
-  router-dispatcher {
-    executor = "thread-pool-executor"
-    type = PinnedDispatcher
-
-  }
-  opentsdb-dispatcher {
-    executor = "thread-pool-executor"
-    type = PinnedDispatcher
-
-  }
+opentsdb-dispatcher {
+  executor = "thread-pool-executor"
+  type = PinnedDispatcher
+}
 
 akka.log-dead-letters-during-shutdown = false
 akka.log-dead-letters = 0
-
-


### PR DESCRIPTION
It seems that only server/opentsdb dispatchers are used so I thought I'd clean up this file. 