### PR TITLE
minor improvement to metrics api

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -49,8 +49,6 @@ object BenchmarkService {
       tcpBacklogSize = Some(1024)
     )
     val serviceConfig = ServiceConfig(
-      name = "/sample",
-      requestTimeout = Duration.Inf,
       requestMetrics = false
     )
 

--- a/colossus-examples/src/main/scala/colossus-examples/ChatExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/ChatExample.scala
@@ -74,8 +74,8 @@ object Broadcaster {
   case class ClientClosed(user: String, id: Long) extends BroadcasterMessage
 }
 
-class ChatHandler(broadcaster: ActorRef, context: Context) 
-extends Controller[String, ChatMessage](new ChatCodec, ControllerConfig(50, 100, 10.seconds), context) with ServerConnectionHandler {
+class ChatHandler(broadcaster: ActorRef, context: ServerContext) 
+extends Controller[String, ChatMessage](new ChatCodec, ControllerConfig(50, 100, 10.seconds), context.context) with ServerConnectionHandler {
   implicit lazy val sender = worker.worker
 
   sealed trait State

--- a/colossus-examples/src/main/scala/colossus-examples/EchoExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/EchoExample.scala
@@ -11,7 +11,7 @@ import colossus.encoding._
  * implementations for most of the methods.  It also stores the WriteEndpoint
  * that is passed in the connected method.
  */
-class EchoHandler(context: Context) extends BasicSyncHandler(context) with ServerConnectionHandler {
+class EchoHandler(context: ServerContext) extends BasicSyncHandler(context.context) with ServerConnectionHandler {
   var bytes = ByteString()
   def receivedData(data: DataBuffer){
     bytes = ByteString(data.takeAll)

--- a/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
@@ -2,7 +2,7 @@ package colossus.examples
 
 import akka.util.ByteString
 import colossus.IOSystem
-import colossus.core.{Context, DataBuffer, Initializer, Server, ServerRef, WorkerRef}
+import colossus.core.{ServerContext, DataBuffer, Initializer, Server, ServerRef, WorkerRef}
 import colossus.protocols.http._
 import colossus.protocols.redis._
 import colossus.service.{Callback, Service, ServiceClient, ServiceConfig}
@@ -14,12 +14,9 @@ import Callback.Implicits._
 
 import colossus.controller.IteratorGenerator
 
-import scala.concurrent.duration._
-
-
 object HttpExample {
 
-  class HttpExampleService(redis: RedisCallbackClient, context: Context) extends HttpService(ServiceConfig("/foo", 1.second, requestMetrics = false), context){
+  class HttpExampleService(redis: RedisCallbackClient, context: ServerContext) extends HttpService(ServiceConfig(), context){
     
     def invalidReply(reply: Reply) = s"Invalid reply from redis $reply"    
 
@@ -50,7 +47,6 @@ object HttpExample {
   def start(port: Int, redisAddress: InetSocketAddress)(implicit system: IOSystem): ServerRef = {
     Server.start("http-example", port){implicit worker => new Initializer(worker) {
 
-      implicit val w = worker
       val redis = new RedisCallbackClient(ServiceClient[Redis](redisAddress.getHostName, redisAddress.getPort))
 
       def onConnect = context => new HttpExampleService(redis, context)

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -2,7 +2,7 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Counter(val address: MetricAddress)(implicit collection: Collection) extends Collector {
+class Counter private[colossus](val address: MetricAddress)(implicit collection: Collection) extends Collector {
 
   private val counters = new CollectionMap[TagMap]
 
@@ -23,4 +23,11 @@ class Counter(val address: MetricAddress)(implicit collection: Collection) exten
   }
     
 
+}
+
+object Counter {
+
+  def apply(address: MetricAddress)(implicit collection: Collection): Counter = {
+    collection.getOrAdd(new Counter(address))
+  }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -43,6 +43,10 @@ object Histogram {
     }.toVector
     BucketList(buckets)
   }
+  
+  def apply(address: MetricAddress, percentiles: Seq[Double] = Histogram.defaultPercentiles, sampleRate: Double = 1.0)(implicit collection: Collection): Histogram = {
+    collection.getOrAdd(new Histogram(address, percentiles, sampleRate))
+  }
 
 }
 
@@ -166,7 +170,7 @@ class BaseHistogram(val bucketList: BucketList = Histogram.defaultBucketRanges) 
 
 }
 
-class Histogram(val address: MetricAddress, percentiles: Seq[Double] = Histogram.defaultPercentiles, sampleRate: Double = 1.0)(implicit collection: Collection) extends Collector {
+class Histogram private[colossus](val address: MetricAddress, percentiles: Seq[Double] = Histogram.defaultPercentiles, sampleRate: Double = 1.0)(implicit collection: Collection) extends Collector {
 
   val tagHists: Map[FiniteDuration, ConcurrentHashMap[TagMap, BaseHistogram]] = collection.config.intervals.map{i => 
     val m = new ConcurrentHashMap[TagMap, BaseHistogram]

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -2,7 +2,7 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Rate(val address: MetricAddress)(implicit collection: Collection) extends Collector {
+class Rate private[colossus](val address: MetricAddress)(implicit collection: Collection) extends Collector {
 
   private val maps = collection.config.intervals.map{i => (i, new CollectionMap[TagMap])}.toMap
 
@@ -24,6 +24,13 @@ class Rate(val address: MetricAddress)(implicit collection: Collection) extends 
   }
     
 
+}
+
+object Rate {
+
+  def apply(address: MetricAddress)(implicit collection: Collection): Rate = {
+    collection.getOrAdd(new Rate(address))
+  }
 }
 
 

--- a/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
@@ -111,7 +111,7 @@ abstract class ColossusSpec(_system: ActorSystem) extends TestKit(_system) with 
     }
   }
 
-  def withServer(handler: Context => ServerConnectionHandler)(op: ServerRef => Any) {
+  def withServer(handler: ServerContext => ServerConnectionHandler)(op: ServerRef => Any) {
     withIOSystem { implicit io =>
       val server = Server.basic("test-server", TEST_PORT)(handler)
       waitForServer(server)

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -11,7 +11,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import colossus.encoding._
 
-class EchoHandler(c: Context) extends BasicSyncHandler(c) with ServerConnectionHandler {
+class EchoHandler(c: ServerContext) extends BasicSyncHandler(c.context) with ServerConnectionHandler {
 
   val buffer = new collection.mutable.Queue[ByteString]
   def receivedData(data: DataBuffer){

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -81,7 +81,7 @@ object TestController {
 
   //TODO just return TypedMockConnection instead of the tuple
   def createController(outputBufferSize: Int = 100, dataBufferSize: Int = 100, processor: TestInput => Unit = x => ())(implicit system: ActorSystem): (MockConnection, TestController) = {
-    val endpoint = MockConnection.server(context => new TestController(dataBufferSize, processor, context), outputBufferSize)
+    val endpoint = MockConnection.server(context => new TestController(dataBufferSize, processor, context.context), outputBufferSize)
     endpoint.handler.connected(endpoint)
     (endpoint, endpoint.typedHandler)
   }

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -20,7 +20,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
   "Server Connection Handler" must {
     "bind to worker on creation" in {
       val probe = TestProbe()
-      class MyHandler(context: Context) extends BasicSyncHandler(context) with ServerConnectionHandler {
+      class MyHandler(context: ServerContext) extends BasicSyncHandler(context) with ServerConnectionHandler {
         override def onBind() {
           probe.ref ! "BOUND"
         }
@@ -36,7 +36,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
 
     "unbind on disconnect" in {
       val probe = TestProbe()
-      class MyHandler(context: Context) extends BasicSyncHandler(context) with ServerConnectionHandler{
+      class MyHandler(context: ServerContext) extends BasicSyncHandler(context) with ServerConnectionHandler{
         override def onUnbind() {
           probe.ref ! "UNBOUND"
         }

--- a/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
@@ -4,7 +4,7 @@ import colossus.testkit._
 
 import scala.concurrent.duration._
 
-class TestHandler(ctx: Context) extends BasicCoreHandler(ctx) {
+class TestHandler(ctx: ServerContext) extends BasicCoreHandler(ctx.context) {
 
   var shutdownCalled = false
 
@@ -26,7 +26,7 @@ class CoreHandlerSpec extends ColossusSpec {
   "Core Handler" must {
     
     "set connectionStatus to Connected" in {
-      val con = MockConnection.server(new BasicCoreHandler(_))
+      val con = MockConnection.server(srv => new BasicCoreHandler(srv.context))
       con.typedHandler.connectionState must equal(ConnectionState.NotConnected)
       con.typedHandler.connected(con)
       con.typedHandler.connectionState must equal(ConnectionState.Connected(con))

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -154,7 +154,7 @@ class ServerSpec extends ColossusSpec {
 
       "signal open connections before termination when shutdown" in {
         val probe = TestProbe()
-        class MyHandler(c: Context) extends BasicSyncHandler(c) with ServerConnectionHandler {
+        class MyHandler(c: ServerContext) extends BasicSyncHandler(c) with ServerConnectionHandler {
           def receivedData(data: DataBuffer){}
           override def shutdownRequest() {probe.ref ! "SHUTDOWN"}
           override def connectionTerminated(cause: DisconnectCause) {
@@ -361,7 +361,7 @@ class ServerSpec extends ColossusSpec {
   }
 
   class TestDelegator(server: ServerRef, worker: WorkerRef) extends Delegator(server, worker) {
-    def acceptNewConnection = Some(new EchoHandler(worker.generateContext()))
+    def acceptNewConnection = Some(new EchoHandler(ServerContext(server, worker.generateContext())))
     override def handleMessage = {
       case a: ActorRef => a.!(())
     }    

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -21,14 +21,13 @@ class ServiceServerSpec extends ColossusSpec {
 
   import system.dispatcher
   
-  class FakeService(handler: ByteString => Callback[ByteString], context: Context) extends ServiceServer[ByteString, ByteString](
+  class FakeService(handler: ByteString => Callback[ByteString], srv: ServerContext) extends ServiceServer[ByteString, ByteString](
       config = ServiceConfig (
-        name = "/test",
         requestBufferSize = 2,
         requestTimeout = 50.milliseconds
       ),
       codec = RawCodec,
-      context = context
+      serverContext = srv
   ) {
     def processFailure(request: ByteString, reason: Throwable) = ByteString("ERROR")
 
@@ -150,7 +149,6 @@ class ServiceServerSpec extends ColossusSpec {
       )
 
       val serviceConfig = ServiceConfig (
-        name = "/timeout-test",
         requestTimeout = 50.milliseconds
       )
       withIOSystem{implicit io => 

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -131,6 +131,9 @@ trait WatchedHandler extends ConnectionHandler {
  * for the functions they require.
  */
 abstract class BasicSyncHandler(context: Context) extends WorkerItem(context) with ConnectionHandler {
+
+  def this(serverContext: ServerContext) = this(serverContext.context)
+
   private var _endpoint: Option[WriteEndpoint] = None
   def endpoint = _endpoint.getOrElse{
     throw new Exception("Handler is not connected")

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -77,6 +77,8 @@ case class WorkerRef private[colossus](id: Int, worker: ActorRef, system: IOSyst
    * default dispatcher of the worker's underlying ActorSystem.
    */
   implicit val callbackExecutor = service.CallbackExecutor(system.actorSystem.dispatcher, worker)
+
+  implicit val metrics = system.metrics.base
 }
 
 /**

--- a/colossus/src/main/scala/colossus/core/WorkerItem.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerItem.scala
@@ -25,6 +25,7 @@ case class Context(id: Long, worker: WorkerRef) {
   }
 }
 
+
 /**
  * A WorkerItem is anything that can be bound to worker to receive both events
  * and external messages.  WorkerItems are expected to be single-threaded and

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -3,7 +3,7 @@ package protocols
 
 import colossus.metrics.TagMap
 import colossus.parsing.DataSize
-import core.{Context, WorkerRef}
+import core.{Context, ServerContext, WorkerRef}
 import service._
 
 import akka.util.ByteString
@@ -49,7 +49,7 @@ package object http {
   }
 
   abstract class BaseHttpServiceHandler[D <: BaseHttp]
-  (config: ServiceConfig, provider: CodecProvider[D], context: Context)
+  (config: ServiceConfig, provider: CodecProvider[D], context: ServerContext)
   extends Service[D](config, context)(provider) {
 
     override def tagDecorator = new ReturnCodeTagDecorator
@@ -61,9 +61,9 @@ package object http {
 
   }
 
-  abstract class HttpService(config: ServiceConfig, context: Context) extends BaseHttpServiceHandler[Http](config, DefaultHttpProvider, context)
+  abstract class HttpService(config: ServiceConfig, context: ServerContext) extends BaseHttpServiceHandler[Http](config, DefaultHttpProvider, context)
 
-  abstract class StreamingHttpService(config: ServiceConfig, context: Context) extends BaseHttpServiceHandler[StreamingHttp](config, StreamingHttpProvider, context)
+  abstract class StreamingHttpService(config: ServiceConfig, context: ServerContext) extends BaseHttpServiceHandler[StreamingHttp](config, StreamingHttpProvider, context)
 
   implicit object StreamingHttpProvider extends CodecProvider[StreamingHttp] {
     def provideCodec = new StreamingHttpServerCodec

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -26,8 +26,7 @@ import Codec._
  * access to the ServerRef
  */
 case class ServiceConfig(
-  name: MetricAddress,
-  requestTimeout: Duration,
+  requestTimeout: Duration = Duration.Inf,
   requestBufferSize: Int = 100,
   logErrors: Boolean = true,
   requestMetrics: Boolean = true
@@ -61,11 +60,13 @@ class DroppedReplyException extends ServiceServerException("Dropped Reply")
  *
  */
 abstract class ServiceServer[I,O]
-  (codec: ServerCodec[I,O], config: ServiceConfig, context: Context) 
-extends Controller[I,O](codec, ControllerConfig(config.requestBufferSize, OutputController.DefaultDataBufferSize, Duration.Inf), context) with ServerConnectionHandler {
+  (codec: ServerCodec[I,O], config: ServiceConfig, serverContext: ServerContext) 
+extends Controller[I,O](codec, ControllerConfig(config.requestBufferSize, OutputController.DefaultDataBufferSize, Duration.Inf), serverContext.context)
+with ServerConnectionHandler {
   import ServiceServer._
   import config._
   import context.worker.metrics
+  def name = serverContext.server.config.name
 
   val log = Logging(context.worker.system.actorSystem, name.toString())
   def tagDecorator: TagDecorator[I,O] = TagDecorator.default[I,O]


### PR DESCRIPTION
This fixes #298 .

Now it's easier than ever to get handles to metrics.  Where in the base branch you need to do:

```scala
implicit val collection = context.worker.system.metrics.base
val myrate = collection.getOrAdd(new Rate("/foo"))
```

Now you can do:

```scala
import context.worker.metrics
val myrate = Rate("/foo")
```

so you no longer need to use the collection both explicitly and implicitly.