### PR TITLE
overhauling http query parameters, fixing parsing issues

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -238,6 +238,28 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     "handle empty value" in {
       h("/x?a=&b=c") must equal(p("a" -> "", "b" -> "c"))
     }
+
+    "getFirst" in {
+      val p = h("/x?a=111&a=222&b=333")
+      p.getFirst("a") must equal(Some("111"))
+      p.getFirst("b") must equal(Some("333"))
+      p.getFirst("c") must equal(None)
+    }
+
+    "getAll" in {
+      val p = h("/x?a=111&a=222&b=333")
+      p.getAll("a") must equal(Seq("111", "222"))
+      p.getAll("b") must equal(Seq("333"))
+      p.getAll("c") must equal(Seq())
+    }
+
+    "contains" in {
+      val p = h("/x?a=111&a=222&b=333")
+      p.contains("a") must equal(true)
+      p.contains("b") must equal(true)
+      p.contains("c") must equal(false)
+    }
+      
     
   }
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -178,19 +178,21 @@ object Connection {
 
 case class QueryParameters(parameters: Seq[(String, String)]) extends AnyVal{
 
-  def apply(key: String) = singleValue(key).get
+  def apply(key: String) = getFirst(key).get
 
   /**
-   * Get the value of a query string parameter when only at most one value is expected
+   * Get the value of a query string parameter when only at most one value is
+   * expected.  If there are multiple instances of the parameter then only the
+   * value of the first is returned
    **/
-  def singleValue(key: String): Option[String] = parameters.collectFirst{case (k,v) if k == key => v}
+  def getFirst(key: String): Option[String] = parameters.collectFirst{case (k,v) if k == key => v}
 
   /**
    * Get the values of all instances of key
    *
    * This is for urls like http://foo.com?bar=val1&bar=val2&bar=val3, which is a valid url
    */
-  def multiValue(key: String) : Seq[String] = parameters.collect{case (k,v) if k == key => v}
+  def getAll(key: String) : Seq[String] = parameters.collect{case (k,v) if k == key => v}
 
   /**
    * return true if at least one parameter's key matches the given key


### PR DESCRIPTION
Fixes #288 .  The new parser correctly handles url encoding inside query parameters.  Also switches from a map to a seq of tuples to handle multiple parameters with the same name (which is allowed) and wrapped the values in a case class with some convenience methods.

I also added a test that shows #279 appears to be invalid.