### PR TITLE
Http data structures improvements, part 1

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -35,7 +35,7 @@ object BenchmarkService {
       }
     }
   }
-  val response          = ByteString("Hello, World!")
+  val response          = HttpResponseBody("Hello, World!")
   val plaintextHeader   = HttpHeader("Content-Type", "text/plain")
   val jsonHeader        = HttpHeader("Content-Type", "application/json")
   val serverHeader      = HttpHeader("Server", "Colossus")
@@ -65,10 +65,12 @@ object BenchmarkService {
         def handle = { case request => 
           if (request.head.url == "/plaintext") {
             val res = HttpResponse(
-              version  = HttpVersion.`1.1`,
-              code    = HttpCodes.OK,
-              data    = response,
-              headers = new HttpHeaders(Array(plaintextHeader, serverHeader, dateHeader))
+              HttpResponseHead(
+                version  = HttpVersion.`1.1`,
+                code    = HttpCodes.OK,
+                headers = new HttpHeaders(Array(plaintextHeader, serverHeader, dateHeader))
+              ),
+              response
             )
             Callback.successful(res)
           } else if (request.head.url == "/json") {

--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -68,7 +68,7 @@ object BenchmarkService {
               version  = HttpVersion.`1.1`,
               code    = HttpCodes.OK,
               data    = response,
-              headers = HttpHeaders(plaintextHeader, serverHeader, dateHeader)
+              headers = new HttpHeaders(Array(plaintextHeader, serverHeader, dateHeader))
             )
             Callback.successful(res)
           } else if (request.head.url == "/json") {

--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -36,9 +36,9 @@ object BenchmarkService {
     }
   }
   val response          = ByteString("Hello, World!")
-  val plaintextHeader   = HttpResponseHeader("Content-Type", "text/plain")
-  val jsonHeader        = HttpResponseHeader("Content-Type", "application/json")
-  val serverHeader      = HttpResponseHeader("Server", "Colossus")
+  val plaintextHeader   = HttpHeader("Content-Type", "text/plain")
+  val jsonHeader        = HttpHeader("Content-Type", "application/json")
+  val serverHeader      = HttpHeader("Server", "Colossus")
 
 
   def start(port: Int)(implicit io: IOSystem) {
@@ -55,10 +55,10 @@ object BenchmarkService {
     val server = Server.start("benchmark", serverConfig) { worker => new Initializer(worker) {
 
       ///the ??? is filled in almost immediately
-      var dateHeader = HttpResponseHeader("Date", "???")
+      var dateHeader = HttpHeader("Date", "???")
 
       override def receive = {
-        case ts: String => dateHeader = HttpResponseHeader("Date", ts)
+        case ts: String => dateHeader = HttpHeader("Date", ts)
       }
       
       def onConnect = ctx => new Service[Http](serviceConfig, ctx){ 
@@ -68,7 +68,7 @@ object BenchmarkService {
               version  = HttpVersion.`1.1`,
               code    = HttpCodes.OK,
               data    = response,
-              headers = Array(plaintextHeader, serverHeader, dateHeader)
+              headers = HttpHeaders(plaintextHeader, serverHeader, dateHeader)
             )
             Callback.successful(res)
           } else if (request.head.url == "/json") {
@@ -77,7 +77,7 @@ object BenchmarkService {
               version  = HttpVersion.`1.1`,
               code    = HttpCodes.OK,
               data    = compact(render(json)),
-              headers = Array(jsonHeader, serverHeader, dateHeader)
+              headers = HttpHeaders(jsonHeader, serverHeader, dateHeader)
             )
             Callback.successful(res)
           } else {

--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -68,7 +68,7 @@ object BenchmarkService {
               version  = HttpVersion.`1.1`,
               code    = HttpCodes.OK,
               data    = response,
-              headers = Vector(plaintextHeader, serverHeader, dateHeader)
+              headers = Array(plaintextHeader, serverHeader, dateHeader)
             )
             Callback.successful(res)
           } else if (request.head.url == "/json") {
@@ -77,7 +77,7 @@ object BenchmarkService {
               version  = HttpVersion.`1.1`,
               code    = HttpCodes.OK,
               data    = compact(render(json)),
-              headers = Vector(jsonHeader, serverHeader, dateHeader)
+              headers = Array(jsonHeader, serverHeader, dateHeader)
             )
             Callback.successful(res)
           } else {

--- a/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
@@ -32,67 +32,20 @@ abstract class HttpServiceSpec extends ServiceSpec[Http] {
       " " + request.head.url + ": Code " +
       response.head.code + " did not match " +
       expectedCode + ". Body: "  +
-      response.body.map{_.utf8String}.getOrElse("(none)")
+      response.body.bytes.utf8String
     assert(response.head.code == expectedCode, msg)
   }
 
+    
   def assertBody(request : HttpRequest, response : HttpResponse, expectedBody : String){
-    response.body match {
-      case None => throw new Exception(s"No body detected, expected $expectedBody")
-      case Some(x) => assert(x.utf8String == expectedBody, s"${x.utf8String} did not equal $expectedBody")
-    }
-  }
-
-  def get(url: String) = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = url, headers = Nil), None)
-
-  def testGetCode(url : String, expectedCode : HttpCode) {
-    val req = get(url)
-    expectCode(req, expectedCode)
-  }
-
-  def testGet(url: String, expectedBody: String) {
-    val req = get(url)
-    val expected = HttpResponse(
-      HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector(HttpResponseHeader("content-length" ,expectedBody.length.toString))), 
-      Some(ByteString(expectedBody))
-    )
-
-    expectResponse(req, expected)
-  }
-
-  def withGet(url: String, tester: HttpResponse => Any) {
-    val request = get(url)
-    withClient{ client =>
-      val resp = Await.result(client.send(request), requestTimeout)
-      tester(resp)
-    }
-  }
-
-  def testPost(url: String, data: String, expectedCode: HttpCode) {
-    val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Post, url = url, headers = List(("content-length" ->data.length.toString))), Some(ByteString(data)))
-    expectCode(req, expectedCode)
-  }
-
-  def testPost(url: String, data: String, expectedCode: HttpCode, expectedBody : String) {
-    val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Post, url = url, headers = List(("content-length" ->data.length.toString))), Some(ByteString(data)))
-    expectCodeAndBody(req, expectedCode, expectedBody)
-  }
-
-  def testDelete(url: String, expectedCode: HttpCode) {
-    val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Delete, url = url, headers = List()), None)
-    expectCode(req, expectedCode)
-  }
-    
-    
-  def testGetJson[T : Manifest](url : String, expectedResponse : T) {
-    val req = get(url)
-    expectJson(req, expectedResponse)
+    val body = response.body.bytes.utf8String
+    assert(body == expectedBody, s"$body did not equal $expectedBody")
   }
 
   def expectJson[T : Manifest](request : HttpRequest, expectedJson : T) {
     withClient{ client =>
       val resp = Await.result(client.send(request), requestTimeout)
-      val parsed = parse(resp.body.get.utf8String).extract[T]
+      val parsed = parse(resp.body.bytes.utf8String).extract[T]
       parsed must equal(expectedJson)
     }
   }

--- a/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
@@ -43,7 +43,7 @@ abstract class HttpServiceSpec extends ServiceSpec[Http] {
     }
   }
 
-  def get(url: String) = HttpRequest(HttpHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = url, headers = Nil), None)
+  def get(url: String) = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = url, headers = Nil), None)
 
   def testGetCode(url : String, expectedCode : HttpCode) {
     val req = get(url)
@@ -69,17 +69,17 @@ abstract class HttpServiceSpec extends ServiceSpec[Http] {
   }
 
   def testPost(url: String, data: String, expectedCode: HttpCode) {
-    val req = HttpRequest(HttpHead(version = HttpVersion.`1.1`, method = HttpMethod.Post, url = url, headers = List(("content-length" ->data.length.toString))), Some(ByteString(data)))
+    val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Post, url = url, headers = List(("content-length" ->data.length.toString))), Some(ByteString(data)))
     expectCode(req, expectedCode)
   }
 
   def testPost(url: String, data: String, expectedCode: HttpCode, expectedBody : String) {
-    val req = HttpRequest(HttpHead(version = HttpVersion.`1.1`, method = HttpMethod.Post, url = url, headers = List(("content-length" ->data.length.toString))), Some(ByteString(data)))
+    val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Post, url = url, headers = List(("content-length" ->data.length.toString))), Some(ByteString(data)))
     expectCodeAndBody(req, expectedCode, expectedBody)
   }
 
   def testDelete(url: String, expectedCode: HttpCode) {
-    val req = HttpRequest(HttpHead(version = HttpVersion.`1.1`, method = HttpMethod.Delete, url = url, headers = List()), None)
+    val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Delete, url = url, headers = List()), None)
     expectCode(req, expectedCode)
   }
     

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
@@ -4,7 +4,9 @@ package colossus.protocols.http
 import org.scalatest._
 
 
-class HttpHeadSuite extends WordSpec with MustMatchers{
+class HttpRequestHeadSuite extends WordSpec with MustMatchers{
+  
+  import HttpHeader.Conversions._
 
   "Cookie" must {
     "parse cookie with equal sign in value" in {
@@ -15,25 +17,38 @@ class HttpHeadSuite extends WordSpec with MustMatchers{
       c.head.value must equal("bar=baz")
     }
   }
+
+  "HttpHeaders" must {
+
+    "decoded match encoded" in {
+      val d = new DecodedHeader("foo", "bar")
+      val e = d.toEncodedHeader
+      e must equal(d)
+    }
+
+    "be equal" in {
+      HttpHeaders(HttpHeader("a", "b"), HttpHeader("b", "c")) must equal(HttpHeaders(HttpHeader("b", "c"), HttpHeader("a", "b")))
+    }
+  }
   
 
-  "HttpHead" must {
+  "HttpRequestHead" must {
     "correctly parse a cookie" in {
-      val head = HttpHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo=bar")))
+      val head = HttpRequestHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo=bar")))
       val expected = List(
         Cookie("foo", "bar", None)
       )
       head.cookies must equal(expected)
     }
     "correctly parse a cookie with whitespace around the equals" in {
-      val head = HttpHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo = bar")))
+      val head = HttpRequestHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo = bar")))
       val expected = List(
         Cookie("foo", "bar", None)
       )
       head.cookies must equal(expected)
     }
     "parse two cookies in the same header line" in {
-      val head = HttpHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo=bar ; bar=baz")))
+      val head = HttpRequestHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo=bar ; bar=baz")))
       val expected = List(
         Cookie("foo", "bar", None),
         Cookie("bar", "baz", None)
@@ -41,7 +56,7 @@ class HttpHeadSuite extends WordSpec with MustMatchers{
       head.cookies must equal(expected)
     }
     "parse cookies with expiration" in {
-      val head = HttpHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo=bar ; bar=baz ; Expires=Wed, 09 Jun 2021 10:18:14 GMT")))
+      val head = HttpRequestHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo=bar ; bar=baz ; Expires=Wed, 09 Jun 2021 10:18:14 GMT")))
       val exp = Cookie.parseCookieExpiration("Wed, 09 Jun 2021 10:18:14 GMT")
       val expected = List(
         Cookie("foo", "bar", Some(exp)),
@@ -50,7 +65,7 @@ class HttpHeadSuite extends WordSpec with MustMatchers{
       head.cookies must equal(expected)
     }
     "parse cookie with optional value" in {
-      val head = HttpHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo=bar ; bar")))
+      val head = HttpRequestHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, List(("cookie" -> "foo=bar ; bar")))
       val expected = List(
         Cookie("foo", "bar", None),
         Cookie("bar", "true", None)
@@ -59,15 +74,15 @@ class HttpHeadSuite extends WordSpec with MustMatchers{
     }
 
     "parse query string parameter with no value" in {
-      val head = HttpHead(HttpMethod.Get, "/foo?a=&b=c", HttpVersion.`1.1`, Nil)
+      val head = HttpRequestHead(HttpMethod.Get, "/foo?a=&b=c", HttpVersion.`1.1`, Nil)
       head.parameters("a") must equal("")
 
-      val head2 = HttpHead(HttpMethod.Get, "/foo?a&b=c", HttpVersion.`1.1`, Nil)
+      val head2 = HttpRequestHead(HttpMethod.Get, "/foo?a&b=c", HttpVersion.`1.1`, Nil)
       head2.parameters("a") must equal("")
     }
 
     "correctly handle = in query string parameter values" in {
-      val head = HttpHead(HttpMethod.Get, "/foo?a=b&b=c=d&e=f=", HttpVersion.`1.1`, Nil)
+      val head = HttpRequestHead(HttpMethod.Get, "/foo?a=b&b=c=d&e=f=", HttpVersion.`1.1`, Nil)
       head.parameters("a") must equal("b")
       head.parameters("b") must equal("c=d")
       head.parameters("e") must equal("f=")

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -15,13 +15,14 @@ object Broke extends Tag("broke")
 class HttpParserSuite extends WordSpec with MustMatchers{
 
   def requestParser = HttpRequestParser()
+  import HttpHeader.Conversions._
 
   "http request parser" must {
     "parse a basic request" in {
       val req = "GET /hello/world HTTP/1.1\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nAuthorization: Basic XXX\r\nAccept-Encoding: gzip, deflate\r\n\r\n"
       val parser = requestParser
 
-      val expected = HttpRequest(HttpHead(
+      val expected = HttpRequest(HttpRequestHead(
         method = HttpMethod.Get,
         url = "/hello/world",
         version = HttpVersion.`1.1`,
@@ -30,7 +31,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "accept" -> "*/*",
           "authorization" -> "Basic XXX",
           "accept-encoding" -> "gzip, deflate"
-        ).reverse
+        )
       ), None)        
       
       parser.parse(DataBuffer(ByteString(req))).toList must equal(List(expected))
@@ -40,7 +41,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       val req = "GET /hello/world HTTP/1.1\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nAuthorization: Basic XXX\r\nAccept-Encoding: gzip, deflate\r\n\r\n"
       val parser = requestParser
 
-      val expected = HttpRequest(HttpHead(
+      val expected = HttpRequest(HttpRequestHead(
         method = HttpMethod.Get,
         url = "/hello/world",
         version = HttpVersion.`1.1`,
@@ -49,7 +50,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "accept" -> "*/*",
           "authorization" -> "Basic XXX",
           "accept-encoding" -> "gzip, deflate"
-        ).reverse
+        )
       ), None)        
 
       (0 until req.length).foreach{splitIndex =>
@@ -68,7 +69,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     "parse request with no headers" in {
       val req = "GET /hello HTTP/1.1\r\n\r\n"
       val parser = requestParser
-      val expected = HttpRequest(HttpHead(method = HttpMethod.Get, url="/hello", version = HttpVersion.`1.1`, headers = Nil), None)
+      val expected = HttpRequest(HttpRequestHead(method = HttpMethod.Get, url="/hello", version = HttpVersion.`1.1`, headers = Nil), None)
       parser.parse(DataBuffer(ByteString(req))) must equal (Some(expected))
     }
 
@@ -76,7 +77,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       val body = ByteString("HELLO I AM A BODY")
       val len = body.size
       val req = s"POST /hello/world HTTP/1.1\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nContent-Length: $len\r\n\r\n${body.utf8String}"
-      val expected = HttpRequest(HttpHead(
+      val expected = HttpRequest(HttpRequestHead(
         method = HttpMethod.Post,
         url = "/hello/world",
         version = HttpVersion.`1.1`,
@@ -84,7 +85,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "host" -> "api.foo.bar:444",
           "accept" ->  "*/*",
           "content-length" -> len.toString
-        ).reverse
+        )
       ), Some(body))        
 
       val parser = requestParser
@@ -94,7 +95,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
 
     "handle request with content-length set to 0" in {
       val req = s"POST /hello/world HTTP/1.1\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nContent-Length: 0\r\n\r\n"
-      val expected = HttpRequest(HttpHead(
+      val expected = HttpRequest(HttpRequestHead(
         method = HttpMethod.Post,
         url = "/hello/world",
         version = HttpVersion.`1.1`,
@@ -102,7 +103,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "host" -> "api.foo.bar:444",
           "accept" -> "*/*",
           "content-length" -> "0"
-        ).reverse
+        )
       ), None)        
 
       val parser = requestParser
@@ -135,7 +136,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     "parse request with authorization header" taggedAs(Broke) in {
       val auth_info = "Basic YmI6Y29vbHBhc3N3b3JkYnJvNDI="// + Base64.encodeBase64String(StringUtils.getBytesUtf8("bb:coolpasswordbro42"))
       val url = "/foo"
-      val request = HttpRequest(HttpHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = url, headers = List("authorization" -> auth_info)), None)
+      val request = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = url, headers = List("authorization" -> auth_info)), None)
       val bytes = request.bytes
       val parser = requestParser
       parser.parse(DataBuffer(bytes)).isEmpty must equal(false)
@@ -195,7 +196,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "parse a generated request" in {
-      val req = HttpRequest(HttpHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = "/foo", headers = Nil), None)
+      val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = "/foo", headers = Nil), None)
       val data = DataBuffer(req.bytes)
       val parser = requestParser
       parser.parse(data) must equal(Some(req))
@@ -218,9 +219,9 @@ class HttpParserSuite extends WordSpec with MustMatchers{
 
 
 
-  "HttpHead parameter parsing" must {
+  "HttpRequestHead parameter parsing" must {
 
-    def h(url: String) = HttpHead(HttpMethod.Get, url, HttpVersion.`1.1`, Nil).parameters
+    def h(url: String) = HttpRequestHead(HttpMethod.Get, url, HttpVersion.`1.1`, Nil).parameters
     def p(params: (String, String)*) = QueryParameters(params.toSeq)
       
     "parse a basic url" in {
@@ -296,7 +297,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "match on http request" in {
-      val h = HttpRequest(HttpHead(Get, "/a/b/c", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/a/b/c", `1.1`, Nil), None)
       val res: Boolean = h match {
         case Get on Root / "a" / "b" / "c" => true
         case _ => false
@@ -304,7 +305,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       res must equal(true)
     }
     "match on http request with one route" in {
-      val h = HttpRequest(HttpHead(Get, "/a", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/a", `1.1`, Nil), None)
       val res: Boolean = h match {
         case Get on Root / "a" => true
         case _ => false
@@ -313,7 +314,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "match http request with integer" in {
-      val h = HttpRequest(HttpHead(Get, "/foo/bar/3", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/foo/bar/3", `1.1`, Nil), None)
       val res: Int = h match {
         case Get on Root / "foo" / "bar" / Integer(x) => x
         case _ => 0
@@ -324,7 +325,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
 
 
     "match http request with long" in {
-      val h = HttpRequest(HttpHead(Get, "/foo/bar/17592186044416", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/foo/bar/17592186044416", `1.1`, Nil), None)
       val res: Long = h match {
         case Get on Root / "foo" / "bar" / Long(x) => x
         case _ => 0
@@ -333,7 +334,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "match root url" in {
-      val h = HttpRequest(HttpHead(Get, "/", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/", `1.1`, Nil), None)
       val res: Boolean = h match {
         case Get on Root => true
         case _ => false
@@ -342,7 +343,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "parse requests with no request parameters" in {
-      val req = HttpRequest(HttpHead(HttpMethod.Get, "a/path/with/1", HttpVersion.`1.1`, Nil), None)
+      val req = HttpRequest(HttpRequestHead(HttpMethod.Get, "a/path/with/1", HttpVersion.`1.1`, Nil), None)
       req match {
         case r @ Get on Root / "a" / "path" / "with" / Integer(1) =>
         case _ => throw new Exception(s"$req failed to parse correctly")
@@ -350,7 +351,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "parse requests with request parameters" in {
-      val req = HttpRequest(HttpHead(HttpMethod.Get, "a/path/with/1?a=bla&b=2", HttpVersion.`1.1`, Nil), None)
+      val req = HttpRequest(HttpRequestHead(HttpMethod.Get, "a/path/with/1?a=bla&b=2", HttpVersion.`1.1`, Nil), None)
       req match {
         case r @ Get on Root / "a" / "path" / "with" / Integer(1) =>
         case _ => throw new Exception(s"$req failed to parse correctly")

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpResponseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpResponseSpec.scala
@@ -18,9 +18,9 @@ class HttpResponseSpec extends ColossusSpec with TryValues with OptionValues wit
 
     "be constuctable from a ByteStringLike" in {
 
-      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.ACCEPTED, Vector(), "test conversion")
+      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.ACCEPTED, HttpHeaders(), "test conversion")
 
-      val expected = HttpResponse(HttpVersion.`1.1`, HttpCodes.ACCEPTED, Vector(), ByteString("test conversion"))
+      val expected = HttpResponse(HttpVersion.`1.1`, HttpCodes.ACCEPTED, HttpHeaders(), ByteString("test conversion"))
 
       response must equal(expected)
 
@@ -32,12 +32,12 @@ class HttpResponseSpec extends ColossusSpec with TryValues with OptionValues wit
     "be constructable from a StaticHttpResponse" in {
 
       val payload = "look ma, no hands!"
-      val res = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Vector(), ByteString(payload))
+      val res = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, HttpHeaders(), ByteString(payload))
 
       val streamed = StreamingHttpResponse.fromStatic(res)
 
       streamed.body.get.pullCB() must evaluateTo{x : Option[DataBuffer] =>
-        ByteString(x.value.takeAll) must equal(res.body.get)
+        ByteString(x.value.takeAll) must equal(res.body.bytes)
       }
     }
 
@@ -46,11 +46,11 @@ class HttpResponseSpec extends ColossusSpec with TryValues with OptionValues wit
       val payload = "look ma, no hands!"
 
       val expected = StreamingHttpResponse(
-        HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector(HttpResponseHeader("content-length", "18"))), 
+        HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, HttpHeaders(HttpHeader("content-length", "18"))), 
         Some(Source.one(DataBuffer(ByteString("test conversion"))))
       )
 
-      val response = StreamingHttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Vector(), payload)
+      val response = StreamingHttpResponse(HttpVersion.`1.1`, HttpCodes.OK, HttpHeaders(), payload)
 
       response.head must equal(expected.head)
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -10,9 +10,11 @@ import akka.util.ByteString
 
 class HttpSpec extends WordSpec with MustMatchers{
 
+  import HttpHeader.Conversions._
+
   "http request" must {
     "encode to bytes" in {
-      val head = HttpHead(
+      val head = HttpRequestHead(
         version = HttpVersion.`1.1`,
         url = "/hello",
         method = HttpMethod.Post,
@@ -26,7 +28,7 @@ class HttpSpec extends WordSpec with MustMatchers{
     }
 
     "encode request with headers and no body" in {
-      val head = HttpHead(
+      val head = HttpRequestHead(
         version = HttpVersion.`1.1`,
         url = "/hello",
         method = HttpMethod.Post,
@@ -40,7 +42,7 @@ class HttpSpec extends WordSpec with MustMatchers{
     }
 
     "want to close HTTP/1.0 requests without the Connection header" in {
-      val head = HttpHead(
+      val head = HttpRequestHead(
         version = HttpVersion.`1.0`,
         url = "/hello",
         method = HttpMethod.Post,
@@ -52,7 +54,7 @@ class HttpSpec extends WordSpec with MustMatchers{
     }
 
     "want to close HTTP/1.0 requests without keep-alive in the Connection header" in {
-      val head = HttpHead(
+      val head = HttpRequestHead(
         version = HttpVersion.`1.0`,
         url = "/hello",
         method = HttpMethod.Post,
@@ -64,7 +66,7 @@ class HttpSpec extends WordSpec with MustMatchers{
     }
 
     "want to persist HTTP/1.0 requests with keep-alive in the Connection header" in {
-      val head = HttpHead(
+      val head = HttpRequestHead(
         version = HttpVersion.`1.0`,
         url = "/hello",
         method = HttpMethod.Post,
@@ -76,7 +78,7 @@ class HttpSpec extends WordSpec with MustMatchers{
     }
 
     "want to persist HTTP/1.1 requests without the Connection header" in {
-      val head = HttpHead(
+      val head = HttpRequestHead(
         version = HttpVersion.`1.1`,
         url = "/hello",
         method = HttpMethod.Post,
@@ -88,7 +90,7 @@ class HttpSpec extends WordSpec with MustMatchers{
     }
 
     "want to persist HTTP/1.1 requests without close in the Connection header" in {
-      val head = HttpHead(
+      val head = HttpRequestHead(
         version = HttpVersion.`1.1`,
         url = "/hello",
         method = HttpMethod.Post,
@@ -100,7 +102,7 @@ class HttpSpec extends WordSpec with MustMatchers{
     }
 
     "want to close HTTP/1.1 requests with close in the Connection header" in {
-      val head = HttpHead(
+      val head = HttpRequestHead(
         version = HttpVersion.`1.1`,
         url = "/hello",
         method = HttpMethod.Post,
@@ -116,7 +118,7 @@ class HttpSpec extends WordSpec with MustMatchers{
   "http response" must {
     "encode basic response" in {
       val content = "Hello World!"
-      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Vector(), ByteString(content))
+      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, HttpHeaders(), ByteString(content))
       val expected = s"HTTP/1.1 200 OK\r\nContent-Length: ${content.length}\r\n\r\n$content"
       val buf = new DynamicOutBuffer(100)
       val res = response.encode(buf)
@@ -126,7 +128,7 @@ class HttpSpec extends WordSpec with MustMatchers{
 
     "encode a basic response as a stream" ignore {
       val content = "Hello World!"
-      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, Vector(), ByteString(content))
+      val response = HttpResponse(HttpVersion.`1.1`, HttpCodes.OK, HttpHeaders(), ByteString(content))
       val expected = s"HTTP/1.1 200 OK\r\nContent-Length: ${content.length}\r\n\r\n$content"
       //val stream: DataReader = StreamingHttpResponse.fromStatic(response).encode(new DynamicOutBuffer(100))
     }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/WildcardURLParsingTest.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/WildcardURLParsingTest.scala
@@ -12,7 +12,7 @@ class WildcardURLParsingTest extends WordSpec with MustMatchers {
     "The wildcard url parser" should {
       "match a root url" in {
           val url = ""
-          val request = HttpRequest(HttpHead(Get, url, `1.1`, List()), None)
+          val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), None)
           request match {
             case req @ Get on Root => {}
             case _ => fail()
@@ -21,7 +21,7 @@ class WildcardURLParsingTest extends WordSpec with MustMatchers {
 
       "match a resource url" in {
         val url = "/moose.jpg"
-        val request = HttpRequest(HttpHead(Get, url, `1.1`, List()), None)
+        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), None)
         request match {
           case req @ Get on Root /: rest => rest must be("moose.jpg")
           case _ => fail("Failed to match url")
@@ -30,7 +30,7 @@ class WildcardURLParsingTest extends WordSpec with MustMatchers {
 
       "match a complex resource url" in {
         val url = "/bronx/zoo/moose.jpg"
-        val request = HttpRequest(HttpHead(Get, url, `1.1`, List()), None)
+        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), None)
         request match {
           case req @ Get on base /: city /: place /: animal  =>
             base must be("/")
@@ -43,7 +43,7 @@ class WildcardURLParsingTest extends WordSpec with MustMatchers {
 
       "partially match a url" in {
         val url = "/bronx/zoo/moose.jpg"
-        val request = HttpRequest(HttpHead(Get, url, `1.1`, List()), None)
+        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), None)
         request match {
           case req @ Get on Root /: city /: placeAndAnimal => placeAndAnimal must be("zoo/moose.jpg")
           case _ => fail("Failed to match complex url")

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
@@ -17,7 +17,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
   import DecodedResult.Static
 
-  import HttpResponseHeader.Conversions._
+  import HttpHeader.Conversions._
 
   "HttpResponseParser" must {
 
@@ -25,7 +25,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       val res = ByteString("HTTP/1.1 204 NO_CONTENT\r\n\r\n")
       val parser = HttpResponseParser.static(res.size.bytes)
       val data = DataBuffer(res)
-      parser.parse(data) must equal(Some(Static(HttpResponse(HttpResponseHead(HttpVersion.`1.1`, HttpCodes.NO_CONTENT, Vector()), None))))
+      parser.parse(data) must equal(Some(Static(HttpResponse(HttpVersion.`1.1`, HttpCodes.NO_CONTENT, HttpHeaders()))))
       data.remaining must equal(0)
     }
 
@@ -35,12 +35,18 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       val res = "HTTP/1.1 200 OK\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nAuthorization: Basic XXX\r\nAccept-Encoding: gzip, deflate\r\ncontent-length: 0\r\n\r\n"
       val parser = HttpResponseParser.static()
 
-      val expected = Static(HttpResponse(
+      val expected = HttpResponse(
         HttpVersion.`1.1`,
         HttpCodes.OK,
-        Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate", "content-length"->"0")
-      ))
-      parser.parse(DataBuffer(ByteString(res))) must equal(Some(expected))
+        Seq("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate", "content-length"->"0")
+      )
+      val actual = parser.parse(DataBuffer(ByteString(res))).get.value
+      println(actual.head.headers.toSeq.toSet.toString)
+      println(expected.head.headers.toSeq.toSet.toString)
+      println("ISECT " + actual.head.headers.toSeq.toSet.intersect(expected.head.headers.toSeq.toSet).toString)
+      actual.head.headers must equal(expected.head.headers)
+      actual must equal(expected)
+
     }
 
     "parse a 200 response with body and no content-length" in {
@@ -53,9 +59,9 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
         HttpResponseHead(
           HttpVersion.`1.1`,
           HttpCodes.OK,
-          Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate")
+          Seq("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate")
         ),
-        Some(ByteString(body))
+        HttpResponseBody(body)
       ))
       parser.parse(DataBuffer(ByteString(res))) must equal(None)
       parser.endOfStream() must equal(Some(expected))
@@ -69,7 +75,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
       val expected = Static(HttpResponse(HttpVersion.`1.1`,
         HttpCodes.OK,
-        Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate", "content-length"->size.toString),
+        Seq("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate", "content-length"->size.toString),
         ByteString("{some : json}")
       ))
       val data = DataBuffer(ByteString(res))
@@ -82,7 +88,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       val sent = HttpResponse(
         HttpVersion.`1.1`,
         HttpCodes.OK,
-        Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate")
+        Seq("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate")
       )
 
       val expected = Some(DecodedResult.Static(sent.withHeader("content-length", "0")))
@@ -106,7 +112,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       val sent = HttpResponse(
         HttpVersion.`1.1`,
         HttpCodes.OK,
-        Vector("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate"),
+        Seq("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate"),
         ByteString("{some : json}")
       )
 
@@ -127,7 +133,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
     "accept a response under the size limit" in {
       val res = ByteString("HTTP/1.1 304 NOT_MODIFIED\r\n\r\n")
       val parser = HttpResponseParser.static(res.size.bytes)
-      parser.parse(DataBuffer(res)) must equal(Some(Static(HttpResponse(HttpVersion.`1.1`, HttpCodes.NOT_MODIFIED, Vector()))))
+      parser.parse(DataBuffer(res)) must equal(Some(Static(HttpResponse(HttpVersion.`1.1`, HttpCodes.NOT_MODIFIED, Seq()))))
     }
 
     "reject a response over the size limit" in {
@@ -143,7 +149,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       val parser = HttpResponseParser.static()
 
       val parsed = parser.parse(DataBuffer(ByteString(res))).get
-      parsed.value.body.get must equal (ByteString("foo123456789abcde"))
+      parsed.value.body.bytes must equal (ByteString("foo123456789abcde"))
     }
       
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/StreamingHttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/StreamingHttpResponseParserSpec.scala
@@ -15,7 +15,7 @@ class StreamingHttpResponseParserSpec extends ColossusSpec with MustMatchers wit
   implicit val cbe = FakeIOSystem.testExecutor
 
   implicit val duration = 1.second
-  import HttpResponseHeader.Conversions._
+  import HttpHeader.Conversions._
 
   "StreamingHttpResponseParser" must {
 

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -14,8 +14,10 @@ import scala.util.Success
 
 class WebsocketSpec extends WordSpec with MustMatchers{
 
+  import HttpHeader.Conversions._
+
   val valid = HttpRequest(
-    HttpHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, Vector(
+    HttpRequestHead(HttpMethod.Get, "/foo", HttpVersion.`1.1`, Vector(
       ("connection", "Upgrade"),
       ("upgrade", "Websocket"),
       ("sec-websocket-version", "13"),
@@ -40,13 +42,13 @@ class WebsocketSpec extends WordSpec with MustMatchers{
         HttpResponseHead(
           HttpVersion.`1.1`,
           HttpCodes.SWITCHING_PROTOCOLS,
-          Vector(
-            HttpResponseHeader("Upgrade", "websocket"),
-            HttpResponseHeader("Connection", "Upgrade"),
-            HttpResponseHeader("Sec-Websocket-Accept","MeFiDAjivCOffr7Pn3T2DM7eJHo=")
+          HttpHeaders(
+            HttpHeader("Upgrade", "websocket"),
+            HttpHeader("Connection", "Upgrade"),
+            HttpHeader("Sec-Websocket-Accept","MeFiDAjivCOffr7Pn3T2DM7eJHo=")
           )
         ),
-        None
+        HttpResponseBody.NoBody
       )
       UpgradeRequest.unapply(valid).get must equal(expected)
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -196,7 +196,11 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
 
   def accepting: Receive = {
     case Select => {
-      selectLoop()
+      var n = 0
+      while (n < 5) {
+        selectLoop()
+        n += 1
+      }
       self ! Select
     }
     case c: IOCommand => handleIOCommand(c)

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -196,11 +196,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
 
   def accepting: Receive = {
     case Select => {
-      var n = 0
-      while (n < 5) {
-        selectLoop()
-        n += 1
-      }
+      selectLoop()
       self ! Select
     }
     case c: IOCommand => handleIOCommand(c)

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -64,37 +64,68 @@ object HttpHeaders {
   val CookieHeader      = "cookie"
   val SetCookie         = "set-cookie"
   val TransferEncoding  = "transfer-encoding"
+
+  def apply(hdrs: HttpHeader*) : HttpHeaders = new HttpHeaders(hdrs.toList)
 }
 
-//TODO: support for pulling values as types other than String
-trait HttpHeaderUtils {
+trait HttpHeader {
+  def key: String
+  def value: String
+  def encoded: Array[Byte]
 
-  def headers : Seq[(String, String)]
+}
+
+//generally created when encoding http responses
+class EncodedHeader(val encoded: Array[Byte], keyLength: Int, valueStart: Int) extends HttpHeader {
+  lazy val key = new String(encoded.take(keyLength))
+  lazy val value = new String(encoded.drop(valueStart))
+}
+
+//generally created when parsing http requests
+class DecodedHeader(val key: String, val value: String) extends HttpHeader {
+  lazy val encoded = (key + ": " + value).getBytes("UTF-8")
+
+  def toEncodedHeader = new EncodedHeader(encoded, key.length, key.length + 2)
+}
 
 
+object HttpHeader {
+  def apply(key: String, value: String): HttpHeader = (new DecodedHeader(key, value)).toEncodedHeader
+
+
+  object Conversions {
+    implicit def stringTuple2Header(t: (String, String)): HttpHeader = HttpHeader(t._1, t._2)
+    implicit def seqStringTuple2Headers(t: List[(String, String)]): HttpHeaders = new HttpHeaders(t.map{stringTuple2Header}.toList)
+  }
+
+}
+    
+class HttpHeaders(val headers: List[HttpHeader]) {
   def singleHeader(name: String): Option[String] = {
     val l = name.toLowerCase
-    headers.collectFirst{ case (`l`, v) => v}
+    headers.collectFirst{ case x if (x.key == l) => x.value }
   }
 
   def multiHeader(name: String): Seq[String] = {
     val l = name.toLowerCase
-    headers.collect{ case (`l`, v) => v}
+    headers.collect{ case x if (x.key == l) => x.value }
   }
-
-  //TODO: These vals are probably inefficient, should be generated as the
-  //headers are being parsed.  Benchmark before changing
 
   /** Returns the value of the content-length header, if it exists.
    * 
    * Be aware that lacking this header may or may not be a valid request,
    * depending if the "transfer-encoding" header is set to "chunked"
    */
-  lazy val contentLength: Option[Int] = headers.collectFirst{case (HttpHeaders.ContentLength, l) => l.toInt}
+  lazy val contentLength: Option[Int] = singleHeader(HttpHeaders.ContentLength).map{_.toInt}
 
   lazy val transferEncoding : TransferEncoding = singleHeader(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
 
   lazy val connection: Option[Connection] = singleHeader(HttpHeaders.Connection).flatMap(Connection.unapply)
+
+  def + (kv: (String, String)) = new HttpHeaders(HttpHeader(kv._1, kv._2) :: headers)
+
+  def size = headers.size
+
 }
 
 
@@ -182,6 +213,8 @@ object Connection {
   }
 }
 
+
+
 case class QueryParameters(parameters: Seq[(String, String)]) extends AnyVal{
 
   def apply(key: String) = getFirst(key).get
@@ -207,66 +240,4 @@ case class QueryParameters(parameters: Seq[(String, String)]) extends AnyVal{
 
 }
 
-case class HttpHead(method: HttpMethod, url: String, version: HttpVersion, headers: Seq[(String, String)]) extends HttpHeaderUtils {
-  import HttpHeaders._
-
-  lazy val (path, query) = {
-    val pieces = url.split("\\?",2)
-    (pieces(0), if (pieces.size > 1) Some(pieces(1)) else None)
-  }
-
-  lazy val parameters: QueryParameters = query.map { qstring =>
-    def decode(s: String) = java.net.URLDecoder.decode(s, "UTF-8")
-    var build = Vector[(String, String)]()
-    var remain = qstring
-    while (remain != "") {
-      val keyval = remain.split("&", 2)
-      val splitKV = keyval(0).split("=", 2)
-      val key = decode(splitKV(0))
-      val value = if (splitKV.size > 1) decode(splitKV(1)) else ""
-      build = build :+ (key -> value)
-      remain = if (keyval.size > 1) keyval(1) else ""
-    }
-    QueryParameters(build)
-  } getOrElse QueryParameters(Vector())
-
-  def withHeader(header: String, value: String): HttpHead = {
-    copy(headers = (header -> value) +: headers)
-  }
-
-  lazy val cookies: Seq[Cookie] = multiHeader(CookieHeader).flatMap{Cookie.parseHeader}
-
-  //we should only encode if the string is decoded.
-  //To check for that, if we decode an already decoded URL, it should not change (this may not be necessary)
-  //the alternative is one big fat honkin ugly regex and knowledge of what characters are allowed where(gross)
-  //TODO: this doesn't work, "/test" becomes %2Ftest
-  private def getEncodedURL : String = url
-  /*{
-    if(URLDecoder.decode(url,"UTF-8") == url) {
-      URLEncoder.encode(url, "UTF-8")
-    }else {
-      url
-    }
-  }*/
-
-
-  //TODO: optimize
-  def bytes : ByteString = {
-    val reqString = ByteString(s"${method.name} $getEncodedURL HTTP/$version\r\n")
-    if (headers.size > 0) {
-      val headerString = ByteString(headers.map{case(k,v) => k + ": " + v}.mkString("\r\n"))
-      reqString ++ headerString ++ ByteString("\r\n\r\n")
-    } else {
-      reqString ++ ByteString("\r\n")
-    }
-  }
-
-  def persistConnection: Boolean =
-    (version, connection) match {
-      case (HttpVersion.`1.1`, Some(Close)) => false
-      case (HttpVersion.`1.1`, _) => true
-      case (HttpVersion.`1.0`, Some(KeepAlive)) => true
-      case (HttpVersion.`1.0`, _) => false
-    }
-}
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -110,12 +110,12 @@ object HttpHeader {
 }
     
 class HttpHeaders(private val headers: Array[HttpHeader]) {
-  def singleHeader(name: String): Option[String] = {
+  def firstValue(name: String): Option[String] = {
     val l = name.toLowerCase
     headers.collectFirst{ case x if (x.key == l) => x.value }
   }
 
-  def multiHeader(name: String): Seq[String] = {
+  def allValues(name: String): Seq[String] = {
     val l = name.toLowerCase
     headers.collect{ case x if (x.key == l) => x.value }
   }
@@ -125,11 +125,11 @@ class HttpHeaders(private val headers: Array[HttpHeader]) {
    * Be aware that lacking this header may or may not be a valid request,
    * depending if the "transfer-encoding" header is set to "chunked"
    */
-  def contentLength: Option[Int] = singleHeader(HttpHeaders.ContentLength).map{_.toInt}
+  def contentLength: Option[Int] = firstValue(HttpHeaders.ContentLength).map{_.toInt}
 
-  def transferEncoding : TransferEncoding = singleHeader(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
+  def transferEncoding : TransferEncoding = firstValue(HttpHeaders.TransferEncoding).flatMap(TransferEncoding.unapply).getOrElse(TransferEncoding.Identity)
 
-  def connection: Option[Connection] = singleHeader(HttpHeaders.Connection).flatMap(Connection.unapply)
+  def connection: Option[Connection] = firstValue(HttpHeaders.Connection).flatMap(Connection.unapply)
 
   def + (kv: (String, String)) = new HttpHeaders(headers :+ HttpHeader(kv._1, kv._2))
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -25,9 +25,11 @@ object HttpMethod {
 
   def apply(str: String): HttpMethod = {
     val ucase = str.toUpperCase
-    methods.find{_.name == ucase}.getOrElse(
-      throw new ParseException(s"Invalid http method $str")
-    )
+    def loop(remain: List[HttpMethod]): HttpMethod = remain match {
+      case head :: tail => if (head.name == ucase) head else loop(tail)
+      case Nil => throw new ParseException(s"Invalid http method $str")
+    }
+    loop(methods)    
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -73,6 +73,15 @@ trait HttpHeader {
   def value: String
   def encoded: Array[Byte]
 
+  override def equals(that: Any): Boolean = that match {
+    case that: HttpHeader => this.key == that.key && this.value == that.value
+    case other => false
+  }
+
+  override def hashCode = (key + value).hashCode
+
+  override def toString = s"($key,$value)"
+
 }
 
 //generally created when encoding http responses
@@ -95,12 +104,12 @@ object HttpHeader {
 
   object Conversions {
     implicit def stringTuple2Header(t: (String, String)): HttpHeader = HttpHeader(t._1, t._2)
-    implicit def seqStringTuple2Headers(t: List[(String, String)]): HttpHeaders = new HttpHeaders(t.map{stringTuple2Header}.toArray)
+    implicit def seqStringTuple2Headers(t: Seq[(String, String)]): HttpHeaders = new HttpHeaders(t.map{stringTuple2Header}.toArray)
   }
 
 }
     
-class HttpHeaders(private val headers: Array[HttpHeader]) extends AnyVal {
+class HttpHeaders(private val headers: Array[HttpHeader]) {
   def singleHeader(name: String): Option[String] = {
     val l = name.toLowerCase
     headers.collectFirst{ case x if (x.key == l) => x.value }
@@ -126,6 +135,8 @@ class HttpHeaders(private val headers: Array[HttpHeader]) extends AnyVal {
 
   def size = headers.size
 
+  def toSeq : Seq[HttpHeader] = headers
+
   def encode(buffer: core.DataOutBuffer) {
     var i = 0
     while (i < headers.size) {
@@ -135,6 +146,13 @@ class HttpHeaders(private val headers: Array[HttpHeader]) extends AnyVal {
     }
 
   }
+
+  override def equals(that: Any): Boolean = that match {
+    case that: HttpHeaders => this.toSeq.toSet == that.toSeq.toSet
+    case other => false
+  }
+
+  override def toString = "[" + headers.map{_.toString}.mkString(" ") + "]"
 
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -9,7 +9,7 @@ case class HttpRequest(head: HttpHead, entity: Option[ByteString]) {
 
   def respond(code: HttpCode, data: String, headers: List[(String, String)] = Nil) = {
     import HttpResponseHeader.Conversions._
-    HttpResponse(HttpResponseHead(version, code, headers.toVector), Some(ByteString(data)))
+    HttpResponse(HttpResponseHead(version, code, headers), Some(ByteString(data)))
   }
 
   def ok(data: String, headers: List[(String, String)] = Nil)              = respond(OK, data, headers)

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -29,7 +29,7 @@ case class HttpRequestHead(method: HttpMethod, url: String, version: HttpVersion
     copy(headers = headers + (header -> value))
   }
 
-  lazy val cookies: Seq[Cookie] = headers.multiHeader(HttpHeaders.CookieHeader).flatMap{Cookie.parseHeader}
+  lazy val cookies: Seq[Cookie] = headers.allValues(HttpHeaders.CookieHeader).flatMap{Cookie.parseHeader}
 
   //we should only encode if the string is decoded.
   //To check for that, if we decode an already decoded URL, it should not change (this may not be necessary)
@@ -96,7 +96,6 @@ object HttpRequest {
   def apply(method: HttpMethod, url: String, body: Option[String]): HttpRequest = {
     val bodybytes = body.map{ByteString(_)}
     val head = HttpRequestHead(method, url, HttpVersion.`1.1`, List((HttpHeaders.ContentLength -> bodybytes.map{_.size.toString}.getOrElse("0"))))
-    //val head = HttpHead(method, url, HttpVersion.`1.1`, Map(HttpHeaders.ContentLength -> List(bodybytes.map{_.size.toString}.getOrElse("0"))))
     HttpRequest(head, bodybytes)
   }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -52,7 +52,7 @@ case class HttpRequestHead(method: HttpMethod, url: String, version: HttpVersion
       val buf = new core.DynamicOutBuffer(200, false)
       headers.encode(buf)
       val encodedHeaders = ByteString(buf.data.data)
-      reqString ++ encodedHeaders ++ ByteString("\r\n\r\n")
+      reqString ++ encodedHeaders ++ ByteString("\r\n")
     } else {
       reqString ++ ByteString("\r\n")
     }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -73,7 +73,7 @@ case class HttpRequest(head: HttpRequestHead, entity: Option[ByteString]) {
 
   def respond(code: HttpCode, data: String, headers: List[(String, String)] = Nil) = {
     import HttpHeader.Conversions._
-    HttpResponse(HttpResponseHead(version, code, headers), Some(ByteString(data)))
+    HttpResponse(HttpResponseHead(version, code, headers), HttpResponseBody(data))
   }
 
   def ok(data: String, headers: List[(String, String)] = Nil)              = respond(OK, data, headers)

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -49,8 +49,10 @@ case class HttpRequestHead(method: HttpMethod, url: String, version: HttpVersion
   def bytes : ByteString = {
     val reqString = ByteString(s"${method.name} $getEncodedURL HTTP/$version\r\n")
     if (headers.size > 0) {
-      val headerString = ByteString(headers.headers.map{h => h.key + ": " + h.value}.mkString("\r\n"))
-      reqString ++ headerString ++ ByteString("\r\n\r\n")
+      val buf = new core.DynamicOutBuffer(200, false)
+      headers.encode(buf)
+      val encodedHeaders = ByteString(buf.data.data)
+      reqString ++ encodedHeaders ++ ByteString("\r\n\r\n")
     } else {
       reqString ++ ByteString("\r\n")
     }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -3,12 +3,74 @@ package protocols.http
 
 import akka.util.ByteString
 
-case class HttpRequest(head: HttpHead, entity: Option[ByteString]) {
+case class HttpRequestHead(method: HttpMethod, url: String, version: HttpVersion, headers: HttpHeaders) {
+
+  lazy val (path, query) = {
+    val pieces = url.split("\\?",2)
+    (pieces(0), if (pieces.size > 1) Some(pieces(1)) else None)
+  }
+
+  lazy val parameters: QueryParameters = query.map { qstring =>
+    def decode(s: String) = java.net.URLDecoder.decode(s, "UTF-8")
+    var build = Vector[(String, String)]()
+    var remain = qstring
+    while (remain != "") {
+      val keyval = remain.split("&", 2)
+      val splitKV = keyval(0).split("=", 2)
+      val key = decode(splitKV(0))
+      val value = if (splitKV.size > 1) decode(splitKV(1)) else ""
+      build = build :+ (key -> value)
+      remain = if (keyval.size > 1) keyval(1) else ""
+    }
+    QueryParameters(build)
+  } getOrElse QueryParameters(Vector())
+
+  def withHeader(header: String, value: String): HttpRequestHead = {
+    copy(headers = headers + (header -> value))
+  }
+
+  lazy val cookies: Seq[Cookie] = headers.multiHeader(HttpHeaders.CookieHeader).flatMap{Cookie.parseHeader}
+
+  //we should only encode if the string is decoded.
+  //To check for that, if we decode an already decoded URL, it should not change (this may not be necessary)
+  //the alternative is one big fat honkin ugly regex and knowledge of what characters are allowed where(gross)
+  //TODO: this doesn't work, "/test" becomes %2Ftest
+  private def getEncodedURL : String = url
+  /*{
+    if(URLDecoder.decode(url,"UTF-8") == url) {
+      URLEncoder.encode(url, "UTF-8")
+    }else {
+      url
+    }
+  }*/
+
+
+  //TODO: optimize
+  def bytes : ByteString = {
+    val reqString = ByteString(s"${method.name} $getEncodedURL HTTP/$version\r\n")
+    if (headers.size > 0) {
+      val headerString = ByteString(headers.headers.map{h => h.key + ": " + h.value}.mkString("\r\n"))
+      reqString ++ headerString ++ ByteString("\r\n\r\n")
+    } else {
+      reqString ++ ByteString("\r\n")
+    }
+  }
+
+  def persistConnection: Boolean =
+    (version, headers.connection) match {
+      case (HttpVersion.`1.1`, Some(Connection.Close)) => false
+      case (HttpVersion.`1.1`, _) => true
+      case (HttpVersion.`1.0`, Some(Connection.KeepAlive)) => true
+      case (HttpVersion.`1.0`, _) => false
+    }
+}
+
+case class HttpRequest(head: HttpRequestHead, entity: Option[ByteString]) {
   import head._
   import HttpCodes._
 
   def respond(code: HttpCode, data: String, headers: List[(String, String)] = Nil) = {
-    import HttpResponseHeader.Conversions._
+    import HttpHeader.Conversions._
     HttpResponse(HttpResponseHead(version, code, headers), Some(ByteString(data)))
   }
 
@@ -28,9 +90,10 @@ case class HttpRequest(head: HttpHead, entity: Option[ByteString]) {
 }
 
 object HttpRequest {
+  import HttpHeader.Conversions._
   def apply(method: HttpMethod, url: String, body: Option[String]): HttpRequest = {
     val bodybytes = body.map{ByteString(_)}
-    val head = HttpHead(method, url, HttpVersion.`1.1`, List((HttpHeaders.ContentLength -> bodybytes.map{_.size.toString}.getOrElse("0"))))
+    val head = HttpRequestHead(method, url, HttpVersion.`1.1`, List((HttpHeaders.ContentLength -> bodybytes.map{_.size.toString}.getOrElse("0"))))
     //val head = HttpHead(method, url, HttpVersion.`1.1`, Map(HttpHeaders.ContentLength -> List(bodybytes.map{_.size.toString}.getOrElse("0"))))
     HttpRequest(head, bodybytes)
   }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
@@ -56,7 +56,7 @@ class HttpHeadParser extends Parser[HeadResult]{
     }
 
     def build: HeadResult = {
-      val r = HeadResult(HttpRequestHead(HttpMethod(method), path, HttpVersion(version), new HttpHeaders(headers)), contentLength, transferEncoding)
+      val r = HeadResult(HttpRequestHead(HttpMethod(method), path, HttpVersion(version), new HttpHeaders(headers.toArray)), contentLength, transferEncoding)
       reset()
       r
     }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
@@ -29,7 +29,7 @@ object HttpRequestParser {
   
 }
 
-case class HeadResult(head: HttpHead, contentLength: Option[Int], transferEncoding: Option[String] )
+case class HeadResult(head: HttpRequestHead, contentLength: Option[Int], transferEncoding: Option[String] )
 
 /**
  * This parser is optimized to reduce the number of operations per character
@@ -41,13 +41,13 @@ class HttpHeadParser extends Parser[HeadResult]{
     var method: String = ""
     var path: String = ""
     var version: String = ""
-    var headers: List[(String, String)] = Nil
+    var headers: List[HttpHeader] = Nil
     var contentLength: Option[Int] = None
     var transferEncoding: Option[String] = None
     var body: Option[ByteString] = None
 
     def addHeader(name: String, value: String) {
-      headers = (name, value) :: headers
+      headers = new DecodedHeader(name, value) :: headers
       if (name == HttpHeaders.ContentLength) {
         contentLength = Some(value.toInt)
       } else if (name == HttpHeaders.TransferEncoding) {
@@ -56,7 +56,7 @@ class HttpHeadParser extends Parser[HeadResult]{
     }
 
     def build: HeadResult = {
-      val r = HeadResult(HttpHead(HttpMethod(method), path, HttpVersion(version), headers), contentLength, transferEncoding)
+      val r = HeadResult(HttpRequestHead(HttpMethod(method), path, HttpVersion(version), new HttpHeaders(headers)), contentLength, transferEncoding)
       reset()
       r
     }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -32,12 +32,7 @@ case class HttpResponseHead(version : HttpVersion, code : HttpCode, headers : Ht
     buffer.write(HttpResponseHeader.SPACE_ARRAY)
     buffer.write(code.headerArr)
     buffer.write(NEWLINE_ARRAY)
-    var writing = headers.headers
-    while (writing != Nil) {
-      buffer.write(writing.head.encoded)
-      buffer.write(NEWLINE_ARRAY)
-      writing = writing.tail
-    }
+    headers.encode(buffer)
   }
 
   def withHeader(key: String, value: String) = copy(headers = headers + (key -> value))
@@ -66,6 +61,7 @@ sealed trait BaseHttpResponse {
 //TODO: We need to make some headers like Content-Length, Transfer-Encoding,
 //first-class citizens and separate them from the other headers.  This would
 //prevent things like creating a response with the wrong content length
+
 
 case class HttpResponse(head: HttpResponseHead, body: Option[ByteString]) extends BaseHttpResponse with Encoder {
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -63,7 +63,7 @@ sealed trait BaseHttpResponse {
 //prevent things like creating a response with the wrong content length
 
 
-class HttpResponseBody(private val body: Array[Byte]) extends AnyVal {
+class HttpResponseBody(private val body: Array[Byte])  {
 
   def size = body.size
 
@@ -72,6 +72,13 @@ class HttpResponseBody(private val body: Array[Byte]) extends AnyVal {
   }
 
   def bytes: ByteString = ByteString(body)
+
+  override def equals(that: Any) = that match {
+    case that: HttpResponseBody => that.bytes == this.bytes
+    case other => false
+  }
+
+  override def toString = bytes.utf8String
 
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -32,12 +32,12 @@ object HttpResponseHeader {
 
   object Conversions {
     implicit def stringTuple2Header(t: (String, String)): HttpResponseHeader = HttpResponseHeader(t._1, t._2)
-    implicit def seqStringTuple2Headers(t: Seq[(String, String)]): Vector[HttpResponseHeader] = t.map{stringTuple2Header}.toVector
+    implicit def seqStringTuple2Headers(t: Seq[(String, String)]): Array[HttpResponseHeader] = t.map{stringTuple2Header}.toArray
   }
 
 }
 
-case class HttpResponseHead(version : HttpVersion, code : HttpCode, headers : Vector[HttpResponseHeader] = Vector()) {
+case class HttpResponseHead(version : HttpVersion, code : HttpCode, headers : Array[HttpResponseHeader] = Array()) {
 
 
   def encode(buffer: DataOutBuffer) {
@@ -144,12 +144,12 @@ object HttpResponse {
 
   val ContentLengthKey = ByteString("Content-Length: ")
 
-  def apply[T : ByteStringLike](version : HttpVersion, code : HttpCode, headers : Vector[HttpResponseHeader] , data : T) : HttpResponse = {
+  def apply[T : ByteStringLike](version : HttpVersion, code : HttpCode, headers : Array[HttpResponseHeader] , data : T) : HttpResponse = {
     HttpResponse(HttpResponseHead(version, code, headers), Some(implicitly[ByteStringLike[T]].toByteString(data)))
   }
 
 
-  def apply(version : HttpVersion, code : HttpCode, headers : Vector[HttpResponseHeader]) : HttpResponse = {
+  def apply(version : HttpVersion, code : HttpCode, headers : Array[HttpResponseHeader]) : HttpResponse = {
     HttpResponse(HttpResponseHead(version, code, headers), None)
   }
 
@@ -192,7 +192,7 @@ object StreamingHttpResponse {
     StreamingHttpResponse(resp.head.withHeader(HttpHeaders.ContentLength, resp.body.map{_.size}.getOrElse(0).toString), resp.body.map{b => Source.one(DataBuffer(b))})
   }
 
-  def apply[T : ByteStringLike](version : HttpVersion, code : HttpCode, headers : Vector[HttpResponseHeader] = Vector(), data : T) : StreamingHttpResponse = {
+  def apply[T : ByteStringLike](version : HttpVersion, code : HttpCode, headers : Array[HttpResponseHeader] = Array(), data : T) : StreamingHttpResponse = {
     fromStatic(HttpResponse(
       HttpResponseHead(version, code, headers), 
       Some(implicitly[ByteStringLike[T]].toByteString(data))

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -65,7 +65,7 @@ object HttpResponseParser  {
     
 
   protected def head: Parser[HttpResponseHead] = firstLine ~ headers >> {case version ~ code ~ headers => 
-    HttpResponseHead(version, code, headers.map{case (k,v) => HttpResponseHeader(k,v)})
+    HttpResponseHead(version, code, headers.map{case (k,v) => HttpResponseHeader(k,v)}.toArray)
   }
 
   protected def firstLine = version ~ code 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -65,7 +65,7 @@ object HttpResponseParser  {
     
 
   protected def head: Parser[HttpResponseHead] = firstLine ~ headers >> {case version ~ code ~ headers => 
-    HttpResponseHead(version, code, new HttpHeaders(headers.map{case (k,v) => HttpHeader(k,v)}.toList))
+    HttpResponseHead(version, code, new HttpHeaders(headers.map{case (k,v) => HttpHeader(k,v)}.toArray))
   }
 
   protected def firstLine = version ~ code 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -31,8 +31,8 @@ object HttpResponseParser  {
   //TODO: Dechunk on static
 
   protected def staticBody(dechunk: Boolean): Parser[DecodedResult.Static[HttpResponse]] = head |> {parsedHead =>
-    parsedHead.transferEncoding match {
-      case TransferEncoding.Identity => parsedHead.contentLength match {
+    parsedHead.headers.transferEncoding match {
+      case TransferEncoding.Identity => parsedHead.headers.contentLength match {
         case Some(0)  => const(DecodedResult.Static(HttpResponse(parsedHead, None)))
         case Some(n)  => bytes(n) >> {body => DecodedResult.Static(HttpResponse(parsedHead, Some(body)))}
         case None if (parsedHead.code.isInstanceOf[NoBodyCode]) => const(DecodedResult.Static(HttpResponse(parsedHead, None)))
@@ -43,8 +43,8 @@ object HttpResponseParser  {
   }
 
   protected def streamBody(dechunk: Boolean): Parser[DecodedResult[StreamingHttpResponse]] = head >> {parsedHead =>
-    parsedHead.transferEncoding match {
-      case TransferEncoding.Identity => parsedHead.contentLength match {
+    parsedHead.headers.transferEncoding match {
+      case TransferEncoding.Identity => parsedHead.headers.contentLength match {
         case Some(0)=> DecodedResult.Static(StreamingHttpResponse(parsedHead, None))
         case Some(n) => streamingResponse(parsedHead, Some(n), false)
         case None if (parsedHead.code.isInstanceOf[NoBodyCode]) => DecodedResult.Static(StreamingHttpResponse(parsedHead, None))
@@ -65,7 +65,7 @@ object HttpResponseParser  {
     
 
   protected def head: Parser[HttpResponseHead] = firstLine ~ headers >> {case version ~ code ~ headers => 
-    HttpResponseHead(version, code, headers.map{case (k,v) => HttpResponseHeader(k,v)}.toArray)
+    HttpResponseHead(version, code, new HttpHeaders(headers.map{case (k,v) => HttpHeader(k,v)}.toList))
   }
 
   protected def firstLine = version ~ code 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -33,12 +33,12 @@ object HttpResponseParser  {
   protected def staticBody(dechunk: Boolean): Parser[DecodedResult.Static[HttpResponse]] = head |> {parsedHead =>
     parsedHead.headers.transferEncoding match {
       case TransferEncoding.Identity => parsedHead.headers.contentLength match {
-        case Some(0)  => const(DecodedResult.Static(HttpResponse(parsedHead, None)))
-        case Some(n)  => bytes(n) >> {body => DecodedResult.Static(HttpResponse(parsedHead, Some(body)))}
-        case None if (parsedHead.code.isInstanceOf[NoBodyCode]) => const(DecodedResult.Static(HttpResponse(parsedHead, None)))
-        case None     => bytesUntilEOS >> {body => DecodedResult.Static(HttpResponse(parsedHead, Some(body)))}
+        case Some(0)  => const(DecodedResult.Static(HttpResponse(parsedHead, HttpResponseBody.NoBody)))
+        case Some(n)  => bytes(n) >> {body => DecodedResult.Static(HttpResponse(parsedHead, body))}
+        case None if (parsedHead.code.isInstanceOf[NoBodyCode]) => const(DecodedResult.Static(HttpResponse(parsedHead, HttpResponseBody.NoBody)))
+        case None     => bytesUntilEOS >> {body => DecodedResult.Static(HttpResponse(parsedHead, body))}
       }
-      case _  => chunkedBody >> {body => DecodedResult.Static(HttpResponse(parsedHead, Some(body)))}
+      case _  => chunkedBody >> {body => DecodedResult.Static(HttpResponse(parsedHead, body))}
     }
   }
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -52,7 +52,7 @@ object UpgradeRequest {
           HttpHeader("Sec-Websocket-Accept",processKey(seckey))
         )
       ),
-      None
+      HttpResponseBody.NoBody
     )      
   }
 }

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -29,13 +29,14 @@ object UpgradeRequest {
 
   //todo proper handling of key
   def unapply(request : HttpRequest): Option[HttpResponse] = {
+    val headers = request.head.headers
     for {
-      cheader   <- request.head.singleHeader("connection") 
-      uheader   <- request.head.singleHeader("upgrade") 
-      host      <- request.head.singleHeader("host")
-      origin    <- request.head.singleHeader("origin")
-      seckey    <- request.head.singleHeader("sec-websocket-key")
-      secver    <- request.head.singleHeader("sec-websocket-version") 
+      cheader   <- headers.singleHeader("connection") 
+      uheader   <- headers.singleHeader("upgrade") 
+      host      <- headers.singleHeader("host")
+      origin    <- headers.singleHeader("origin")
+      seckey    <- headers.singleHeader("sec-websocket-key")
+      secver    <- headers.singleHeader("sec-websocket-version") 
       if (request.head.version == HttpVersion.`1.1`)
       if (request.head.method == HttpMethod.Get)
       if (secver == "13")
@@ -45,10 +46,10 @@ object UpgradeRequest {
       HttpResponseHead(
         HttpVersion.`1.1`,
         HttpCodes.SWITCHING_PROTOCOLS,
-        Array(
-          HttpResponseHeader("Upgrade", "websocket"),
-          HttpResponseHeader("Connection", "Upgrade"),
-          HttpResponseHeader("Sec-Websocket-Accept",processKey(seckey))
+        HttpHeaders(
+          HttpHeader("Upgrade", "websocket"),
+          HttpHeader("Connection", "Upgrade"),
+          HttpHeader("Sec-Websocket-Accept",processKey(seckey))
         )
       ),
       None

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -45,7 +45,7 @@ object UpgradeRequest {
       HttpResponseHead(
         HttpVersion.`1.1`,
         HttpCodes.SWITCHING_PROTOCOLS,
-        Vector(
+        Array(
           HttpResponseHeader("Upgrade", "websocket"),
           HttpResponseHeader("Connection", "Upgrade"),
           HttpResponseHeader("Sec-Websocket-Accept",processKey(seckey))

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -31,12 +31,12 @@ object UpgradeRequest {
   def unapply(request : HttpRequest): Option[HttpResponse] = {
     val headers = request.head.headers
     for {
-      cheader   <- headers.singleHeader("connection") 
-      uheader   <- headers.singleHeader("upgrade") 
-      host      <- headers.singleHeader("host")
-      origin    <- headers.singleHeader("origin")
-      seckey    <- headers.singleHeader("sec-websocket-key")
-      secver    <- headers.singleHeader("sec-websocket-version") 
+      cheader   <- headers.firstValue("connection") 
+      uheader   <- headers.firstValue("upgrade") 
+      host      <- headers.firstValue("host")
+      origin    <- headers.firstValue("origin")
+      seckey    <- headers.firstValue("sec-websocket-key")
+      secver    <- headers.firstValue("sec-websocket-version") 
       if (request.head.version == HttpVersion.`1.1`)
       if (request.head.method == HttpMethod.Get)
       if (secver == "13")


### PR DESCRIPTION
_Notice this is to merge into a new `develop-0.7.1` branch, so this is not going into 0.7.0_

Made a bunch of improvements that both clean things up a lot and considerably improve performance.

1.  Previously headers were handled differently in requests versus responses, mainly because things were optimized for parsing requests and encoding responses.  Now there's a single `HttpHeader` trait that abstracts all that away.  Under the hood there's still two versions, one optimized for decoding and the other encoding, but now it can all be hidden from the user.
2.  Replacing the `Vector` with a plain old `Array` for the collection of headers resulted in a huge performance boost.  I tried a few different approaches to try to keep using a `Seq` or `IndexedSeq` but this one worked best.  So again to hide this detail from users and keep the API as an immutable collection, there's a new `HttpHeaders` class, used in both requests and responses.
3.  Basically did the same thing for the Http Body as well.

This isn't a complete unification but it does go a long way and this branch was starting to get pretty big.  So I'll save the rest for another PR.