### PR TITLE
Connection Handler hot swapping : Phase 1

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/ChatExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/ChatExample.scala
@@ -123,9 +123,9 @@ class ChatHandler(broadcaster: ActorRef) extends Controller[String, ChatMessage]
     }
   }
 
-  def shutdownRequest(){
+  override def shutdownRequest(){
     push(Status("The server is shutting down, goodbye")){_ => ()}
-    gracefulDisconnect()
+    super.shutdownRequest()
   }
 
 

--- a/colossus-examples/src/main/scala/colossus-examples/EchoExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/EchoExample.scala
@@ -18,8 +18,6 @@ class EchoHandler extends BasicSyncHandler with ServerConnectionHandler {
     endpoint.requestWrite()
   }
 
-  def shutdownRequest(){}
-
   override def readyForData(buffer: DataOutBuffer) = {
     buffer.write(bytes)
     MoreDataResult.Complete

--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -13,6 +13,8 @@ import akka.testkit.CallingThreadDispatcher
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.concurrent.duration._
 
+case class FakeWorker(probe: TestProbe, worker: WorkerRef)
+
 object FakeIOSystem {
   def apply()(implicit system: ActorSystem): IOSystem = {
     IOSystem(system.deadLetters, IOSystemConfig("FAKE", 0), MetricSystem.deadSystem, system)
@@ -28,6 +30,11 @@ object FakeIOSystem {
     implicit val aref = probe.ref
     val ref = WorkerRef(0, probe.ref, apply())
     (probe, ref)
+  }
+  //use this for new tests
+  def fakeWorker(implicit system: ActorSystem) = {
+    val (p, w) = fakeWorkerRef
+    FakeWorker(p, w)
   }
 
   /**

--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -5,6 +5,7 @@ import core._
 import metrics._
 import service._
 
+import akka.agent.Agent
 import akka.actor._
 import akka.testkit.TestProbe
 import akka.testkit.CallingThreadDispatcher
@@ -26,6 +27,21 @@ object FakeIOSystem {
     val probe = TestProbe()
     implicit val aref = probe.ref
     val ref = WorkerRef(0, probe.ref, apply())
+    (probe, ref)
+  }
+
+  /**
+   * Returns a ServerRef representing a server in the Bound state
+   */
+  def fakeServerRef(implicit system: ActorSystem): (TestProbe, ServerRef) = {
+    import system.dispatcher
+    val probe = TestProbe()
+    val config = ServerConfig(
+      "/foo",
+      (s,w) => ???,
+      ServerSettings(987)
+    )
+    val ref = ServerRef(config, probe.ref, apply(), Agent(ServerState(ConnectionVolumeState.Normal, ServerStatus.Bound)))
     (probe, ref)
   }
 

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
@@ -46,6 +46,8 @@ trait MockChannelActions extends ChannelActions {
     connection_status = ConnectionStatus.NotConnected
   }
 
+  def channelHost() = java.net.InetAddress.getLocalHost()
+
   /*
   def completeDisconnect() {
     connection_status = ConnectionStatus.NotConnected

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
@@ -52,6 +52,10 @@ trait MockChannelActions extends ChannelActions {
   }
   */
 
+
+  //legacy method
+  def disconnectCalled = status == ConnectionStatus.NotConnected
+
   def clearBuffer(): ByteString = {
     println("clearing buffer")
     val lastsize = bytesAvailable
@@ -99,7 +103,7 @@ trait MockChannelActions extends ChannelActions {
 }
 
 class MockWriteBuffer(val maxWriteSize: Int) extends WriteBuffer with MockChannelActions {
-  def completeDisconnect(){}
+  def completeDisconnect(){channelClose()}
 
   def testWrite(d: DataBuffer): WriteStatus = write(d)
 }

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
@@ -8,16 +8,18 @@ import akka.util.{ByteString, ByteStringBuilder}
 /**
  * if a handler is passed, the buffer will call the handler's readyForData, and it will call it's own handleWrite if interestRW is true
  */
-class MockWriteBuffer(val maxWriteSize: Int) extends WriteBuffer {
+trait MockChannelActions extends ChannelActions {
+
+  def maxWriteSize: Int
+
+
   protected var bytesAvailable = maxWriteSize
   private var writeCalls = collection.mutable.Queue[ByteString]()
   protected var connection_status: ConnectionStatus = ConnectionStatus.Connected
 
-  def connectionStatus = connection_status
+  def status = connection_status
 
   private var bufferCleared = false
-
-  protected def setKeyInterest(){}
 
   private val writtenData = new ByteStringBuilder
 
@@ -35,9 +37,20 @@ class MockWriteBuffer(val maxWriteSize: Int) extends WriteBuffer {
 
   }
 
+
+  def finishConnect(){}
+
+  def keyInterestOps(ops: Int) {}
+
+  def channelClose() {
+    connection_status = ConnectionStatus.NotConnected
+  }
+
+  /*
   def completeDisconnect() {
     connection_status = ConnectionStatus.NotConnected
   }
+  */
 
   def clearBuffer(): ByteString = {
     println("clearing buffer")
@@ -83,4 +96,10 @@ class MockWriteBuffer(val maxWriteSize: Int) extends WriteBuffer {
     
 
     
+}
+
+class MockWriteBuffer(val maxWriteSize: Int) extends WriteBuffer with MockChannelActions {
+  def completeDisconnect(){}
+
+  def testWrite(d: DataBuffer): WriteStatus = write(d)
 }

--- a/colossus-testkit/src/test/scala/colossus/MockWriteBufferSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/MockWriteBufferSpec.scala
@@ -14,32 +14,32 @@ class MockWriteBufferSpec extends WordSpec with MustMatchers{
 
     "write" in {
       val m = new MockWriteBuffer(10)
-      m.write(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Complete)
+      m.testWrite(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Complete)
 
       m.expectOneWrite(ByteString("abcd"))
     }
 
     "return partial when exceeds size" in {
       val m = new MockWriteBuffer(2)
-      m.write(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
+      m.testWrite(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
       m.expectOneWrite(ByteString("ab"))
     }
 
     "return zero when full" in {
       val m = new MockWriteBuffer(2)
-      m.write(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
-      m.write(DataBuffer(ByteString("1234"))) must equal(WriteStatus.Zero)
+      m.testWrite(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
+      m.testWrite(DataBuffer(ByteString("1234"))) must equal(WriteStatus.Zero)
       m.expectOneWrite(ByteString("ab"))
       m.expectNoWrite()
     }
 
     "clear buffer" in {
       val m = new MockWriteBuffer(2)
-      m.write(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
+      m.testWrite(DataBuffer(ByteString("abcd"))) must equal(WriteStatus.Partial)
       m.expectOneWrite(ByteString("ab"))
       m.clearBuffer()
       m.continueWrite() must equal(true)
-      m.write(DataBuffer(ByteString("1234"))) must equal(WriteStatus.Partial)
+      m.testWrite(DataBuffer(ByteString("1234"))) must equal(WriteStatus.Partial)
       m.expectOneWrite(ByteString("cd"))
     }
 

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -26,7 +26,6 @@ class EchoHandler extends BasicSyncHandler with ServerConnectionHandler {
   }
       
 
-  def shutdownRequest() {}
 }
 
 object RawProtocol {

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -78,11 +78,12 @@ class TestController(dataBufferSize: Int, processor: TestInput => Unit) extends 
 }
 
 object TestController {
-  def createController(outputBufferSize: Int = 100, dataBufferSize: Int = 100, processor: TestInput => Unit = x => ())(implicit system: ActorSystem): (MockWriteEndpoint, TestController) = {
+  def createController(outputBufferSize: Int = 100, dataBufferSize: Int = 100, processor: TestInput => Unit = x => ())(implicit system: ActorSystem): (MockConnection, TestController) = {
     val controller = new TestController(dataBufferSize, processor)
     val (probe, worker) = FakeIOSystem.fakeWorkerRef
+    val (probe, server) = FakeIOSystem.fakeServerRef
     controller.setBind(1, worker)
-    val endpoint = new MockWriteEndpoint(outputBufferSize, probe, Some(controller))
+    val endpoint = new MockConnection.server(outputBufferSize, probe, controller, server)
     controller.connected(endpoint)
     (endpoint, controller)
   }

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -51,7 +51,7 @@ class PushPromise {
 
 }
 
-class TestController(dataBufferSize: Int, processor: TestInput => Unit) extends Controller[TestInput, TestOutput](new TestCodec, ControllerConfig(4, dataBufferSize, 50.milliseconds)) {
+class TestController(dataBufferSize: Int, processor: TestInput => Unit) extends Controller[TestInput, TestOutput](new TestCodec, ControllerConfig(4, dataBufferSize, 50.milliseconds)) with ServerConnectionHandler {
 
   def receivedMessage(message: Any,sender: akka.actor.ActorRef): Unit = ???
 
@@ -80,13 +80,10 @@ class TestController(dataBufferSize: Int, processor: TestInput => Unit) extends 
 object TestController {
   def createController(outputBufferSize: Int = 100, dataBufferSize: Int = 100, processor: TestInput => Unit = x => ())(implicit system: ActorSystem): (MockConnection, TestController) = {
     val controller = new TestController(dataBufferSize, processor)
-    val (probe, worker) = FakeIOSystem.fakeWorkerRef
-    val (probe, server) = FakeIOSystem.fakeServerRef
-    controller.setBind(1, worker)
-    val endpoint = new MockConnection.server(outputBufferSize, probe, controller, server)
+    val endpoint = MockConnection.server(controller, outputBufferSize)
     controller.connected(endpoint)
     (endpoint, controller)
   }
 
-  def createController(processor: TestInput => Unit)(implicit system: ActorSystem): (MockWriteEndpoint, TestController) = createController(100, 100, processor)
+  def createController(processor: TestInput => Unit)(implicit system: ActorSystem): (MockConnection, TestController) = createController(100, 100, processor)
 }

--- a/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
@@ -82,13 +82,13 @@ class OutputControllerSpec extends ColossusSpec {
         controller.testGracefulDisconnect()
       }
       endpoint.expectOneWrite(data.take(endpoint.maxWriteSize))
-      endpoint.disconnectCalled must equal(false)
+      endpoint.workerProbe.expectNoMsg(100.milliseconds)
       endpoint.clearBuffer()
       endpoint.iterate({})
       //these occur as separate writes because the first comes from the partial buffer, the second from the controller
       endpoint.expectWrite(data.drop(endpoint.maxWriteSize))
       endpoint.expectWrite(data2)
-      endpoint.disconnectCalled must equal(true)  
+      endpoint.workerProbe.expectMsg(100.milliseconds, WorkerCommand.Disconnect(controller.id.get))
     }
 
     "timeout queued messages that haven't been sent" in {

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -64,10 +64,12 @@ class ConnectionHandlerSpec extends ColossusSpec {
         if (sendBind) probe ! "BOUND"
       }
       override def onUnbind() {
+        println("UNBOUND")
         if (sendUnbind) probe ! "UNBOUND"
       }
 
       override def connected(endpoint: WriteEndpoint) {
+        println("CONNECTED")
         if (disconnect) endpoint.disconnect()
       }
 
@@ -109,7 +111,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
       }
     }
 
-    "automatically unbind on disrupted connection" in {
+    "automatically unbind on disrupted connection" taggedAs(org.scalatest.Tag("test")) in {
       val probe = TestProbe()
       withIOSystem{ implicit io =>
         val server = Service.become[Raw]("test", TEST_PORT){case x => x}
@@ -120,7 +122,8 @@ class ConnectionHandlerSpec extends ColossusSpec {
           probe.expectMsg(500.milliseconds, "BOUND")
         }
         end(server)
-        probe.expectMsg(500.milliseconds, "UNBOUND")
+        println("server ENDED")
+        probe.expectMsg(5000.milliseconds, "UNBOUND")
       }
 
     }

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -25,7 +25,6 @@ class ConnectionHandlerSpec extends ColossusSpec {
           probe.ref ! "BOUND"
         }
 
-        def shutdownRequest(){}
 
         def receivedData(data: DataBuffer) {}
       }
@@ -47,7 +46,6 @@ class ConnectionHandlerSpec extends ColossusSpec {
           println(s"Terminated: $cause")
         }
         def receivedData(data: DataBuffer){}
-        def shutdownRequest(){}
       }
       withIOSystemAndServer(Delegator.basic(() => new MyHandler)){ (io, server) => {
           val c = TestClient(io, TEST_PORT, connectionAttempts = PollingDuration.NoRetry)

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionSpec.scala
@@ -15,6 +15,25 @@ class ConnectionSpec extends ColossusSpec with MockitoSugar{
 
   "Connection" must {
 
+    "call handler.shutdownRequest during become" in {
+      val handler = mock[ServerConnectionHandler]
+      val con = MockConnection.server(handler)
+      verify(handler, never()).shutdownRequest()
+      con.become(throw new Exception("If this is thrown, the connection tried to instantiate the handler too early"))
+      verify(handler).shutdownRequest()
+    }
+
+    "not set shutdown action of lower priority" in {
+      import ShutdownAction._
+      val con = MockConnection.server(mock[ServerConnectionHandler])
+      con.setShutdownAction(DefaultDisconnect) must equal(true)
+      con.setShutdownAction(Become(() => ???))  must equal(true)
+      con.setShutdownAction(DefaultDisconnect) must equal(false)
+      con.setShutdownAction(Disconnect) must equal(true)
+      con.setShutdownAction(DefaultDisconnect) must equal(false)
+      con.setShutdownAction(Become(() => ???))  must equal(false)
+    }
+
     "catch exceptions thrown in handler's connectionTerminated when connection closed" in {
       val handler = new BasicSyncHandler with ClientConnectionHandler {
 

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -167,7 +167,7 @@ class ServerSpec extends ColossusSpec {
         val probe = TestProbe()
         class MyHandler extends BasicSyncHandler with ServerConnectionHandler {
           def receivedData(data: DataBuffer){}
-          def shutdownRequest() {probe.ref ! "SHUTDOWN"}
+          override def shutdownRequest() {probe.ref ! "SHUTDOWN"}
           override def connectionTerminated(cause: DisconnectCause) {
             probe.ref ! "TERMINATED"
           }
@@ -186,7 +186,6 @@ class ServerSpec extends ColossusSpec {
       "immediately terminate when last open connection closes" in {
         class MyHandler extends BasicSyncHandler with ServerConnectionHandler {
           def receivedData(data: DataBuffer){}
-          def shutdownRequest() {endpoint.disconnect()}
         }
         val config = ServerConfig(
           name = "/test",

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -94,10 +94,11 @@ class ServiceServerSpec extends ColossusSpec {
       t.service.gracefulDisconnect()
       t.endpoint.readsEnabled must equal(false)
       t.endpoint.status must equal(ConnectionStatus.Connected)
+      t.endpoint.workerProbe.expectNoMsg(100.milliseconds)
       promises(0).success(ByteString("BBBB"))
       t.endpoint.iterate()
       t.endpoint.expectOneWrite(ByteString("BBBB"))
-      t.endpoint.status must equal(ConnectionStatus.NotConnected)
+      t.endpoint.workerProbe.expectMsg(100.milliseconds, WorkerCommand.Disconnect(t.service.id.get))
     }
 
     "handle backpressure from output controller" in {

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -40,15 +40,15 @@ class ServiceServerSpec extends ColossusSpec {
     def testCanPush = canPush //expose protected method
   }
 
-  case class ServiceTest(service: FakeService, endpoint: MockWriteEndpoint, workerProbe: TestProbe)
+  case class ServiceTest(service: FakeService, endpoint: MockConnection, workerProbe: TestProbe)
 
   def fakeService(handler: ByteString => Callback[ByteString] = x => Callback.successful(x)): ServiceTest = {
-    val (probe, worker) = FakeIOSystem.fakeWorkerRef
-    val service = new FakeService(handler, worker)
-    service.setBind(1, worker)
-    val endpoint = new MockWriteEndpoint(10, probe, Some(service)) 
+    val fw = FakeIOSystem.fakeWorker
+    val service = new FakeService(handler, fw.worker)
+    service.setBind(1, fw.worker)
+    val endpoint = MockConnection.server(service)
     service.connected(endpoint)
-    ServiceTest(service, endpoint, probe)
+    ServiceTest(service, endpoint, fw.probe)
   }
 
   "ServiceServer" must {

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -128,6 +128,10 @@ extends InputController[Input, Output] with OutputController[Input, Output] {
     }
   }
 
+  def shutdownRequest() {
+    gracefulDisconnect()
+  }
+  
   /**
    * stops reading from the connection and accepting new writes, but waits for
    * pending/ongoing write operations to complete before disconnecting

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -83,6 +83,7 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
 
   private[controller] def inputOnConnected() {
     _readsEnabled = true
+    resumeReads()
     inputState = Decoding
   }
 

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -280,12 +280,10 @@ abstract class Connection(val id: Long, initialHandler: ConnectionHandler, val w
 
 
   def disconnect() {
-    println("BEGINNING DISCONNECT")
     super.gracefulDisconnect()
   }
 
   def completeDisconnect() {
-    println("COMPLETE DISCONNECT")
     worker.worker ! WorkerCommand.Disconnect(id)
   }
 

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -154,6 +154,9 @@ trait BasicSyncHandler extends ConnectionHandler {
   def receivedMessage(message: Any, sender: ActorRef){}
   def readyForData(out: encoding.DataOutBuffer): MoreDataResult = MoreDataResult.Complete
   def idleCheck(period: Duration){}
+  def shutdownRequest (){
+    endpoint.completeShutdown()
+  }
 
   //this is the only method you have to implement
   //def receivedData(data: DataBuffer)

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -79,22 +79,20 @@ trait ConnectionHandler extends WorkerItem {
    * @param period the frequency at which this method is called.  Currently this is hardcoded to `WorkerManager.IdleCheckFrequency`, but may become application dependent in the future.
    */
   def idleCheck(period: Duration)
+
+  /**
+   * the connection handler should begin its graceful shutdown procedure.  For
+   * both servers and clients this can be triggered either by a call to
+   * gracefulDisconnect or to become.  For ServerConnectionHandlers this can
+   * also occur when the Server begins shutting down.
+   */
+  def shutdownRequest()
 }
 
 /**
  * Mixin containing events just for server connection handlers
  */
-trait ServerConnectionHandler extends ConnectionHandler {
-
-  /**
-   * The server is beginning to shutdown and is signaling to the connection
-   * that it should cleanup and terminate.  This gives the connection time to
-   * gracefully shutdown, however eventually the server will timeout and
-   * forcefully close the connection
-   */
-  def shutdownRequest()
-
-}
+trait ServerConnectionHandler extends ConnectionHandler {}
 
 
 /**

--- a/colossus/src/main/scala/colossus/core/ConnectionSnapshot.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionSnapshot.scala
@@ -8,7 +8,6 @@ import java.net.InetAddress
  * with the Metrics library and ConnectionPageRenderer.
  * @param domain The domain of this Connection
  * @param host The host of this Connection
- * @param port The port of this Connection
  * @param id The id of this Connection
  * @param timeOpen The amount of time this Connection has been open
  * @param readIdle milliseconds since the last read activity on the connection
@@ -19,7 +18,6 @@ import java.net.InetAddress
 case class ConnectionSnapshot(
   domain: String, //either a server name or client
   host: InetAddress, //this is not a string because looking up the hostname takes time
-  port: Int,
   id: Long,
   timeOpen: Long = 0,
   readIdle: Long = 0,
@@ -30,15 +28,5 @@ case class ConnectionSnapshot(
 
   def timeIdle = math.min(readIdle, writeIdle)
   
-  def consoleString = f"$id%-10s $domain%-10s ${host.getHostName}%-10s $timeOpen%-10s $timeIdle%-10s $bytesSent%-10s $bytesReceived%-10s"
-
-  def itemValues = List(id.toString, domain, host.getHostName, timeOpen.toString, timeIdle.toString, bytesSent.toString, bytesReceived.toString)
-}
-//NOTE:  This feels weird here and is used in conjunction with the PageRenderer used for stats.  Should be moved to the metrics pkg
-object ConnectionSnapshot {
-  val items = List("id", "domain", "host", "ms-alive", "ms-idle", "b-sent", "b-received")
-  val consoleHeader = {
-    String.format(items.map{_ => "%-10s"}.mkString(" "), items:_*)
-  }
 }
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -269,7 +269,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
     }
     case ConnectionSummaryRequest => {
       val now = System.currentTimeMillis //save a few thousand calls by doing this
-      //sender ! ConnectionSummary(connections.values.map{_.info(now)}.toSeq)
+      sender ! ConnectionSummary(connections.values.map{_.info(now)}.toSeq)
     }
   }
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -298,7 +298,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
     val newChannel = SocketChannel.open()
     newChannel.configureBlocking(false)
     val newKey = newChannel.register(selector, SelectionKey.OP_CONNECT)
-    val connection = new ClientConnection(newId(), handler) with LiveConnection {
+    val connection = new ClientConnection(newId(), handler, me) with LiveConnection {
       val key = newKey
       val channel = newChannel
     }
@@ -378,7 +378,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
    */
   def registerConnection(sc: SocketChannel, server: ServerRef, handler: ServerConnectionHandler) {
       val newKey: SelectionKey = sc.register( selector, SelectionKey.OP_READ )
-      val connection = new ServerConnection(newId(), handler, server)(self) with LiveConnection {
+      val connection = new ServerConnection(newId(), handler, server, me) with LiveConnection {
         val key = newKey
         val channel = sc
       }

--- a/colossus/src/main/scala/colossus/core/WriteBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/WriteBuffer.scala
@@ -1,6 +1,7 @@
 package colossus
 package core
 
+import java.net.InetAddress
 import java.nio.ByteBuffer
 import java.nio.channels.{CancelledKeyException, ClosedChannelException, SelectionKey, SocketChannel}
 
@@ -30,6 +31,8 @@ trait ChannelActions {
   protected def channelWrite(data: DataBuffer): Int
 
   protected def channelClose()
+
+  protected def channelHost(): InetAddress
 
   protected def keyInterestOps(ops: Int)
 

--- a/colossus/src/main/scala/colossus/core/WriteBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/WriteBuffer.scala
@@ -16,14 +16,41 @@ object WriteStatus {
   case object Complete extends WriteStatus
 }
 
-trait KeyInterestManager {
+/**
+ * This trait abstracts actions performed on a raw socket channel.  
+ *
+ * This is essentially the only trait that should differ between live
+ * connections and fake connections in testing
+ */
+trait ChannelActions {
+
+  /**
+   * Hook to perform that actual operation of writing to a channel
+   */
+  protected def channelWrite(data: DataBuffer): Int
+
+  protected def channelClose()
+
+  protected def keyInterestOps(ops: Int)
+
+  def finishConnect()
+
+  def status: ConnectionStatus
+
+
+}
+
+trait KeyInterestManager extends ChannelActions {
   private var _readsEnabled = true
   private var _writeReadyEnabled = false
 
   def readsEnabled = _readsEnabled
   def writeReadyEnabled = _writeReadyEnabled
 
-  protected def setKeyInterest()
+  protected def setKeyInterest() {
+    val ops = (if (readsEnabled) SelectionKey.OP_READ else 0) | (if (writeReadyEnabled) SelectionKey.OP_WRITE else 0)
+    keyInterestOps(ops)
+  }
 
   def enableReads() {
     _readsEnabled = true
@@ -44,17 +71,16 @@ trait KeyInterestManager {
   }
 }
 
+
 private[colossus] trait WriteBuffer extends KeyInterestManager {
   import WriteStatus._
 
-  //mostly for DI for testing
-  def channelWrite(data: DataBuffer): Int
 
   /**
    * The WriteBuffer calls this if it has been signaled to disconnect and
    * finishes writing any existing partial buffer
    */
-  def completeDisconnect()
+  protected def completeDisconnect()
 
   /**
    * This should be called when it's time to disconnect the connection, but we
@@ -113,7 +139,7 @@ private[colossus] trait WriteBuffer extends KeyInterestManager {
     }
   }
 
-  def write(raw: DataBuffer): WriteStatus = {
+  protected def write(raw: DataBuffer): WriteStatus = {
     if (partialBuffer.isDefined) {
       Zero
     } else if (disconnecting) {
@@ -145,46 +171,9 @@ private[colossus] trait WriteBuffer extends KeyInterestManager {
     }
   }
 
-  /**
-   * returns true if more data can be written, false otherwise
-   *
-   * Note - the return value is only used in testing
-   */
-  protected def handleWrite(data: encoding.DataOutBuffer, handler: ConnectionHandler) = {
-    if (continueWrite()) {
-      //partial buffer is empty, so we can get data from the handler to write
-      val more  = handler.readyForData(data)
-      val toWrite = data.data
-      //its possible for the handler to not actually have written anything, this
-      //can occur due to the fact that we use the writeReady flag to track both
-      //pending data from the handler and from the partial buffer, so we can end up
-      //calling handler.readyForData even when it didn't request a write
-      val result = if (toWrite.remaining > 0) write(toWrite) else WriteStatus.Complete
-      //we want to leave writeReady enabled if either the handler has more data to write, or if the writebuffer couldn't write everything
-      if (more == MoreDataResult.Complete && result == WriteStatus.Complete) {
-        disableWriteReady()
-      }
-      true
-    } else false
-  }
-
-
   def requestWrite() {
     enableWriteReady()
   }
 
 }
 
-private[core] trait LiveWriteBuffer extends WriteBuffer {
-
-  protected def channel: SocketChannel
-  def channelWrite(raw: DataBuffer): Int = raw.writeTo(channel)
-  def key: SelectionKey
-
-  def setKeyInterest() {
-    val ops = (if (readsEnabled) SelectionKey.OP_READ else 0) | (if (writeReadyEnabled) SelectionKey.OP_WRITE else 0)
-    key.interestOps(ops)
-  }
-
-
-}

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -250,6 +250,10 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, Output
     attemptReconnect()
   }
 
+  def shutdownRequest() {
+    gracefulDisconnect()
+  }
+
   private def attemptReconnect() {
     connectionAttempts += 1
     if(!disconnecting) {

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -250,7 +250,7 @@ extends Controller[O,I](codec, ControllerConfig(config.pendingBufferSize, Output
     attemptReconnect()
   }
 
-  def shutdownRequest() {
+  override def shutdownRequest() {
     gracefulDisconnect()
   }
 

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -247,7 +247,7 @@ extends Controller[I,O](codec, ControllerConfig(config.requestBufferSize, Output
     }
   }
 
-  def shutdownRequest() {
+  override def shutdownRequest() {
     gracefulDisconnect()
   }
 


### PR DESCRIPTION
This adds all the lower-level support for correctly swapping a connection handler for a live connection.  This is a prerequisite for WebSocket support.  The service DSL and overall API are not really affected by this.  Phase 2 will add API support.

Connection Handler swapping is needed for Websocket support because a websocket connection starts out as Http and "upgrades" to the Websocket protocol.  This means a server connection has to switch protocols, and instead of somehow trying to support this functionality within a single connection handler or a single codec, it's much easier to just swap out the Http handler with a new Websocket one.

In general, the way hot-swapping works is: the graceful disconnect logic in the controller and service layers has been generalized such that when the controller is finally ready to disconnect, it instead can trigger a ConnectionHandler swap.  This is done so that when the old handler is removed, we know it is not in the middle of anything important.

In fact, the connection handler itself doesn't know what action, disconnecting or swapping, is going to take place, it is only aware of the fact that it needs to shutdown and signal back to the connection when it has finished its shutdown procedure.  For services this means ensuring that every request has been processed (either successfully or with an error) and for controllers it means all pending messages have been sent (or failed).

This also includes a fairly significant refactoring of some of the traits and classes dealing with connections and connection handlers.  