### PR TITLE
fixing bugs where output controller should not request write

### DIFF
--- a/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
@@ -64,7 +64,7 @@ class OutputControllerSpec extends ColossusSpec {
       p2.expectSuccess()
     }
 
-    "respect pausing writes" in {
+    "respect pausing writes while writing" in {
       val endpoint = static()
       val data = ByteString("hello")
       endpoint.typedHandler.testPush(data){ case _ => endpoint.typedHandler.testPause() }
@@ -76,6 +76,16 @@ class OutputControllerSpec extends ColossusSpec {
       endpoint.iterate()
       p.expectSuccess()
     }
+
+    "not request a write when writes are paused" in {
+      val endpoint = static()
+      val data = ByteString("hello")
+      endpoint.writeReadyEnabled must equal(false)
+      endpoint.typedHandler.testPause()
+      val p = endpoint.typedHandler.pPush(data)
+      endpoint.writeReadyEnabled must equal(false)
+    }
+
       
 
     "drain output buffer on disconnect" in {

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -254,7 +254,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
   private def signalWrite() {
     connectionState match {
       case a: AliveState => {
-        a.endpoint.requestWrite()
+        if (writesEnabled) a.endpoint.requestWrite()
       }
       case _ => {}
     }
@@ -404,7 +404,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
           }
           //TODO this can be cleaned up somehow
           if (continue) {
-            if (state.disconnecting || state.msgQ.size > 0) {
+            if (state.disconnecting || (writesEnabled && state.msgQ.size > 0)) {
               //return incomplete only if we overflowed the buffer and have more
               //in the queue, or id disconnecting to finish the disconnect
               //process


### PR DESCRIPTION
This fixes a bug where if the output controller's writes were manually paused, it would still request a write when a new message was pushed, or if writing was paused while draining the output buffer.  Manually pausing writes can happen from service clients that are limiting the number of concurrent requests.
