### PR TITLE
Adding timeout for OpenTsdbSender

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/OpenTsdbSender.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/OpenTsdbSender.scala
@@ -92,12 +92,9 @@ class OpenTsdbSenderActor(val host: String, val port: Int, timeout: FiniteDurati
 
 }
 
-case class OpenTsdbSender(host: String, port: Int, timeout: Option[FiniteDuration]) extends MetricSender {
-  val name = "tsdb"
-  def props = Props(classOf[OpenTsdbSenderActor], host, port, timeout.getOrElse(OpenTsdbSender.defaultTimeout)).withDispatcher("opentsdb-dispatcher")
-}
-
-object OpenTsdbSender {
+case class OpenTsdbSender(host: String, port: Int) extends MetricSender {
   val defaultTimeout: FiniteDuration = 1.minute
+  val name = "tsdb"
+  def props = Props(classOf[OpenTsdbSenderActor], host, port, defaultTimeout).withDispatcher("opentsdb-dispatcher")
 }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/senders/OpenTsdbSender.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/senders/OpenTsdbSender.scala
@@ -4,36 +4,73 @@ import akka.actor._
 import colossus.metrics.senders.MetricsLogger
 import scala.concurrent.duration._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 import java.net._
 
+class OpenTsdbWatchdog(socket: Socket, timeout: FiniteDuration) extends Actor with ActorLogging {
+
+  import OpenTsdbWatchdog._
+
+  private var lastPing = 0
+
+  def receive = idle
+
+  def idle: Receive = {
+    case StartSend => {
+      val now = System.currentTimeMillis
+      context.system.scheduler.scheduleOnce(timeout, self, CheckTimeout(now))
+      context.become(timing(now))
+    }
+  }
+
+  def timing(start: Long): Receive = {
+    case EndSend => context.become(idle)
+    case CheckTimeout(time) if (time == start) => {
+      log.warning("TSDB sender has timed out, force closing socket")
+      socket.close()
+      self ! PoisonPill
+    }
+  }
+}
+
+object OpenTsdbWatchdog {
+  case object StartSend
+  case object EndSend
+  case class CheckTimeout(time: Long)
+}
+
 //TODO : OH jeez don't use raw socket
-class OpenTsdbSenderActor(val host: String, val port: Int) extends Actor with ActorLogging with MetricsLogger{
+class OpenTsdbSenderActor(val host: String, val port: Int, timeout: FiniteDuration) extends Actor with ActorLogging with MetricsLogger{
+  import OpenTsdbWatchdog._
 
   val address = new InetSocketAddress(host, port)
-  val timeout = 500
 
   case object Initialize
 
-  import context.dispatcher
-
   val socket = new Socket
+
+  val watchdog = context.actorOf(Props(classOf[OpenTsdbWatchdog], socket, timeout))
 
   override def postStop(): Unit = {
     socket.close()
+    watchdog ! PoisonPill
   }
 
   def put(stats: Seq[MetricFragment], ts: Long) {
+    watchdog ! StartSend
     val os = socket.getOutputStream
     val now = ts / 1000
     stats.foreach{stat => os.write(OpenTsdbFormatter.format(stat, now).toCharArray.map{_.toByte})}
     os.flush()
     log.info(s"Sent ${stats.size} stats to OpenTSDB")
+    watchdog ! EndSend
   }
 
   def receive = {
     case Initialize => {
       log.info("Initializing new stats sender")
-      socket.connect(address, timeout)
+      socket.connect(address, 500)
       context.become(accepting)
     }
   }
@@ -55,8 +92,12 @@ class OpenTsdbSenderActor(val host: String, val port: Int) extends Actor with Ac
 
 }
 
-case class OpenTsdbSender(host: String, port: Int) extends MetricSender {
+case class OpenTsdbSender(host: String, port: Int, timeout: Option[FiniteDuration]) extends MetricSender {
   val name = "tsdb"
-  def props = Props(classOf[OpenTsdbSenderActor], host, port).withDispatcher("opentsdb-dispatcher")
+  def props = Props(classOf[OpenTsdbSenderActor], host, port, timeout.getOrElse(OpenTsdbSender.defaultTimeout)).withDispatcher("opentsdb-dispatcher")
+}
+
+object OpenTsdbSender {
+  val defaultTimeout: FiniteDuration = 1.minute
 }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object ColossusBuild extends Build {
     organization := "com.tumblr",
     scalaVersion  := "2.11.7",
     crossScalaVersions := Seq("2.10.4", "2.11.7"),
-    version                   := "0.6.8-M1",
+    version                   := "0.6.8-SNAPSHOT",
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>
       val default = List(


### PR DESCRIPTION
This prevents blocking forever on trying to send data to tsdb.

We can't make the timeout configurable without breaking binary compatibility, so we'll just hard-code it now for a minute and schedule configurability (along with possibly a bigger refactoring) for 0.7