### PR TITLE
More Http cleanup

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -35,7 +35,7 @@ object BenchmarkService {
       }
     }
   }
-  val response          = HttpResponseBody("Hello, World!")
+  val response          = HttpBody("Hello, World!")
   val plaintextHeader   = HttpHeader("Content-Type", "text/plain")
   val jsonHeader        = HttpHeader("Content-Type", "application/json")
   val serverHeader      = HttpHeader("Server", "Colossus")

--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -46,9 +46,6 @@ object BenchmarkService {
             val json: JValue = ("message" -> "Hello, World!")
             request.ok(json, HttpHeaders(serverHeader, dateHeader))
           }
-          case request => {
-            request.notFound("invalid path")
-          }
         }
       }
     }}

--- a/colossus-metrics/src/main/scala/colossus/metrics/package.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/package.scala
@@ -1,9 +1,5 @@
 package colossus
 
-import net.liftweb.json._
-
-//TODO: break up this whole thing
-
 package object metrics {
 
   type MetricValue = Long
@@ -25,7 +21,6 @@ package object metrics {
   object MetricMap {
     val Empty: MetricMap = Map()
 
-    implicit val formats = DefaultFormats
 
     case class TaggedValue(tags: TagMap, value: Long) {
       def tuple = (tags, value)
@@ -38,7 +33,6 @@ package object metrics {
       MetricAddress(addressString) -> tagvalues.map{_.tuple}.toMap
     }
 
-    def fromJson(j: JValue): MetricMap = unserialize(j.extract[SerializedMetricMap])
   }
 
   implicit class RichMetricMap(val underlying: MetricMap) extends AnyVal {
@@ -47,26 +41,6 @@ package object metrics {
       values.map{case (tags, value) => MetricFragment(address, tags ++ globalTags, value)}
     }.toSeq
     def fragments: Seq[MetricFragment] = fragments(TagMap.Empty)
-
-
-    def toJson: JValue = JObject(
-      underlying.map{case (metric, values) =>
-        val valueArray = JArray(
-          values.map{case (tags, value) =>
-            val tagObj = JObject(
-              tags.map{ case (key, value) =>
-                JField(key, JString(value))
-              }.toList
-            )
-            JObject(List(
-              JField("tags", tagObj),
-              JField("value", JInt(value))
-            ))
-          }.toList
-        )
-        JField(metric.toString, valueArray)
-      }.toList
-    )
 
   }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -32,43 +32,4 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
 
   }
 
-  "JSON Serialization" must {
-    import net.liftweb.json._
-
-    "serialize" in {
-      val map: MetricMap = Map(
-        Root / "foo" -> Map(
-          Map("a" -> "va") -> 3L,
-          Map("b" -> "vb") -> 4L
-        )
-      )
-      val expected = parse(
-        """{"/foo" : [ 
-          {"tags" : {"a" : "va"}, "value" : 3},
-          {"tags" : {"b" : "vb"}, "value" : 4}
-          ]}"""
-      )
-
-      map.toJson must equal(expected)
-
-    }
-
-    "unserialize" in {
-      val expected: MetricMap = Map(
-        Root / "foo" -> Map(
-          Map("a" -> "va") -> 3L,
-          Map("b" -> "vb") -> 4L
-        )
-      )
-      val json = parse(
-        """{"/foo" : [ 
-          {"tags" : {"a" : "va"}, "value" : 3},
-          {"tags" : {"b" : "vb"}, "value" : 4}
-          ]}"""
-      )
-
-      MetricMap.fromJson(json) must equal(expected)
-    }
-      
-  }
 }

--- a/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
@@ -6,11 +6,7 @@ import akka.util.ByteString
 
 import protocols.http._
 
-import net.liftweb.json._
-
 abstract class HttpServiceSpec extends ServiceSpec[Http] {
-
-  implicit val formats = DefaultFormats
 
   def expectCode(request: HttpRequest, expectedResponseCode: HttpCode) {
     withClient{client =>
@@ -40,14 +36,6 @@ abstract class HttpServiceSpec extends ServiceSpec[Http] {
   def assertBody(request : HttpRequest, response : HttpResponse, expectedBody : String){
     val body = response.body.bytes.utf8String
     assert(body == expectedBody, s"$body did not equal $expectedBody")
-  }
-
-  def expectJson[T : Manifest](request : HttpRequest, expectedJson : T) {
-    withClient{ client =>
-      val resp = Await.result(client.send(request), requestTimeout)
-      val parsed = parse(resp.body.bytes.utf8String).extract[T]
-      parsed must equal(expectedJson)
-    }
   }
 
 }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
@@ -2,6 +2,8 @@ package colossus.protocols.http
 
 
 import org.scalatest._
+import java.util.Date
+import java.text.SimpleDateFormat
 
 
 class HttpRequestHeadSuite extends WordSpec with MustMatchers{
@@ -91,14 +93,18 @@ class HttpRequestHeadSuite extends WordSpec with MustMatchers{
   }
 
   "DateHeader" must {
+
+    val formatter = new SimpleDateFormat(DateHeader.DATE_FORMAT)
+    def date(time: Long) = "Date: " + formatter.format(new Date(time)) + "\r\n"
+    
     "generate a correct date" in {
-      new String((new DateHeader(123)).encoded(time = 1234567)) must equal("Date: Wed, Dec 31 1969 19:12:34 EST\r\n")
+      new String((new DateHeader(123)).encoded(time = 1234567)) must equal(date(1234567))
     }
     "only generate a new date when more than a second past the last generated date" in {
       val d = new DateHeader(123)
-      new String(d.encoded(time = 1234567)) must equal("Date: Wed, Dec 31 1969 19:12:34 EST\r\n")
-      new String(d.encoded(time = 1235566)) must equal("Date: Wed, Dec 31 1969 19:12:34 EST\r\n")
-      new String(d.encoded(time = 1235567)) must equal("Date: Wed, Dec 31 1969 19:12:35 EST\r\n")
+      new String(d.encoded(time = 1234567)) must equal(date(1234567))
+      new String(d.encoded(time = 1235566)) must equal(date(1234567))
+      new String(d.encoded(time = 1235567)) must equal(date(1235567))
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
@@ -87,6 +87,19 @@ class HttpRequestHeadSuite extends WordSpec with MustMatchers{
       head.parameters("b") must equal("c=d")
       head.parameters("e") must equal("f=")
     }
+
+  }
+
+  "DateHeader" must {
+    "generate a correct date" in {
+      new String((new DateHeader(123)).encoded(time = 1234567)) must equal("Date: Wed, Dec 31 1969 19:12:34 EST\r\n")
+    }
+    "only generate a new date when more than a second past the last generated date" in {
+      val d = new DateHeader(123)
+      new String(d.encoded(time = 1234567)) must equal("Date: Wed, Dec 31 1969 19:12:34 EST\r\n")
+      new String(d.encoded(time = 1235566)) must equal("Date: Wed, Dec 31 1969 19:12:34 EST\r\n")
+      new String(d.encoded(time = 1235567)) must equal("Date: Wed, Dec 31 1969 19:12:35 EST\r\n")
+    }
   }
 
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -16,6 +16,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
 
   def requestParser = HttpRequestParser()
   import HttpHeader.Conversions._
+  import HttpBody._
 
   "http request parser" must {
     "parse a basic request" in {
@@ -32,7 +33,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "authorization" -> "Basic XXX",
           "accept-encoding" -> "gzip, deflate"
         )
-      ), None)        
+      ), HttpBody.NoBody)        
       
       parser.parse(DataBuffer(ByteString(req))).toList must equal(List(expected))
     }
@@ -51,7 +52,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "authorization" -> "Basic XXX",
           "accept-encoding" -> "gzip, deflate"
         )
-      ), None)        
+      ), HttpBody.NoBody)        
 
       (0 until req.length).foreach{splitIndex =>
         val p1 = req.take(splitIndex)
@@ -69,7 +70,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     "parse request with no headers" in {
       val req = "GET /hello HTTP/1.1\r\n\r\n"
       val parser = requestParser
-      val expected = HttpRequest(HttpRequestHead(method = HttpMethod.Get, url="/hello", version = HttpVersion.`1.1`, headers = Nil), None)
+      val expected = HttpRequest(HttpRequestHead(method = HttpMethod.Get, url="/hello", version = HttpVersion.`1.1`, headers = Nil), HttpBody.NoBody)
       parser.parse(DataBuffer(ByteString(req))) must equal (Some(expected))
     }
 
@@ -86,7 +87,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "accept" ->  "*/*",
           "content-length" -> len.toString
         )
-      ), Some(body))        
+      ), HttpBody(body))        
 
       val parser = requestParser
       
@@ -104,7 +105,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "accept" -> "*/*",
           "content-length" -> "0"
         )
-      ), None)        
+      ), HttpBody.NoBody)        
 
       val parser = requestParser
       
@@ -136,10 +137,11 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     "parse request with authorization header" taggedAs(Broke) in {
       val auth_info = "Basic YmI6Y29vbHBhc3N3b3JkYnJvNDI="// + Base64.encodeBase64String(StringUtils.getBytesUtf8("bb:coolpasswordbro42"))
       val url = "/foo"
-      val request = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = url, headers = List("authorization" -> auth_info)), None)
-      val bytes = request.bytes
+      val request = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = url, headers = List("authorization" -> auth_info)), HttpBody.NoBody)
+      val d = new DynamicOutBuffer(100, false)
+      request.encode(d)
       val parser = requestParser
-      parser.parse(DataBuffer(bytes)).isEmpty must equal(false)
+      parser.parse(d.data).isEmpty must equal(false)
     }
 
     //the current parser hangs instead of throwing an exception.  Need to
@@ -196,8 +198,10 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "parse a generated request" in {
-      val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = "/foo", headers = Nil), None)
-      val data = DataBuffer(req.bytes)
+      val req = HttpRequest(HttpRequestHead(version = HttpVersion.`1.1`, method = HttpMethod.Get, url = "/foo", headers = Nil), HttpBody.NoBody)
+      val d = new DynamicOutBuffer(100, false)
+      req.encode(d)
+      val data = d.data
       val parser = requestParser
       parser.parse(data) must equal(Some(req))
       data.remaining must equal(0)
@@ -208,7 +212,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       val data = DataBuffer(ByteString(req))
       val parser = requestParser
       val parsed = parser.parse(data).get
-      parsed.entity must equal(Some(ByteString("foo123456789abcde")))
+      parsed.body must equal(HttpBody(ByteString("foo123456789abcde")))
       data.remaining must equal(0)
     }
     
@@ -297,7 +301,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "match on http request" in {
-      val h = HttpRequest(HttpRequestHead(Get, "/a/b/c", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/a/b/c", `1.1`, Nil), HttpBody.NoBody)
       val res: Boolean = h match {
         case Get on Root / "a" / "b" / "c" => true
         case _ => false
@@ -305,7 +309,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       res must equal(true)
     }
     "match on http request with one route" in {
-      val h = HttpRequest(HttpRequestHead(Get, "/a", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/a", `1.1`, Nil), HttpBody.NoBody)
       val res: Boolean = h match {
         case Get on Root / "a" => true
         case _ => false
@@ -314,7 +318,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "match http request with integer" in {
-      val h = HttpRequest(HttpRequestHead(Get, "/foo/bar/3", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/foo/bar/3", `1.1`, Nil), HttpBody.NoBody)
       val res: Int = h match {
         case Get on Root / "foo" / "bar" / Integer(x) => x
         case _ => 0
@@ -325,7 +329,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
 
 
     "match http request with long" in {
-      val h = HttpRequest(HttpRequestHead(Get, "/foo/bar/17592186044416", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/foo/bar/17592186044416", `1.1`, Nil), HttpBody.NoBody)
       val res: Long = h match {
         case Get on Root / "foo" / "bar" / Long(x) => x
         case _ => 0
@@ -334,7 +338,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "match root url" in {
-      val h = HttpRequest(HttpRequestHead(Get, "/", `1.1`, Nil), None)
+      val h = HttpRequest(HttpRequestHead(Get, "/", `1.1`, Nil), HttpBody.NoBody)
       val res: Boolean = h match {
         case Get on Root => true
         case _ => false
@@ -343,7 +347,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "parse requests with no request parameters" in {
-      val req = HttpRequest(HttpRequestHead(HttpMethod.Get, "a/path/with/1", HttpVersion.`1.1`, Nil), None)
+      val req = HttpRequest(HttpRequestHead(HttpMethod.Get, "a/path/with/1", HttpVersion.`1.1`, Nil), HttpBody.NoBody)
       req match {
         case r @ Get on Root / "a" / "path" / "with" / Integer(1) =>
         case _ => throw new Exception(s"$req failed to parse correctly")
@@ -351,7 +355,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     }
 
     "parse requests with request parameters" in {
-      val req = HttpRequest(HttpRequestHead(HttpMethod.Get, "a/path/with/1?a=bla&b=2", HttpVersion.`1.1`, Nil), None)
+      val req = HttpRequest(HttpRequestHead(HttpMethod.Get, "a/path/with/1?a=bla&b=2", HttpVersion.`1.1`, Nil), HttpBody.NoBody)
       req match {
         case r @ Get on Root / "a" / "path" / "with" / Integer(1) =>
         case _ => throw new Exception(s"$req failed to parse correctly")

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -20,7 +20,7 @@ class HttpSpec extends WordSpec with MustMatchers{
         method = HttpMethod.Post,
         headers = List("foo" -> "bar")
       )
-      val request = HttpRequest(head, Some(ByteString("hello")))
+      val request = HttpRequest(head, HttpBody(ByteString("hello")))
 
       val expected = "POST /hello HTTP/1.1\r\nfoo: bar\r\n\r\nhello"
 
@@ -34,7 +34,7 @@ class HttpSpec extends WordSpec with MustMatchers{
         method = HttpMethod.Post,
         headers = List("foo" -> "bar")
       )
-      val request = HttpRequest(head, None)
+      val request = HttpRequest(head, HttpBody.NoBody)
 
       val expected = "POST /hello HTTP/1.1\r\nfoo: bar\r\n\r\n"
 
@@ -48,7 +48,7 @@ class HttpSpec extends WordSpec with MustMatchers{
         method = HttpMethod.Post,
         headers = List("foo" -> "bar")
       )
-      val request = HttpRequest(head, None)
+      val request = HttpRequest(head, HttpBody.NoBody)
 
       request.head.persistConnection must equal(false)
     }
@@ -60,7 +60,7 @@ class HttpSpec extends WordSpec with MustMatchers{
         method = HttpMethod.Post,
         headers = List("connection" -> "bar")
       )
-      val request = HttpRequest(head, None)
+      val request = HttpRequest(head, HttpBody.NoBody)
 
       request.head.persistConnection must equal(false)
     }
@@ -72,7 +72,7 @@ class HttpSpec extends WordSpec with MustMatchers{
         method = HttpMethod.Post,
         headers = List("connection" -> "keep-alive")
       )
-      val request = HttpRequest(head, None)
+      val request = HttpRequest(head, HttpBody.NoBody)
 
       request.head.persistConnection must equal(true)
     }
@@ -84,7 +84,7 @@ class HttpSpec extends WordSpec with MustMatchers{
         method = HttpMethod.Post,
         headers = List("foo" -> "bar")
       )
-      val request = HttpRequest(head, None)
+      val request = HttpRequest(head, HttpBody.NoBody)
 
       request.head.persistConnection must equal(true)
     }
@@ -96,7 +96,7 @@ class HttpSpec extends WordSpec with MustMatchers{
         method = HttpMethod.Post,
         headers = List("connection" -> "bar")
       )
-      val request = HttpRequest(head, None)
+      val request = HttpRequest(head, HttpBody.NoBody)
 
       request.head.persistConnection must equal(true)
     }
@@ -108,7 +108,7 @@ class HttpSpec extends WordSpec with MustMatchers{
         method = HttpMethod.Post,
         headers = List("connection" -> "close")
       )
-      val request = HttpRequest(head, None)
+      val request = HttpRequest(head, HttpBody.NoBody)
 
       request.head.persistConnection must equal(false)
     }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/WildcardURLParsingTest.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/WildcardURLParsingTest.scala
@@ -12,7 +12,7 @@ class WildcardURLParsingTest extends WordSpec with MustMatchers {
     "The wildcard url parser" should {
       "match a root url" in {
           val url = ""
-          val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), None)
+          val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), HttpBody.NoBody)
           request match {
             case req @ Get on Root => {}
             case _ => fail()
@@ -21,7 +21,7 @@ class WildcardURLParsingTest extends WordSpec with MustMatchers {
 
       "match a resource url" in {
         val url = "/moose.jpg"
-        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), None)
+        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), HttpBody.NoBody)
         request match {
           case req @ Get on Root /: rest => rest must be("moose.jpg")
           case _ => fail("Failed to match url")
@@ -30,7 +30,7 @@ class WildcardURLParsingTest extends WordSpec with MustMatchers {
 
       "match a complex resource url" in {
         val url = "/bronx/zoo/moose.jpg"
-        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), None)
+        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), HttpBody.NoBody)
         request match {
           case req @ Get on base /: city /: place /: animal  =>
             base must be("/")
@@ -43,7 +43,7 @@ class WildcardURLParsingTest extends WordSpec with MustMatchers {
 
       "partially match a url" in {
         val url = "/bronx/zoo/moose.jpg"
-        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), None)
+        val request = HttpRequest(HttpRequestHead(Get, url, `1.1`, HttpHeaders()), HttpBody.NoBody)
         request match {
           case req @ Get on Root /: city /: placeAndAnimal => placeAndAnimal must be("zoo/moose.jpg")
           case _ => fail("Failed to match complex url")

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
@@ -61,7 +61,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
           HttpCodes.OK,
           Seq("host"->"api.foo.bar:444", "accept"->"*/*", "authorization"->"Basic XXX", "accept-encoding"->"gzip, deflate")
         ),
-        HttpResponseBody(body)
+        HttpBody(body)
       ))
       parser.parse(DataBuffer(ByteString(res))) must equal(None)
       parser.endOfStream() must equal(Some(expected))

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -25,7 +25,7 @@ class WebsocketSpec extends WordSpec with MustMatchers{
       ("host" , "foo.bar"),
       ("origin", "http://foo.bar")
     )),
-    None
+    HttpBody.NoBody
   )
 
   "Http Upgrade Request" must {
@@ -48,7 +48,7 @@ class WebsocketSpec extends WordSpec with MustMatchers{
             HttpHeader("Sec-Websocket-Accept","MeFiDAjivCOffr7Pn3T2DM7eJHo=")
           )
         ),
-        HttpResponseBody.NoBody
+        HttpBody.NoBody
       )
       UpgradeRequest.unapply(valid).get must equal(expected)
 

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -201,7 +201,7 @@ abstract class Connection(val id: Long, initialHandler: ConnectionHandler, val w
    * fullfill the request and provide the handler with a DataOutBuffer to which
    * it can write data.
    */
-  def handleWrite(data: DataOutBuffer): Boolean = {
+  def handleWrite(data: DynamicOutBuffer): Boolean = {
     if (continueWrite()) {
       //the WriteBuffer is ready to accept more data, so let's get some.  Notice
       //this method (usually) only gets called if the handler had previously made a write

--- a/colossus/src/main/scala/colossus/core/DataOutBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/DataOutBuffer.scala
@@ -4,34 +4,46 @@ package core
 import akka.util.{ByteString, ByteStringBuilder}
 import java.nio.ByteBuffer
 
+/**
+ * The DataOutBuffer is a ConnectionHandler's interface for writing data out to
+ * the connection.  DataOutBuffers support a "soft" overflow, which means it
+ * will dynamically allocate more space as needed, but is based off a
+ * fixed-length base size.  The idea is that writing should stop as soon as the
+ * overflow is hit, but it is not a requirement.
+ */
 trait DataOutBuffer {
 
-  def available: Long
   def isOverflowed: Boolean
 
-  /**
-   * Copy as much as `src` into this buffer as possible.  
-   */
-  def write(src: DataBuffer)
+  protected def copyDestination(bytesNeeded: Long): ByteBuffer
 
-  /**
-   * Attempt to write the entire contents of bytes into this buffer.  If there
-   * is not enough available space an exeption is thrown
-   */
-  def write(bytes: ByteString)
+  def write(from: ByteBuffer) {
+    copyDestination(from.remaining).put(from)
+  }
 
-  def write(bytes: Array[Byte])
+  def write(from: DataBuffer) {
+    write(from.data)
+  }
 
-  def write(bytes: Array[Byte], offset: Int, length: Int)
+  def write(bytes: ByteString) {
+    write(bytes.asByteBuffer)
+  }
 
-  def write(byte: Byte)
+  def write(bytes: Array[Byte]) {
+    copyDestination(bytes.size).put(bytes)
+  }
 
-  /* Get a DataBuffer containing the data written into this DataOutBuffer.  This
-   * generally renders this buffer unusable
-   *
-   * TODO: Unify this maybe with DataBuffer
-   */
-  def data: DataBuffer
+  def write(bytes: Array[Byte], offset: Int, length: Int) {
+    copyDestination(length).put(bytes, offset, length)
+  }
+
+  def write(byte: Byte) {
+    copyDestination(1).put(byte)
+  }
+
+  def write(char: Char) {
+    write(char.toByte)
+  }
 
 }
 
@@ -77,7 +89,7 @@ class DynamicOutBuffer(baseSize: Int, allocateDirect: Boolean = true) extends Da
     }
   }
 
-  def copyDestination(bytesNeeded: Long) : ByteBuffer = if (base.remaining >= bytesNeeded) base else {
+  protected def copyDestination(bytesNeeded: Long) : ByteBuffer = if (base.remaining >= bytesNeeded) base else {
     while (dynAvailable < bytesNeeded) {
       growDyn()
     }
@@ -89,32 +101,6 @@ class DynamicOutBuffer(baseSize: Int, allocateDirect: Boolean = true) extends Da
     base.clear()
   }
 
-  def available = Long.MaxValue //maybe limit this somehow?
-
-  def write(from: ByteBuffer) {
-    copyDestination(from.remaining).put(from)
-  }
-
-
-  def write(from: DataBuffer) {
-    write(from.data)
-  }
-
-  def write(bytes: ByteString) {
-    write(bytes.asByteBuffer)
-  }
-
-  def write(bytes: Array[Byte]) {
-    copyDestination(bytes.size).put(bytes)
-  }
-
-  def write(bytes: Array[Byte], offset: Int, length: Int) {
-    copyDestination(length).put(bytes, offset, length)
-  }
-
-  def write(byte: Byte) {
-    copyDestination(1).put(byte)
-  }
 
   def data = {
     val d = dyn.getOrElse(base)

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -282,7 +282,7 @@ class DateHeader(start: Long = System.currentTimeMillis) extends HttpHeader {
   import java.util.Date
   import java.text.SimpleDateFormat
 
-  private val formatter = new SimpleDateFormat("EEE, MMM d yyyy HH:MM:ss z")
+  private val formatter = new SimpleDateFormat(DateHeader.DATE_FORMAT)
   
   private def generate(time: Long) = HttpHeader("Date", formatter.format(new Date(time)))
   private var lastDate = generate(start)
@@ -300,6 +300,12 @@ class DateHeader(start: Long = System.currentTimeMillis) extends HttpHeader {
     }
     lastDate.encoded
   }
+
+}
+
+object DateHeader {
+
+  val DATE_FORMAT = "EEE, MMM d yyyy HH:MM:ss z"
 
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -88,6 +88,12 @@ object HttpHeader {
 
   def apply(key: String, value: String): HttpHeader = (new DecodedHeader(key, value)).toEncodedHeader
 
+  object Conversions {
+    implicit def liftTupleList(l: Seq[(String, String)]): HttpHeaders = new HttpHeaders (
+      l.map{ case (k,v) => HttpHeader(k,v) }.toArray
+    )
+  }
+
 }
     
 class HttpHeaders(private val headers: Array[HttpHeader]) {
@@ -312,6 +318,8 @@ class HttpBody(private val body: Array[Byte], val contentType : Option[HttpHeade
     case other => false
   }
 
+  override def hashCode = body.hashCode
+
   override def toString = bytes.utf8String
 
 }
@@ -337,7 +345,7 @@ trait HttpBodyEncoders {
 
 object HttpBody extends HttpBodyEncoders {
   
-  val NoBody = HttpBody("")
+  val NoBody = new HttpBody(Array(), None)
   
   def apply[T](data: T)(implicit encoder: HttpBodyEncoder[T]): HttpBody = encoder.encode(data)
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -274,14 +274,14 @@ class HttpBody(private val body: Array[Byte])  {
 
   def size = body.size
 
-  def encode(buffer: DataOutBuffer) {
+  def encode(buffer: core.DataOutBuffer) {
     if (size > 0) buffer.write(body)
   }
 
   def bytes: ByteString = ByteString(body)
 
   override def equals(that: Any) = that match {
-    case that: HttpResponseBody => that.bytes == this.bytes
+    case that: HttpBody => that.bytes == this.bytes
     case other => false
   }
 
@@ -290,19 +290,19 @@ class HttpBody(private val body: Array[Byte])  {
 }
 
 trait HttpBodyEncoder[T] {
-  def encode: HttpBody
+  def encode(data: T): HttpBody
 }
 
 trait HttpBodyEncoders {
-  implicit object ByteStringEncoder extends HttpBodyEncodable[ByteString] {
-    def encode(b: ByteString): HttpBody = new HttpBody(data.toArray)
+  implicit object ByteStringEncoder extends HttpBodyEncoder[ByteString] {
+    def encode(data: ByteString): HttpBody = new HttpBody(data.toArray)
   }
 
   implicit object StringEncoder extends HttpBodyEncoder[String] {
-    def encode(s: String) : HttpBody = new HttpBody(data.getBytes("UTF-8"))
+    def encode(data: String) : HttpBody = new HttpBody(data.getBytes("UTF-8"))
   }
 
-  implicit object IdentityEncoder extends HttpBodyEnvoder[HttpBody] {
+  implicit object IdentityEncoder extends HttpBodyEncoder[HttpBody] {
     def encode(b: HttpBody) = b
   }
 }
@@ -311,6 +311,6 @@ object HttpBody extends HttpBodyEncoders {
   
   val NoBody = HttpBody("")
   
-  def apply(data: T)(implicit encoder: HttpBodyEncoder[T]): HttpBody = encoder(data)
+  def apply[T](data: T)(implicit encoder: HttpBodyEncoder[T]): HttpBody = encoder.encode(data)
 
 }

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -278,24 +278,25 @@ case class QueryParameters(parameters: Seq[(String, String)]) extends AnyVal{
 
 }
 
-class DateHeader extends HttpHeader {
+class DateHeader(start: Long = System.currentTimeMillis) extends HttpHeader {
   import java.util.Date
   import java.text.SimpleDateFormat
 
   private val formatter = new SimpleDateFormat("EEE, MMM d yyyy HH:MM:ss z")
   
-  private def generate = HttpHeader("Date", formatter.format(new Date()))
-  private var lastDate = generate
-  private var lastTime = System.currentTimeMillis
+  private def generate(time: Long) = HttpHeader("Date", formatter.format(new Date(time)))
+  private var lastDate = generate(start)
+  private var lastTime = start
 
   def key = lastDate.key
   def value = lastDate.value
 
-  def encoded = {
-    val t = System.currentTimeMillis
-    if (t > lastTime + 1000) {
-      lastDate = generate
-      lastTime = t
+  def encoded: Array[Byte] = encoded(System.currentTimeMillis)
+
+  def encoded(time: Long): Array[Byte] = {
+    if (time >= lastTime + 1000) {
+      lastDate = generate(time)
+      lastTime = time
     }
     lastDate.encoded
   }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
@@ -14,7 +14,7 @@ class BaseHttpClientCodec[T <: BaseHttpResponse](parserFactory: () => Parser[Dec
   private var parser : Parser[DecodedResult[T]] = parserFactory()
 
 
-  override def encode(out: HttpRequest): DataReader = DataBuffer(out.bytes)
+  override def encode(out: HttpRequest): DataReader = out
 
   override def decode(data: DataBuffer): Option[DecodedResult[T]] = parser.parse(data)
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -74,6 +74,12 @@ case class HttpRequest(head: HttpRequestHead, body: HttpBody) extends core.Encod
     body encode buffer
   }
 
+  def bytes: ByteString = {
+    val d = new core.DynamicOutBuffer(100, false)
+    encode(d)
+    ByteString(d.data.takeAll)
+  }
+
   def withHeader(key: String, value: String) = copy(head = head.withHeader(key, value))
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -53,7 +53,7 @@ case class HttpRequestHead(method: HttpMethod, url: String, version: HttpVersion
 
 }
 
-case class HttpRequest(head: HttpRequestHead, body: HttpBody) {
+case class HttpRequest(head: HttpRequestHead, body: HttpBody) extends core.Encoder {
   import head._
   import HttpCodes._
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -31,74 +31,57 @@ case class HttpRequestHead(method: HttpMethod, url: String, version: HttpVersion
 
   lazy val cookies: Seq[Cookie] = headers.allValues(HttpHeaders.CookieHeader).flatMap{Cookie.parseHeader}
 
-  //we should only encode if the string is decoded.
-  //To check for that, if we decode an already decoded URL, it should not change (this may not be necessary)
-  //the alternative is one big fat honkin ugly regex and knowledge of what characters are allowed where(gross)
-  //TODO: this doesn't work, "/test" becomes %2Ftest
-  private def getEncodedURL : String = url
-  /*{
-    if(URLDecoder.decode(url,"UTF-8") == url) {
-      URLEncoder.encode(url, "UTF-8")
-    }else {
-      url
-    }
-  }*/
-
-
-  //TODO: optimize
-  def bytes : ByteString = {
-    val reqString = ByteString(s"${method.name} $getEncodedURL HTTP/$version\r\n")
-    if (headers.size > 0) {
-      val buf = new core.DynamicOutBuffer(200, false)
-      headers.encode(buf)
-      val encodedHeaders = ByteString(buf.data.data)
-      reqString ++ encodedHeaders ++ ByteString("\r\n")
-    } else {
-      reqString ++ ByteString("\r\n")
-    }
+  def encode(buffer: DynamicOutBuffer) {
+    buffer write method.bytes
+    byffer write ' '
+    buffer write url.getBytes("UTF-8")
+    buffer write ' '
+    buffer write version.messageArr
+    buffer write NEWLINE_ARRAY
+    headers encode buffer
+    buffer write NEWLINE_ARRAY
   }
 
-  def persistConnection: Boolean =
+  def persistConnection: Boolean = {
     (version, headers.connection) match {
       case (HttpVersion.`1.1`, Some(Connection.Close)) => false
       case (HttpVersion.`1.1`, _) => true
       case (HttpVersion.`1.0`, Some(Connection.KeepAlive)) => true
       case (HttpVersion.`1.0`, _) => false
     }
+  }
+
 }
 
-case class HttpRequest(head: HttpRequestHead, entity: Option[ByteString]) {
+case class HttpRequest(head: HttpRequestHead, body: HttpBody) {
   import head._
   import HttpCodes._
 
-  def respond(code: HttpCode, data: String, headers: List[(String, String)] = Nil) = {
-    import HttpHeader.Conversions._
-    HttpResponse(HttpResponseHead(version, code, headers), HttpResponseBody(data))
+  def respond[T : HttpBodyEncoder](code: HttpCode, data: T, headers: HttpHeaders = HttpHeaders.Empty) = {
+    HttpResponse(HttpResponseHead(version, code, headers), HttpBody(data))
   }
 
-  def ok(data: String, headers: List[(String, String)] = Nil)              = respond(OK, data, headers)
-  def notFound(data: String = "", headers: List[(String, String)] = Nil)   = respond(NOT_FOUND, data, headers)
-  def error(message: String, headers: List[(String, String)] = Nil)        = respond(INTERNAL_SERVER_ERROR, message, headers)
-  def badRequest(message: String, headers: List[(String, String)] = Nil)   = respond(BAD_REQUEST, message, headers)
-  def unauthorized(message: String, headers: List[(String, String)] = Nil) = respond(UNAUTHORIZED, message, headers)
-  def forbidden(message: String, headers: List[(String, String)] = Nil)    = respond(FORBIDDEN, message, headers)
+  def ok[T : HttpBodyEncoder](data: T, headers: HttpHeaders = HttpHeaders.Empty)              = respond(OK, data, headers)
+  def notFound[T : HttpBodyEncoder](data: T, headers: HttpHeaders = HttpHeaders.Empty)        = respond(NOT_FOUND, data, headers)
+  def error[T : HttpBodyEncoder](message: T, headers: HttpHeaders = HttpHeaders.Empty)        = respond(INTERNAL_SERVER_ERROR, message, headers)
+  def badRequest[T : HttpBodyEncoder](message: T, headers: HttpHeaders = HttpHeaders.Empty)   = respond(BAD_REQUEST, message, headers)
+  def unauthorized[T : HttpBodyEncoder](message: T, headers: HttpHeaders = HttpHeaders.Empty) = respond(UNAUTHORIZED, message, headers)
+  def forbidden[T : HttpBodyEncoder](message: T, headers: HttpHeaders = HttpHeaders.Empty)    = respond(FORBIDDEN, message, headers)
 
-  //TODO optimize
-  def bytes : ByteString = {
-    head.bytes ++ entity.getOrElse(ByteString())
+  def encode(buffer: DataOutBuffer) {
+    head encode buffer
+    body encode buffer
   }
 
   def withHeader(key: String, value: String) = copy(head = head.withHeader(key, value))
 }
 
 object HttpRequest {
-  import HttpHeader.Conversions._
-  def apply(method: HttpMethod, url: String, body: Option[String]): HttpRequest = {
-    val bodybytes = body.map{ByteString(_)}
-    val head = HttpRequestHead(method, url, HttpVersion.`1.1`, List((HttpHeaders.ContentLength -> bodybytes.map{_.size.toString}.getOrElse("0"))))
-    HttpRequest(head, bodybytes)
+
+  def apply[T : HttpBodyEcoder](method: HttpMethod, url: String, body: T): HttpRequest = {
+    val head = HttpRequestHead(method, url, HttpVersion.`1.1`, HttpHeaders.Empty)
+    HttpRequest(head, HttpBody(body))
   }
 
-
-  def get(url: String) = HttpRequest(HttpMethod.Get, url, None)
+  def get(url: String) = HttpRequest(HttpMethod.Get, url, HttpBody.NoBody)
 }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
@@ -43,12 +43,12 @@ class HttpHeadParser extends Parser[HeadResult]{
     var method: String = ""
     var path: String = ""
     var version: String = ""
-    var headers = new java.util.ArrayList[HttpHeader]
+    var headers: List[HttpHeader] = Nil
     var contentLength: Option[Int] = None
     var transferEncoding: Option[String] = None
 
     def addHeader(name: String, value: String) {
-      headers add new DecodedHeader(name, value)
+      headers =  new DecodedHeader(name, value) :: headers
       if (name == HttpHeaders.ContentLength) {
         contentLength = Some(value.toInt)
       } else if (name == HttpHeaders.TransferEncoding) {
@@ -62,7 +62,7 @@ class HttpHeadParser extends Parser[HeadResult]{
           HttpMethod(method),
           path,
           HttpVersion(version),
-          new HttpHeaders(headers.toArray.asInstanceOf[Array[HttpHeader]])
+          new HttpHeaders(headers.toArray)
         ), 
         contentLength,
         transferEncoding
@@ -72,7 +72,7 @@ class HttpHeadParser extends Parser[HeadResult]{
     }
 
     def reset() {
-      headers = new java.util.ArrayList[HttpHeader]
+      headers = Nil
       contentLength = None
       transferEncoding = None
     }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
@@ -10,18 +10,20 @@ import HttpParse._
 import Combinators._
 
 object HttpRequestParser {
+  import HttpBody._
 
   val DefaultMaxSize: DataSize = 1.MB
 
   def apply(size: DataSize = DefaultMaxSize) = maxSize(size, httpRequest)
 
+  //TODO : don't parse body as a bytestring
   protected def httpRequest: Parser[HttpRequest] = httpHead |> {case HeadResult(head, contentLength, transferEncoding) => 
     transferEncoding match { 
       case None | Some("identity") => contentLength match {
-        case Some(0) | None => const(HttpRequest(head, None))
-        case Some(n) => bytes(n) >> {body => HttpRequest(head, Some(body))}
+        case Some(0) | None => const(HttpRequest(head, HttpBody.NoBody))
+        case Some(n) => bytes(n) >> {body => HttpRequest(head, HttpBody(body))}
       }
-      case Some(other)  => chunkedBody >> {body => HttpRequest(head, Some(body))}
+      case Some(other)  => chunkedBody >> {body => HttpRequest(head, HttpBody(body))}
     } 
   }
 
@@ -41,13 +43,12 @@ class HttpHeadParser extends Parser[HeadResult]{
     var method: String = ""
     var path: String = ""
     var version: String = ""
-    var headers: List[HttpHeader] = Nil
+    var headers = new java.util.ArrayList[HttpHeader]
     var contentLength: Option[Int] = None
     var transferEncoding: Option[String] = None
-    var body: Option[ByteString] = None
 
     def addHeader(name: String, value: String) {
-      headers = new DecodedHeader(name, value) :: headers
+      headers add new DecodedHeader(name, value)
       if (name == HttpHeaders.ContentLength) {
         contentLength = Some(value.toInt)
       } else if (name == HttpHeaders.TransferEncoding) {
@@ -56,16 +57,24 @@ class HttpHeadParser extends Parser[HeadResult]{
     }
 
     def build: HeadResult = {
-      val r = HeadResult(HttpRequestHead(HttpMethod(method), path, HttpVersion(version), new HttpHeaders(headers.toArray)), contentLength, transferEncoding)
+      val r = HeadResult(
+        HttpRequestHead(
+          HttpMethod(method),
+          path,
+          HttpVersion(version),
+          new HttpHeaders(headers.toArray.asInstanceOf[Array[HttpHeader]])
+        ), 
+        contentLength,
+        transferEncoding
+      )
       reset()
       r
     }
 
     def reset() {
-      headers = Nil
+      headers = new java.util.ArrayList[HttpHeader]
       contentLength = None
       transferEncoding = None
-      body = None
     }
   }
   var requestBuilder = new RBuilder

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -63,33 +63,6 @@ sealed trait BaseHttpResponse {
 //prevent things like creating a response with the wrong content length
 
 
-class HttpResponseBody(private val body: Array[Byte])  {
-
-  def size = body.size
-
-  def encode(buffer: DataOutBuffer) {
-    if (size > 0) buffer.write(body)
-  }
-
-  def bytes: ByteString = ByteString(body)
-
-  override def equals(that: Any) = that match {
-    case that: HttpResponseBody => that.bytes == this.bytes
-    case other => false
-  }
-
-  override def toString = bytes.utf8String
-
-}
-
-object HttpResponseBody {
-  
-  val NoBody = HttpResponseBody("")
-  
-  def apply(data: ByteString): HttpResponseBody = new HttpResponseBody(data.toArray)
-  def apply(data: String) : HttpResponseBody = new HttpResponseBody(data.getBytes("UTF-8"))
-
-}
 
 case class HttpResponse(head: HttpResponseHead, body: HttpResponseBody) extends BaseHttpResponse with Encoder {
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -87,7 +87,6 @@ case class HttpResponse(head: HttpResponseHead, body: HttpBody) extends BaseHttp
     head.encode(buffer)
     body.contentType.foreach{ctype =>
       buffer.write(ctype.encoded)
-      buffer.write(HttpParse.NEWLINE_ARRAY)
     }
     buffer.write(HttpResponse.ContentLengthKeyArray)
     fastIntToString(body.size, buffer)

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponseParser.scala
@@ -26,6 +26,8 @@ object HttpResponseParser  {
 
   def stream(dechunkBody: Boolean): Parser[DecodedResult[StreamingHttpResponse]] = streamBody(dechunkBody)
 
+  import HttpBody._
+
 
   //TODO: eliminate duplicate code
   //TODO: Dechunk on static
@@ -33,9 +35,9 @@ object HttpResponseParser  {
   protected def staticBody(dechunk: Boolean): Parser[DecodedResult.Static[HttpResponse]] = head |> {parsedHead =>
     parsedHead.headers.transferEncoding match {
       case TransferEncoding.Identity => parsedHead.headers.contentLength match {
-        case Some(0)  => const(DecodedResult.Static(HttpResponse(parsedHead, HttpResponseBody.NoBody)))
+        case Some(0)  => const(DecodedResult.Static(HttpResponse(parsedHead, HttpBody.NoBody)))
         case Some(n)  => bytes(n) >> {body => DecodedResult.Static(HttpResponse(parsedHead, body))}
-        case None if (parsedHead.code.isInstanceOf[NoBodyCode]) => const(DecodedResult.Static(HttpResponse(parsedHead, HttpResponseBody.NoBody)))
+        case None if (parsedHead.code.isInstanceOf[NoBodyCode]) => const(DecodedResult.Static(HttpResponse(parsedHead, HttpBody.NoBody)))
         case None     => bytesUntilEOS >> {body => DecodedResult.Static(HttpResponse(parsedHead, body))}
       }
       case _  => chunkedBody >> {body => DecodedResult.Static(HttpResponse(parsedHead, body))}

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -9,9 +9,8 @@ import service._
 import akka.util.ByteString
 import scala.concurrent.ExecutionContext
 
-package object http {
+package object http extends HttpBodyEncoders {
 
-  import HttpBody._
 
   class InvalidRequestException(message: String) extends Exception(message)
 

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -11,6 +11,8 @@ import scala.concurrent.ExecutionContext
 
 package object http {
 
+  import HttpBody._
+
   class InvalidRequestException(message: String) extends Exception(message)
 
   trait BaseHttp extends CodecDSL {
@@ -107,12 +109,5 @@ package object http {
     )
 
     */
-  implicit object ByteStringLikeString extends ByteStringLike[String] {
-    override def toByteString(t: String): ByteString = ByteString(t)
-  }
-
-  implicit object ByteStringLikeByteString extends ByteStringLike[ByteString] {
-    override def toByteString(t: ByteString): ByteString = t
-  }
 
 }

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -52,7 +52,7 @@ object UpgradeRequest {
           HttpHeader("Sec-Websocket-Accept",processKey(seckey))
         )
       ),
-      HttpResponseBody.NoBody
+      HttpBody.NoBody
     )      
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -53,9 +53,12 @@ object ColossusBuild extends Build {
     "org.scalatest"     %% "scalatest" % SCALATEST_VERSION
   )
 
-  val MetricSettings = ColossusSettings ++ Seq(
+  val MetricSettings = ColossusSettings 
+
+  val ExamplesSettings = Seq (
     libraryDependencies ++= Seq(
-      "net.liftweb"       %% "lift-json"     % "2.6-RC1")
+      "org.json4s" %% "json4s-jackson" % "3.3.0"
+    )
   )
 
   lazy val RootProject = Project(id="root", base=file("."))
@@ -74,6 +77,7 @@ object ColossusBuild extends Build {
       .settings(noPubSettings:_*)
       .settings(Revolver.settings:_*)
       .configs(IntegrationTest)
+      .settings(ExamplesSettings:_*)
       .dependsOn(ColossusProject)
 
   lazy val ColossusMetricsProject = Project(id="colossus-metrics", base=file("colossus-metrics"))


### PR DESCRIPTION
* Both requests and responses now use `HttpBody`, which also now includes an optional content-type header
* A new `HttpBodyEncoder` typeclass for easily turning typed data into http bodies with the correct content type header.
* Created a new `DateHeader` which can be used to generate correct values for the http date header.
* removed all the json stuff from the metrics
* cleaned up some of the interface code in `DataOutBuffer`