### PR TITLE
fixing histogram race condition

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -57,7 +57,7 @@ case class Snapshot(min: Int, max: Int, mean: Int, count: Int, bucketValues: Vec
     def p(num: Int, index: Int, build: Seq[Int], remain: Seq[Double]): Seq[Int] = remain.headOption match {
       case None => build
       case Some(perc) => {
-        if (perc <= 0.0 || count == 0) {
+        if (perc <= 0.0 || count == 0 || bucketValues.size == 0) {
           p(num, index, build :+ 0, remain.tail)
         } else if (perc >= 1.0) {
           p(num, index, build :+ max, remain.tail)          

--- a/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
@@ -56,6 +56,11 @@ class HistogramSpec extends MetricIntegrationSpec {
       (new BaseHistogram).snapshot.mean must equal(0)
     }
 
+    "handle possible race condition" in {
+      val s = Snapshot(0,0 ,0, 1, Vector())
+      s.percentiles(Seq(0.5, 1.0)) must equal(Map(0.5 -> 0, 1.0 -> 0))
+    }
+
   }
 
   "Histogram" must {


### PR DESCRIPTION
Due to the use of separate atomics, it's possible, though rare to end up in a situation where a histogram's snapshot has a non-zero count but empty set of values.  So now calculating percentiles checks to make sure it's non-empty.