### PR TITLE
fixing bug where reported metrics lagged by one tick interval

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/ActorMetrics.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/ActorMetrics.scala
@@ -21,8 +21,7 @@ trait ActorMetrics extends Actor with ActorLogging {
       case InvalidEvent => log.error(s"Invalid event $m")
     }
     case Tick(v, interval) => {
-      val agg = metrics.aggregate(interval)
-      metrics.tick(interval)
+      val agg = metrics.tick(interval)
       sender() ! Tock(agg, v)
     }
   }


### PR DESCRIPTION
Fixes #268 

Basically ticked collectors like rates and histograms were reporting metrics off by 1 interval (and dropping the very first interval of data) due to the fact that two operations, ticking the collector and getting the data, were happening in the wrong order.  Those metrics always return data from the last tick period (to always show the last fully collected period), but since the tick was happening after the collection, it was actually returning data from the previous tick interval, not the one that just ended.

Turns out these two operations were implemented in separate methods that didn't actually need to be separate, so now they're merged and in the right order.