### PR TITLE
Support for infinite timeouts in the ServiceServer

### DIFF
--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -89,7 +89,7 @@ extends Controller[I,O](codec, ControllerConfig(config.requestBufferSize, Durati
   case class SyncPromise(request: I) {
     val creationTime = System.currentTimeMillis
 
-    def isTimedOut(time: Long) = !isComplete && (time - creationTime) > requestTimeout.toMillis
+    def isTimedOut(time: Long) = !isComplete && requestTimeout.isFinite && (time - creationTime) > requestTimeout.toMillis
 
     private var _response: Option[O] = None
     def isComplete = _response.isDefined


### PR DESCRIPTION
Hard to run out of time when the timeout is infinite. Infinite timeouts, such as are in the example project, will break the server without this little change.