### PR TITLE
Websocket protocol

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -38,5 +38,7 @@ object Main extends App {
 
   val benchmarkServer = BenchmarkService.start(9007)
 
+  val websocketServer = WebsocketExample.start(9008)
+
 
 }

--- a/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
@@ -1,0 +1,75 @@
+package colossus.examples
+
+
+import colossus._
+import colossus.core._
+import colossus.service._
+import colossus.protocols.http._
+import colossus.protocols.websocket._
+
+import akka.actor._
+import akka.util.ByteString
+
+/*
+class PrimeGenerator extends Actor {
+
+  var lastPrime = 1
+
+  def receive = {
+    case c: Context => context.become(sending(c))
+  }
+
+  def sending(c: Context): Receive = {
+    case Next => {
+      var nextPrime = lastPrime
+      var prime = false
+      while (!prime) {
+        nextPrime += 1
+        var n = 1
+        var ok = true
+        while (n < nextPrime && ok) {
+          n += 1
+          if (nextPrime % n == 0) {
+            ok = false
+          }
+        }
+        prime = ok
+      }
+      c ! nextPrime
+    }
+  }
+}
+ */         
+    
+
+
+object WebsocketExample {
+
+  def start(port: Int)(implicit io: IOSystem) = {
+    Server.basic("websocket", port){ new Service[Http](_) {
+      override def shutdown() {
+        println("shutting down")
+        super.shutdown()
+      }
+      def handle = {
+        case WebsocketUpgradeRequest(resp) => {
+          become(new WebsocketHandler(_){
+            println("starting websocket")           
+
+            override def preStart() {
+              send(ByteString("HELLO THERE!"))
+            }
+
+            def handle = {
+              case bytes => {
+                println("Got bytes " + bytes.utf8String)
+                send(ByteString(s"got " + bytes.utf8String))
+              }
+            }
+          })
+          Callback.successful(resp)
+        }
+      }
+    }}
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -1,0 +1,20 @@
+package colossus
+package protocols.websocket
+
+import core.DataBuffer
+
+import org.scalatest._
+
+import akka.util.ByteString
+
+import scala.util.Success
+
+class WebsocketSpec extends WordSpec with MustMatchers{
+
+  "ProcessKey" must {
+    "correctly translate key from RFC" in {
+      WebsocketUpgradeRequest.processKey("dGhlIHNhbXBsZSBub25jZQ==") must equal("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
+    }
+  }
+}
+

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -2,6 +2,9 @@ package colossus
 package protocols.websocket
 
 import core.DataBuffer
+import service.DecodedResult
+import protocols.http._
+import java.util.Random
 
 import org.scalatest._
 
@@ -11,10 +14,63 @@ import scala.util.Success
 
 class WebsocketSpec extends WordSpec with MustMatchers{
 
-  "ProcessKey" must {
+  val valid = HttpRequest(
+    HttpHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, Vector(
+      ("connection", "Upgrade"),
+      ("upgrade", "Websocket"),
+      ("sec-websocket-version", "13"),
+      ("sec-websocket-key", "rrBE1CeTUMlALwoQxfmTfg=="),
+      ("host" , "foo.bar"),
+      ("origin", "http://foo.bar")
+    )),
+    None
+  )
+
+  "Http Upgrade Request" must {
     "correctly translate key from RFC" in {
-      WebsocketUpgradeRequest.processKey("dGhlIHNhbXBsZSBub25jZQ==") must equal("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
+      UpgradeRequest.processKey("dGhlIHNhbXBsZSBub25jZQ==") must equal("s3pPLMBiTxaQ9kYGzzhZRbK+xOo=")
+    }
+
+    "accept a properly crafted upgrade request" in {
+      UpgradeRequest.unapply(valid).isEmpty must equal(false)
+    }
+
+    "produce a correctly formatted response" in {
+      val expected = HttpResponse(
+        HttpResponseHead(
+          HttpVersion.`1.1`,
+          HttpCodes.SWITCHING_PROTOCOLS,
+          Vector(
+            HttpResponseHeader("Upgrade", "websocket"),
+            HttpResponseHeader("Connection", "Upgrade"),
+            HttpResponseHeader("Sec-Websocket-Accept","MeFiDAjivCOffr7Pn3T2DM7eJHo=")
+          )
+        ),
+        None
+      )
+      UpgradeRequest.unapply(valid).get must equal(expected)
+
     }
   }
+
+  "frame parsing" must {
+
+    "unmask data" in {
+      val masked = ByteString("abcd") ++ ByteString(41, 7, 15, 8, 14, 66, 52, 11, 19, 14, 7, 69)
+      FrameParser.unmask(true, masked) must equal(ByteString("Hello World!"))
+    }
+    
+    "parse a frame" in {
+      val data = ByteString(-119, -116, 115, 46, 27, -120, 59, 75, 119, -28, 28, 14, 76, -25, 1, 66, 127, -87)
+      val expected = Frame(Header(OpCodes.Ping, true), ByteString("Hello World!"))
+      FrameParser.frame.parse(DataBuffer(data)) must equal(Some(DecodedResult.Static(expected)))
+    }
+
+    "parse its own encoding" in {
+      val expected = Frame(Header(OpCodes.Text, true), ByteString("Hello World!!!!!!"))
+      FrameParser.frame.parse(expected.encode(new Random)) must equal(Some(DecodedResult.Static(expected)))
+    }
+  }
+
 }
 

--- a/colossus/src/main/scala/colossus/core/WorkerItem.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerItem.scala
@@ -17,9 +17,11 @@ class WorkerItemException(message: String) extends Exception(message)
  * @param worker the worker the item is bound to
  */
 case class Context(id: Long, worker: WorkerRef) {
-  def send(message: Any) {
+
+  def !(message: Any)(implicit sender: ActorRef) {
     worker.worker ! WorkerCommand.Message(id, message)
   }
+
   def unbind() {
     worker.worker ! WorkerCommand.UnbindWorkerItem(id)
   }

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -40,7 +40,7 @@ object UpgradeRequest {
       if (request.head.method == HttpMethod.Get)
       if (secver == "13")
       if (uheader.toLowerCase == "websocket")
-      if (cheader.toLowerCase == "upgrade")
+      if (cheader.toLowerCase.split(",").map{_.trim} contains "upgrade")
     } yield HttpResponse (
       HttpResponseHead(
         HttpVersion.`1.1`,

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -1,0 +1,166 @@
+package colossus
+package protocols.websocket
+
+import core._
+import controller._
+import service._
+import akka.util.{ByteString, ByteStringBuilder}
+
+import java.math.BigInteger
+import java.security.MessageDigest
+import sun.misc.{BASE64Encoder, BASE64Decoder}
+
+
+object WebsocketUpgradeRequest {
+  import protocols.http._
+
+  val salt = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" //GUID for websocket
+  
+  val b64 = new BASE64Encoder
+
+  def processKey(key: String): String = {
+    val digest = MessageDigest.getInstance("SHA-1")
+    digest.reset()
+    digest.update((key + salt).getBytes("UTF-8"))
+    new String(b64.encode(digest.digest()))
+  }
+  
+
+  //todo proper handling of key
+  def unapply(request : HttpRequest): Option[HttpResponse] = {
+    for {
+      cheader   <- request.head.singleHeader("connection") 
+      uheader   <- request.head.singleHeader("upgrade") 
+      host      <- request.head.singleHeader("host")
+      origin    <- request.head.singleHeader("origin")
+      seckey    <- request.head.singleHeader("sec-websocket-key")
+      secver    <- request.head.singleHeader("sec-websocket-version") 
+      if (request.head.version == HttpVersion.`1.1`)
+      if (request.head.method == HttpMethod.Get)
+      if (secver == "13")
+      if (uheader.toLowerCase == "websocket")
+      if (cheader.toLowerCase == "upgrade")
+    } yield HttpResponse (
+      HttpResponseHead(
+        HttpVersion.`1.1`,
+        HttpCodes.SWITCHING_PROTOCOLS,
+        Vector(
+          HttpResponseHeader("Upgrade", "websocket"),
+          HttpResponseHeader("Connection", "Upgrade"),
+          HttpResponseHeader("Sec-Websocket-Accept",processKey(seckey))
+        )
+      ),
+      None
+    )      
+  }
+}
+
+object OpCodes {
+
+  type OpCode = Byte
+
+  val Continue  = 0x00.toByte
+  val Text      = 0x01.toByte
+  val Binary    = 0x02.toByte
+  val Close     = 0x08.toByte
+  val Ping      = 0x09.toByte
+  val Pong      = 0x0A.toByte
+
+  def fromHeaderByte(b: Byte) = b & 0x0F
+  
+  implicit val byteOrder = java.nio.ByteOrder.nativeOrder()
+
+}
+
+/**
+ * A Parsed Frame Header
+ */
+case class Header(opcode: Byte, mask: Boolean)
+
+case class Frame(header: Header, payload: ByteString) {
+  import OpCodes.byteOrder
+
+  def encode: DataBuffer = {
+    val b = new ByteStringBuilder
+    b.sizeHint(payload.size + 20)
+    b putByte ((header.opcode | 0x80).toByte) //set the fin bit for now every time
+    if (payload.size < 126) {
+      b putByte payload.size.toByte
+    } else if (payload.size < 65536) {
+      b putByte 0x7E
+      b putShort(payload.size)
+    } else {
+      b putByte 0x7F
+      b putLong(payload.size)
+    }
+    b append payload
+    DataBuffer(b.result)
+  }
+}
+
+
+object FrameParser {
+  import parsing._
+  import Combinators._
+
+  def unmask(isMasked: Boolean, data: ByteString): ByteString = if (!isMasked) data else {
+    val mask = data.take(4)
+    val payload = data.drop(4)
+    val builder = new ByteStringBuilder
+    builder.sizeHint(payload.size)
+    var index = 0
+    payload.foreach{ b: Byte =>
+      builder putByte (b ^ (mask(index % 4).toByte)).toByte
+      index += 1
+    }
+    builder.result
+  }
+
+  
+  def frame = bytes(2) |> {head =>
+    val payloadLen = head(1) & 0x7F //toss the first bit, len is 7 bits
+    val mask = (head(1) & 0x80) == 0x80
+    val maskKeyBytes = if (mask) 4 else 0
+    val p: Parser[ByteString] = if (payloadLen == 0x7E) {
+      bytes(short >> {_.toLong + maskKeyBytes})
+    } else if (payloadLen == 0x7F) {
+      bytes(long >> {_ + maskKeyBytes})
+    } else {
+      bytes(payloadLen + maskKeyBytes)
+    }
+    p >> {data => DecodedResult.Static(Frame(Header(0, mask), unmask(mask,data)))}
+  }
+}
+
+abstract class WebsocketHandler(context: Context) extends Controller(new WebsocketCodec, ControllerConfig(50, 16384, scala.concurrent.duration.Duration.Inf), context) {
+
+  def send(bytes: ByteString) {
+    push(Frame(Header(OpCodes.Text, false), bytes)){_ => {}}
+  }
+
+  def handle: PartialFunction[ByteString, Unit]
+
+  private def fullHandler: PartialFunction[ByteString, Unit] = handle orElse {case _ => {}}
+
+  def processMessage(message: Frame) = {
+    fullHandler(message.payload)
+  }
+
+  //TODO : generalize the stuff in Service and use it for this and for Task as well
+  def receivedMessage(message: Any, sender: akka.actor.ActorRef){}
+
+  def preStart(){}
+
+  def postStop(){}
+
+  override def connected(e: WriteEndpoint) {
+    super.connected(e)
+    preStart()
+  }
+
+  override def connectionTerminated(cause: DisconnectCause) {
+    super.connectionTerminated(cause)
+    postStop()
+  }
+
+}

--- a/colossus/src/main/scala/colossus/protocols/websocket/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/package.scala
@@ -1,0 +1,37 @@
+package colossus
+package protocols
+
+import core._
+import controller._
+import service._
+import akka.util.{ByteString, ByteStringBuilder}
+
+package object websocket {
+
+  class WebsocketCodec extends Codec[Frame, Frame]{
+    
+    private val parser = FrameParser.frame
+
+    def decode(data: DataBuffer) = parser.parse(data)
+
+    def encode(f: Frame) = f.encode
+
+    def reset(){}
+  }
+
+  trait Websocket extends CodecDSL {
+    type Input = Frame
+    type Output = Frame
+  }
+
+  implicit object WebsocketCodecProvider extends CodecProvider[Websocket] {
+
+    def provideCodec() = new WebsocketCodec
+
+    //TODO : looks like we need to break this out from codec provider
+    def errorResponse(request: Frame, reason: Throwable): Frame = ???
+  }
+    
+
+}
+

--- a/colossus/src/main/scala/colossus/protocols/websocket/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/package.scala
@@ -5,16 +5,18 @@ import core._
 import controller._
 import service._
 import akka.util.{ByteString, ByteStringBuilder}
+import java.util.Random
 
 package object websocket {
 
   class WebsocketCodec extends Codec[Frame, Frame]{
     
+    private val random = new Random
     private val parser = FrameParser.frame
 
     def decode(data: DataBuffer) = parser.parse(data)
 
-    def encode(f: Frame) = f.encode
+    def encode(f: Frame) = f.encode(random)
 
     def reset(){}
   }


### PR DESCRIPTION
_Note : This branch merges into my other unmerged PR.  Once that PR is merge I'll change this to merge into develop._

This is a mostly complete, working implementation of the websocket protocol.  It properly handles the upgrade http request and the basics of parsing and encoding websocket frames as defined in [RFC 6455](https://tools.ietf.org/html/rfc6455).

The new example server can be tested by running the examples, browsing to http://www.websocket.org/echo.html and connecting to `ws://localhost:9008`.  I've so far tested with Chome, Firefox, and Safari.

The `WebsocketController` is very basic, and I think there's a lot of room to make it more flexible and easier to use.  In particular, we could make it automatically handle PING and CLOSE opcodes, and we can probably build another layer on top that is type-parameterized for a higher-level protocol.  There's also no websocket client yet, which would be useful for integration testing.