### PR TITLE
gracefulDisconnect => disconnect, disconnect => forceDisconnect

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
@@ -81,7 +81,7 @@ object WebsocketExample {
                   sending = false
                 }
                 case "EXIT" => {
-                  gracefulDisconnect()
+                  disconnect()
                 }
               }
             }

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -73,7 +73,7 @@ class TestController(dataBufferSize: Int, processor: TestInput => Unit, context:
 
 
   def testGracefulDisconnect() {
-    gracefulDisconnect()
+    disconnect()
   }
 }
 

--- a/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
@@ -38,16 +38,16 @@ class CoreHandlerSpec extends ColossusSpec {
       con.typedHandler.connectionState must equal(ConnectionState.NotConnected)
     }
 
-    "disconnect" in {
+    "forceDisconnect" in {
       val con = setup()
-      con.typedHandler.disconnect()
+      con.typedHandler.forceDisconnect()
       con.typedHandler.shutdownCalled must equal(false)
       con.workerProbe.expectMsg(100.milliseconds, WorkerCommand.Disconnect(con.id))
     }
 
-    "graceful disconnect" in {
+    "disconnect" in {
       val con = setup()
-      con.typedHandler.gracefulDisconnect()
+      con.typedHandler.disconnect()
       con.typedHandler.shutdownCalled must equal(true)
       con.workerProbe.expectMsg(100.milliseconds, WorkerCommand.Disconnect(con.id))
     }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -93,7 +93,7 @@ class ServiceServerSpec extends ColossusSpec {
       })
       val r1 = ByteString("AAAA")
       t.typedHandler.receivedData(DataBuffer(r1))
-      t.typedHandler.gracefulDisconnect()
+      t.typedHandler.disconnect()
       t.readsEnabled must equal(false)
       t.status must equal(ConnectionStatus.Connected)
       t.workerProbe.expectNoMsg(100.milliseconds)

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -55,7 +55,7 @@ package object http {
     override def tagDecorator = new ReturnCodeTagDecorator
 
     override def processRequest(input: D#Input): Callback[D#Output] = super.processRequest(input).map{response =>
-      if(!input.head.persistConnection) gracefulDisconnect()
+      if(!input.head.persistConnection) disconnect()
       response
     }
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/package.scala
@@ -2,7 +2,6 @@ package colossus
 package protocols
 
 import core._
-import controller._
 import service._
 import akka.util.{ByteString, ByteStringBuilder}
 import java.util.Random

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -113,7 +113,7 @@ class LoadBalancingClient[I,O] (
   def addClient(address: InetSocketAddress): ServiceClient[I,O] = addClient(address, true)
 
   def removeClient(client: ServiceClient[I,O]) {
-    client.gracefulDisconnect()
+    client.disconnect()
     clients.remove(clients.indexOf(client))
     regeneratePermutations()
   }
@@ -141,8 +141,8 @@ class LoadBalancingClient[I,O] (
     regeneratePermutations()
   }
 
-  def gracefulDisconnect() {
-    clients.foreach{_.gracefulDisconnect()}
+  def disconnect() {
+    clients.foreach{_.disconnect()}
     clients.clear()
   }
       

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -77,7 +77,7 @@ class RequestTimeoutException extends ServiceClientException("Request Timed out"
 class DataException(message: String) extends ServiceClientException(message)
 
 trait ServiceClientLike[I,O]  {
-  def gracefulDisconnect()
+  def disconnect()
   def send(request: I): Callback[O]
 }
 

--- a/colossus/src/main/scala/colossus/service/ServiceClientPool.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClientPool.scala
@@ -35,7 +35,7 @@ class ServiceClientPool[I,O, T <: ServiceClient[I, O]](val commonConfig: ClientC
     }
     removed.foreach{address =>
       val client = clients(address)
-      client.gracefulDisconnect()
+      client.disconnect()
       clients -= address
     }
   }

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -32,6 +32,10 @@ case class ServiceConfig(
   requestMetrics: Boolean = true
 )
 
+object ServiceConfig {
+  val Default = ServiceConfig()
+}
+
 trait RequestFormatter[I] {
   def format(request : I) : String
 }


### PR DESCRIPTION
Minor API change.  This is mostly to signify that the existing `gracefulDisconnect` should be considered the "normal" process of disconnecting, whereas `forceDisconnect` is a more disruptive action.