### PR TITLE
flipping the arguments on counter set method to make backwards compatible

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -12,7 +12,7 @@ class Counter private[metrics](val address: MetricAddress)(implicit collection: 
 
   def decrement(tags: TagMap = TagMap.Empty, num: Long = 1) = increment(tags, 0 - num)
 
-  def set(tags: TagMap = TagMap.Empty, num: Long) {
+  def set(num: Long, tags: TagMap = TagMap.Empty) {
     counters.set(tags, num)
   }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
@@ -31,10 +31,10 @@ class CounterSpec extends MetricIntegrationSpec {
 
     "correctly handle tags" in {
       val c = counter
-      c.increment(Map("a" -> "a"))
-      c.increment(Map("a" -> "b"))
-      c.increment(Map("a" -> "b"))
-      c.get(Map("a" -> "a")) must equal(1)
+      c.set(123, tags = Map("a" -> "a"))
+      c.increment(tags = Map("a" -> "b"))
+      c.increment(tags = Map("a" -> "b"))
+      c.get(Map("a" -> "a")) must equal(123)
       c.get(Map("a" -> "b")) must equal(2)
     }
 


### PR DESCRIPTION
We used to have gauges that just had a `set` method.  Now we've rolled that functionality into counters, but the arguments were in the opposite order.  So we'll just flip them back to make converting gauges to counters easier.