### PR TITLE
don't throw exception when gracefulDisconnect it call while disconnecting

### DIFF
--- a/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
@@ -61,6 +61,16 @@ class OutputControllerSpec extends ColossusSpec {
       controller.testPush(message2){_ must equal (OutputResult.Cancelled)}
 
     }
+
+    "allow multiple calls to gracefulDisconnect" in {
+      val (endpoint, controller) = createController()
+      controller.testGracefulDisconnect()
+      //this used to throw an exception
+      controller.testGracefulDisconnect()
+    }
+
+
+      
   }
 
 

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -129,6 +129,8 @@ extends InputController[Input, Output] with OutputController[Input, Output] {
   /**
    * stops reading from the connection and accepting new writes, but waits for
    * pending/ongoing write operations to complete before disconnecting
+   *
+   * This is an idempotent operation
    */
   def gracefulDisconnect() {
     state match {
@@ -136,7 +138,7 @@ extends InputController[Input, Output] with OutputController[Input, Output] {
         state = Disconnecting(e)
       }
       case Disconnecting(e) => {}
-      case other => throw new InvalidConnectionStateException(other)
+      case NotConnected => {}
     }
     inputGracefulDisconnect()
     outputGracefulDisconnect()


### PR DESCRIPTION
Right now if `gracefulDisconnect` is called after the connection has already disconnected (which can happen when requests finish processing after the connection is terminated), we end up throwing an exception.  Really instead we should just ignore the second call, so this does that.