### PR TITLE
fixing bug where exception thrown in connection close kills worker

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
@@ -2,6 +2,7 @@ package colossus
 package core
 
 import testkit._
+import java.nio.channels.SocketChannel
 import org.scalatest.mock.MockitoSugar
 import org.mockito.Mockito._
 
@@ -11,6 +12,33 @@ import akka.util.ByteString
 import scala.concurrent.duration._
 
 class ConnectionSpec extends ColossusSpec with MockitoSugar{
+
+  "Connection" must {
+
+    "catch exceptions thrown in handler's connectionTerminated when connection closed" in {
+      val channel = SocketChannel.open()
+      val key     = mock[java.nio.channels.SelectionKey]
+      val handler = new BasicSyncHandler with ClientConnectionHandler {
+
+        override def connectionClosed(cause: DisconnectCause) {
+          println("here")
+          throw new Exception("x_x")
+        }
+
+        override def connectionLost(error: DisconnectError) {
+          throw new Exception("o_O")
+        }
+
+        def receivedData(data: DataBuffer){}
+      }
+      val con = new ClientConnection(1, key, channel, handler)
+
+      //this test fails if this throws an exception
+      con.close(DisconnectCause.Closed)
+      con.close(DisconnectCause.Disconnect)
+    }
+
+  }
 
 
   "ClientConnection" must {

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -217,7 +217,18 @@ private[core] abstract class Connection(val id: Long, val key: SelectionKey, _ch
    */
   def close(cause : DisconnectCause) {
     channel.close()
-    handler.connectionTerminated(cause)
+    try {
+      handler.connectionTerminated(cause)
+    } catch {
+      case t: Throwable => {
+        //Notice that it's possible that an exception from somewhere else can
+        //end up getting thrown here.  For example, if closing this connection
+        //ends up terminating a pipe, the pipe's receive may throw an exception
+        //here.  Since we're already closing the connection there's nothing else
+        //to do here if this occurs
+        //TODO: pending logging overhaul, this should log a warning
+      }
+    }
   }
 
 


### PR DESCRIPTION
If a connection handler (or any code executed from within) throws an exception, this will currently kill the worker.  This can eventually lead to a connection leak if while the dead worker is closing all its connections in `postStop`, another handle also throws an exception.