### PR TITLE
Build artifacts from master/develop branches and all release tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ env:
   - secure: KOt7FSG8FckBl49tfassG/fQKFMSAU/Xaz83UvEY0oAnFBbBSuSR/OkUd6NAHxFy/RotFsVoAxed8NgL8Nh7nsut3clXmhXuxhWsIOpR+q4wWrqA7KG+Fw4Q3SUsrICKGm92LnVsTeHKQ57qZ3mQaV/j/srmc+mrbi2kIYdmpFk=
   - secure: JjPl0W+YTRiANGnmPilLM0lZywkoH26YdQ5C9KrdMwbb92dxxR2D+qEbxVlH36sjOual3txeETTbmCbcTTdQCkbrND7+hSaHNx4vmj05P8HT5TwgQXmp9U4Sp7BapRezRS5KCr12fYaoaDE5xS3Anq/F5ErJDVv5x2HoXhmXEdo=
 before_install:
-- [[ "$TRAVIS_TAG" =~ "^v*$" || (( "$TRAVIS_BRANCH" = "master" || "$TRAVIS_BRANCH" = "develop" ) && "$TRAVIS_PULL_REQUEST" = "false")  ]]
-- SHOULD_PUBLISH=$?
+- if [[ "$TRAVIS_TAG" =~ "^v*$" || (( "$TRAVIS_BRANCH" = "master" || "$TRAVIS_BRANCH" = "develop" ) && "$TRAVIS_PULL_REQUEST" = "false")  ]] ; then SHOULD_PUBLISH=0; fi
 - if (( $SHOULD_PUBLISH == 0)) ; then openssl aes-256-cbc -K $encrypted_aa756c3a201c_key -iv $encrypted_aa756c3a201c_iv -in secrets.tar.enc -out secrets.tar -d; tar xvf secrets.tar; fi
 after_success:
 - if (( $SHOULD_PUBLISH == 0)) ; then  sbt ++$TRAVIS_SCALA_VERSION publishSigned; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
   - secure: KOt7FSG8FckBl49tfassG/fQKFMSAU/Xaz83UvEY0oAnFBbBSuSR/OkUd6NAHxFy/RotFsVoAxed8NgL8Nh7nsut3clXmhXuxhWsIOpR+q4wWrqA7KG+Fw4Q3SUsrICKGm92LnVsTeHKQ57qZ3mQaV/j/srmc+mrbi2kIYdmpFk=
   - secure: JjPl0W+YTRiANGnmPilLM0lZywkoH26YdQ5C9KrdMwbb92dxxR2D+qEbxVlH36sjOual3txeETTbmCbcTTdQCkbrND7+hSaHNx4vmj05P8HT5TwgQXmp9U4Sp7BapRezRS5KCr12fYaoaDE5xS3Anq/F5ErJDVv5x2HoXhmXEdo=
 before_install:
-- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then openssl aes-256-cbc -K $encrypted_aa756c3a201c_key -iv $encrypted_aa756c3a201c_iv -in secrets.tar.enc -out secrets.tar -d; tar xvf secrets.tar; fi
+- if [ "$TRAVIS_TAG" =~ "^release-*$" ]; then openssl aes-256-cbc -K $encrypted_aa756c3a201c_key -iv $encrypted_aa756c3a201c_iv -in secrets.tar.enc -out secrets.tar -d; tar xvf secrets.tar; fi
 after_success:
-- if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then  sbt ++$TRAVIS_SCALA_VERSION publishSigned; fi
+- if [ "$TRAVIS_TAG" =~ "^release-*$" ]; then  sbt ++$TRAVIS_SCALA_VERSION publishSigned; fi
 - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then bash <(curl -s https://codecov.io/bash); elif [ "$TRAVIS_BRANCH" = "master" ]; then bash <(curl -s https://codecov.io/bash); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ env:
   - secure: KOt7FSG8FckBl49tfassG/fQKFMSAU/Xaz83UvEY0oAnFBbBSuSR/OkUd6NAHxFy/RotFsVoAxed8NgL8Nh7nsut3clXmhXuxhWsIOpR+q4wWrqA7KG+Fw4Q3SUsrICKGm92LnVsTeHKQ57qZ3mQaV/j/srmc+mrbi2kIYdmpFk=
   - secure: JjPl0W+YTRiANGnmPilLM0lZywkoH26YdQ5C9KrdMwbb92dxxR2D+qEbxVlH36sjOual3txeETTbmCbcTTdQCkbrND7+hSaHNx4vmj05P8HT5TwgQXmp9U4Sp7BapRezRS5KCr12fYaoaDE5xS3Anq/F5ErJDVv5x2HoXhmXEdo=
 before_install:
-- if [ "$TRAVIS_TAG" =~ "^release-*$" ]; then openssl aes-256-cbc -K $encrypted_aa756c3a201c_key -iv $encrypted_aa756c3a201c_iv -in secrets.tar.enc -out secrets.tar -d; tar xvf secrets.tar; fi
+- [[ "$TRAVIS_TAG" =~ "^v*$" || (( "$TRAVIS_BRANCH" = "master" || "$TRAVIS_BRANCH" = "develop" ) && "$TRAVIS_PULL_REQUEST" = "false")  ]]
+- SHOULD_PUBLISH=$?
+- if (( $SHOULD_PUBLISH == 0)) ; then openssl aes-256-cbc -K $encrypted_aa756c3a201c_key -iv $encrypted_aa756c3a201c_iv -in secrets.tar.enc -out secrets.tar -d; tar xvf secrets.tar; fi
 after_success:
-- if [ "$TRAVIS_TAG" =~ "^release-*$" ]; then  sbt ++$TRAVIS_SCALA_VERSION publishSigned; fi
+- if (( $SHOULD_PUBLISH == 0)) ; then  sbt ++$TRAVIS_SCALA_VERSION publishSigned; fi
 - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then bash <(curl -s https://codecov.io/bash); elif [ "$TRAVIS_BRANCH" = "master" ]; then bash <(curl -s https://codecov.io/bash); fi


### PR DESCRIPTION
Right now artifacts are only built off of master, which is a problem when it comes to publishing releases as well as building artifacts from multiple branches.  This is especially important since I with to publish a M1 release of 0.7.0 and currently can't do so from travis.

The plan going forward will be this:

* "master" and "develop" will be our snapshot branches.  Master is for ongoing work on 0.6.x and develop is for 0.7.0, so as soon as we release 0.7.0 we'll go back to just master.
* To publish a stable release (whether it's a milestone, candidate, or final release), we'll cut a branch just to change the version, the create a tag off that branch.  This way master and develop are always on "x.x.x-SNAPSHOT" versions and we never accidentally trigger a stable build from one of them.
* any tag that starts with "v*", for example "v0.7.0-M1" will be considered a release tag and have artifacts published.

I'm open to other ideas, but I think this will work.