### PR TITLE
Metrics prune

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -2,7 +2,7 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Counter private[colossus](val address: MetricAddress)(implicit collection: Collection) extends Collector {
+class Counter private[metrics](val address: MetricAddress)(implicit collection: Collection) extends Collector {
 
   private val counters = new CollectionMap[TagMap]
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -180,7 +180,7 @@ class BaseHistogram(val bucketList: BucketList = Histogram.defaultBucketRanges) 
 
 }
 
-class Histogram private[colossus](
+class Histogram private[metrics](
   val address: MetricAddress,
   percentiles: Seq[Double] = Histogram.defaultPercentiles,
   sampleRate: Double = 1.0, 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -2,7 +2,7 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Rate private[colossus](val address: MetricAddress, pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
+class Rate private[metrics](val address: MetricAddress, pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
 
   private val maps = collection.config.intervals.map{i => (i, new CollectionMap[TagMap])}.toMap
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -2,7 +2,7 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Rate private[colossus](val address: MetricAddress)(implicit collection: Collection) extends Collector {
+class Rate private[colossus](val address: MetricAddress, pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
 
   private val maps = collection.config.intervals.map{i => (i, new CollectionMap[TagMap])}.toMap
 
@@ -16,12 +16,12 @@ class Rate private[colossus](val address: MetricAddress)(implicit collection: Co
   }
 
   def tick(interval: FiniteDuration): MetricMap  = {
-    val snap = maps(interval).snapshot(false, true)
+    val snap = maps(interval).snapshot(pruneEmpty, true)
     if (interval == minInterval) {
       snap.foreach{ case (tags, value) => totals.increment(tags, value) }
     }
     if (snap.isEmpty) Map() else {
-      Map(address -> snap, address / "count" -> totals.snapshot(false, false))
+      Map(address -> snap, address / "count" -> totals.snapshot(pruneEmpty, false))
     }
   }
     
@@ -30,8 +30,8 @@ class Rate private[colossus](val address: MetricAddress)(implicit collection: Co
 
 object Rate {
 
-  def apply(address: MetricAddress)(implicit collection: Collection): Rate = {
-    collection.getOrAdd(new Rate(address))
+  def apply(address: MetricAddress, pruneEmpty: Boolean = false)(implicit collection: Collection): Rate = {
+    collection.getOrAdd(new Rate(address, pruneEmpty))
   }
 }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -52,6 +52,23 @@ class RateSpec extends MetricIntegrationSpec {
       rate().tick(1.second) must equal(Map())
     }
 
+    "prune empty values" in {
+      val r = rate()
+      r.hit(Map("a" -> "b"))
+      r.hit(Map("b" -> "c"))
+      r.hit(Map("b" -> "c"))
+      val s = r.tick(1.second)
+      s("foo").size must equal(2)
+      s("foo/count").size must equal(2)
+      r.hit(Map("a" -> "b"))
+      val s2 = t.tick(1.second)
+      s("foo").size must equal(1)
+      s("foo/count").size must equal(1)
+      s("foo")(Map("b" -> "c")) must equal(1)
+    }
+
+
+
 
   }
 

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -184,11 +184,11 @@ private[colossus] class Server(io: IOSystem, config: ServerConfig, stateAgent : 
 
   //initialize metrics
   import io.metrics.base
-  val connections   = base getOrAdd new Counter(name / "connections")
-  val refused       = base getOrAdd new Rate(name / "refused_connections")
-  val connects      = base getOrAdd new Rate(name / "connects")
-  val closed        = base getOrAdd new Rate(name / "closed")
-  val highwaters    = base getOrAdd new Rate(name / "highwaters")
+  val connections   = Counter(name / "connections")
+  val refused       = Rate(name / "refused_connections")
+  val connects      = Rate(name / "connects")
+  val closed        = Rate(name / "closed")
+  val highwaters    = Rate(name / "highwaters")
 
   private var openConnections = 0
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -160,9 +160,9 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
 
   import config.io.metrics.base
 
-  val eventLoops              = new Rate(io.namespace / "worker" / "event_loops")
-  val numConnections          = new Counter(io.namespace / "worker" / "connections")
-  val rejectedConnections     = new Rate(io.namespace / "worker" / "rejected_connections")
+  val eventLoops              = Rate(io.namespace / "worker" / "event_loops")
+  val numConnections          = Counter(io.namespace / "worker" / "connections")
+  val rejectedConnections     = Rate(io.namespace / "worker" / "rejected_connections")
 
   val selector: Selector = Selector.open()
   val buffer = ByteBuffer.allocateDirect(1024 * 128)


### PR DESCRIPTION
This was a feature that almost got lost in the overhaul of metrics, but it's now added back in and supports the same functionality.  `pruneEmpty` can be used to prevent rates and histograms from filling up with lots of 0 values if they are hit with many different combinations of tags.