### PR TITLE
Cleanup output controller

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -195,26 +195,22 @@ class ServiceClientSpec extends ColossusSpec {
     }
 
     //this should be written as a controller test
-    "immediately fail requests when pending buffer is full" ignore {
+    "immediately fail requests when pending buffer is full" in {
       val (endpoint, client, probe) = newClient()
-      val big = Command(CMD_GET, "123456789012345678901234567890")
+      val big = Command(CMD_GET, "hello")
       val commands = (1 to client.config.pendingBufferSize).map{i => 
         Command(CMD_GET, i.toString)
       }
       val shouldFail = Command(CMD_GET, "fail")
       client.send(big).execute()
       commands.foreach{cmd =>
-        client.send(cmd).execute{
-          case _ => throw new Exception("Executed!")
-        }
+        client.send(cmd).execute()
       }
-      endpoint.expectOneWrite(big.raw)
       var failed = false
       client.send(shouldFail).execute{
         case Success(_) => throw new Exception("Didn't fail?!?!")
         case Failure(goodjob) => failed = true
       }
-
       failed must equal (true)
     }
 

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -14,7 +14,8 @@ import scala.concurrent.duration.Duration
  */
 case class ControllerConfig(
   outputBufferSize: Int,
-  sendTimeout: Duration
+  sendTimeout: Duration,
+  flushBufferOnClose: Boolean = true
 )
 
 //used to terminate input streams when a connection is closing

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -94,7 +94,7 @@ extends CoreHandler(context) with InputController[Input, Output] with OutputCont
    */
   private[controller] def checkControllerGracefulDisconnect() {
     (connectionState, inputState, outputState) match {
-      case (ShuttingDown(endpoint), InputState.Terminated, OutputState.Terminated()) => {
+      case (ShuttingDown(endpoint), InputState.Terminated, OutputState.Terminated) => {
         super.shutdown()
       }
       case _ => {} 


### PR DESCRIPTION
This is a refactoring of `OutputController` that cleans up a lot of the logic.  Previously I had moved all the mutable state into the `OutputState` ADT, but unfortunately this mostly ended up in tons of pattern matching everywhere.  So they've been moved back into the class itself.