### PR TITLE
fix histogram min, don't report empty metrics

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -19,7 +19,8 @@ class Counter private[colossus](val address: MetricAddress)(implicit collection:
   def get(tags: TagMap = TagMap.Empty): Long = counters.get(tags).getOrElse(0)
 
   def tick(interval: FiniteDuration): MetricMap  = {
-    Map(address -> counters.snapshot(false, false))
+    val values = counters.snapshot(false, false)
+    if (values.isEmpty) Map() else Map(address -> values)
   }
     
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -149,8 +149,8 @@ class BaseHistogram(val bucketList: BucketList = Histogram.defaultBucketRanges) 
   def snapshot = {
 
     val smax = mMax.getAndSet(0)
-    val smin = mMin.getAndSet(infinity)
     val scount = mCount.getAndSet(0)
+    val smin = if (scount > 0) mMin.getAndSet(infinity) else 0L
     val mean = if (scount > 0) mTotal.getAndSet(0)/scount else 0L
     var values = Vector[BucketValue]()
     var index = 0

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -20,7 +20,9 @@ class Rate private[colossus](val address: MetricAddress)(implicit collection: Co
     if (interval == minInterval) {
       snap.foreach{ case (tags, value) => totals.increment(tags, value) }
     }
-    Map(address -> snap, address / "count" -> totals.snapshot(false, false))
+    if (snap.isEmpty) Map() else {
+      Map(address -> snap, address / "count" -> totals.snapshot(false, false))
+    }
   }
     
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
@@ -38,6 +38,10 @@ class CounterSpec extends MetricIntegrationSpec {
       c.get(Map("a" -> "b")) must equal(2)
     }
 
+    "return no metrics when not used yet" in {
+      counter.tick(1.second) must equal(Map())
+    }
+
     
   }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
@@ -47,6 +47,14 @@ class HistogramSpec extends MetricIntegrationSpec {
       h.bucketFor(5) must equal (5)
     }
 
+    "return 0 for min when empty" in {
+      (new BaseHistogram).snapshot.min must equal(0)
+    }
+
+    "return 0 for mean when empty" in {
+      (new BaseHistogram).snapshot.mean must equal(0)
+    }
+
   }
 
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -1,10 +1,8 @@
 package colossus.metrics
 
-import colossus.metrics.IntervalAggregator._
 import org.scalatest._
 
 import akka.actor._
-import scala.concurrent.duration._
 import MetricAddress._
 
 
@@ -13,8 +11,6 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
   def this() = this(ActorSystem("MetricSpec"))
 
   implicit val sys = _system
-
-  import akka.testkit._
 
   "MetricAddress" must {
     "startsWith" in {

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -48,6 +48,10 @@ class RateSpec extends MetricIntegrationSpec {
       r.tick(1.second)("/foo/count")(Map()) must equal(2)
     }
 
+    "not return any metrics when never hit" in {
+      rate().tick(1.second) must equal(Map())
+    }
+
 
   }
 


### PR DESCRIPTION
Fixing a few minor metrics bugs:

* Right now `min` is reported as `2147483647` for a histogram with no values...oops!
* counters and rates are returning non-empty metric map with empty value maps when they have no values.