### PR TITLE
first pass of getting typesafe config into colossus

### DIFF
--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -1,8 +1,8 @@
 colossus {
   metrics {
     collect-system-metrics: true
-    metric-intervals: ["1 second", "1 minute"]
-    metric-address: "/"
+    collection-intervals: ["1 second", "1 minute"]
+    namespace: "/"
     collectors-defaults {
       rate {
         prune-empty: false
@@ -16,5 +16,9 @@ colossus {
 
       }
     }
+    ##Metrics can be listed here as well:
+    # /my/path/to/my/histogram {
+     # ...configuration
+    ##}
   }
 }

--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -3,17 +3,20 @@ colossus {
     collect-system-metrics: true
     collection-intervals: ["1 second", "1 minute"]
     namespace: "/"
+    enabled : true
     collectors-defaults {
       rate {
+        enabled : true
         prune-empty: false
       }
       histogram {
+        enabled : true
         percentiles: [0.75, 0.9, 0.99, 0.999, 0.9999]
         sample-rate: 1.0
         prune-empty: false
       }
       counter {
-
+        enabled : true
       }
     }
     ##Metrics can be listed here as well:

--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -1,0 +1,20 @@
+colossus {
+  metrics {
+    collect-system-metrics: true
+    metric-intervals: ["1 second", "1 minute"]
+    metric-address: "/"
+    collectors-defaults {
+      rate {
+        prune-empty: false
+      }
+      histogram {
+        percentiles: [0.75, 0.9, 0.99, 0.999, 0.9999]
+        sample-rate: 1.0
+        prune-empty: false
+      }
+      counter {
+
+      }
+    }
+  }
+}

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -22,9 +22,22 @@ import java.util.concurrent.atomic.AtomicLong
  */
 case class CollectorConfig(intervals: Seq[FiniteDuration], config : Config = ConfigFactory.defaultReference())
 
+/**
+  * Base trait required by all metric types.
+  */
 trait Collector {
 
+  /**
+    * The MetricAddress of this Collector.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @return
+    */
   def address: MetricAddress
+
+  /**
+    * TODO
+    * @param interval
+    * @return
+    */
   def tick(interval: FiniteDuration): MetricMap
 }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -1,7 +1,8 @@
 package colossus.metrics
 
+import com.typesafe.config.{ConfigFactory, Config}
+
 import scala.concurrent.duration._
-import scala.reflect.ClassTag
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
@@ -19,7 +20,9 @@ import java.util.concurrent.atomic.AtomicLong
  *
  * @param intervals The aggregation intervals configured for the MetricSystem this collection belongs to
  */
-case class CollectorConfig(intervals: Seq[FiniteDuration])
+case class CollectorConfig(intervals: Seq[FiniteDuration], config : Config = ConfigFactory.defaultReference())
+
+trait CollectorParameterDefaults
 
 trait Collector {
 
@@ -88,7 +91,7 @@ class Collection(val config: CollectorConfig) {
     collectors.put(collector.address, collector)
   }
 
-  def getOrAdd[T <: Collector : ClassTag](created: T): T = {
+  def getOrAdd[T <: Collector](created: T): T = {
     collectors.putIfAbsent(created.address, created) match {
       case null => created
       case exists: T => exists

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -22,8 +22,6 @@ import java.util.concurrent.atomic.AtomicLong
  */
 case class CollectorConfig(intervals: Seq[FiniteDuration], config : Config = ConfigFactory.defaultReference())
 
-trait CollectorParameterDefaults
-
 trait Collector {
 
   def address: MetricAddress

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -41,7 +41,7 @@ trait Collector {
   def tick(interval: FiniteDuration): MetricMap
 }
 
-class CollectionMap[T] {
+private[metrics] class CollectionMap[T] {
 
   private val map = new ConcurrentHashMap[T, AtomicLong]
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -52,10 +52,13 @@ case class MetricSystem private[metrics] (namespace: MetricAddress, metricInterv
 }
 
 object MetricSystem {
+
+  val ConfigRoot = "colossus.metrics"
+
   /**
    * Constructs a metric system
-    *
-    * @param namespace the base of the url describing the location of metrics within the system
+   *
+   * @param namespace the base of the url describing the location of metrics within the system
    * @param metricIntervals How often to report metrics
    * @param collectSystemMetrics whether to collect metrics from the system as well
    * @param config Typesafe Config source which shoudl contain configuration for a MetricSystem.  This Configuration object is used during
@@ -96,7 +99,7 @@ object MetricSystem {
     * @return
     */
   def apply()(implicit system : ActorSystem) : MetricSystem = {
-    apply("colossus.metrics")
+    apply(ConfigRoot)
   }
 
   /**
@@ -109,7 +112,7 @@ object MetricSystem {
     * @return
     */
   def apply(configPath : String)(implicit system : ActorSystem) : MetricSystem = {
-    apply(configPath, ConfigFactory.load()) //reference?
+    apply(configPath, ConfigFactory.load())
   }
 
   /**
@@ -125,12 +128,12 @@ object MetricSystem {
     import MetricSystemConfigHelpers._
 
     val userPathObject = config.getObject(configPath)
-    val metricsObject = userPathObject.withFallback(config.getObject("colossus.metrics"))
+    val metricsObject = userPathObject.withFallback(config.getObject(ConfigRoot))
     val metricsConfig = metricsObject.toConfig
 
     //after creating the merged config object, overwrite colossus.metrics with this value and use that internally,
     //This simplifies Collector creation.
-    val mergedConfig = config.withValue("colossus.metrics", metricsObject)
+    val mergedConfig = config.withValue(ConfigRoot, metricsObject)
 
     val collectSystemMetrics = metricsConfig.getBoolean("collect-system-metrics")
     val metricIntervals = metricsConfig.getFiniteDurations("metric-intervals")

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -3,20 +3,25 @@ package colossus.metrics
 import akka.actor._
 import akka.agent.Agent
 import colossus.metrics.MetricAddress.Root
+import com.typesafe.config.{ConfigFactory, Config}
 
 import scala.concurrent.duration._
 
-class MetricInterval private[metrics](val namespace : MetricAddress, val interval : FiniteDuration, val intervalAggregator : ActorRef, snapshot : Agent[MetricMap]) {
+class MetricInterval private[metrics](val namespace : MetricAddress,
+                                      val interval : FiniteDuration,
+                                      val intervalAggregator : ActorRef, snapshot : Agent[MetricMap]){
 
-    /**
+  /**
    * The latest metrics snapshot
-   * @return
+    *
+    * @return
    */
   def last : MetricMap = snapshot.get()
 
   /**
    * Attach a reporter to this MetricPeriod.
-   * @param config  The [[MetricReporterConfig]] used to configure the [[MetricReporter]]
+    *
+    * @param config  The [[MetricReporterConfig]] used to configure the [[MetricReporter]]
    * @return
    */
   def report(config : MetricReporterConfig)(implicit fact: ActorRefFactory) : ActorRef = MetricReporter(config, intervalAggregator)
@@ -32,10 +37,12 @@ class MetricInterval private[metrics](val namespace : MetricAddress, val interva
  *
  * @param namespace the base of the url describing the location of metrics within the system
  * @param metricIntervals Map of all MetricIntervals for which this system collects Metrics.
+ * @param config Config object from which Metric configurations will be sourced.
  */
-case class MetricSystem private [metrics](namespace: MetricAddress, metricIntervals : Map[FiniteDuration, MetricInterval]) {
+case class MetricSystem private[metrics] (namespace: MetricAddress, metricIntervals : Map[FiniteDuration, MetricInterval],
+                                          collectionSystemMetrics : Boolean, config : Config) {
 
-  implicit val base = new Collection(CollectorConfig(metricIntervals.keys.toSeq))
+  implicit val base = new Collection(CollectorConfig(metricIntervals.keys.toSeq, config))
   registerCollection(base)
 
   def registerCollection(collection: Collection): Unit = {
@@ -47,13 +54,15 @@ case class MetricSystem private [metrics](namespace: MetricAddress, metricInterv
 object MetricSystem {
   /**
    * Constructs a metric system
-   * @param namespace the base of the url describing the location of metrics within the system
+    *
+    * @param namespace the base of the url describing the location of metrics within the system
    * @param metricIntervals How often to report metrics
    * @param collectSystemMetrics whether to collect metrics from the system as well
    * @param system the actor system the metric system should use
    * @return
    */
-  def apply(namespace: MetricAddress, metricIntervals: Seq[FiniteDuration] = Seq(1.second, 1.minute), collectSystemMetrics: Boolean = true)
+  def apply(namespace: MetricAddress, metricIntervals: Seq[FiniteDuration] = Seq(1.second, 1.minute),
+            collectSystemMetrics: Boolean = true, config : Config = ConfigFactory.defaultReference())
   (implicit system: ActorSystem): MetricSystem = {
     import system.dispatcher
 
@@ -65,7 +74,7 @@ object MetricSystem {
       interval -> i
     }.toMap
 
-    MetricSystem(namespace, m)
+    MetricSystem(namespace, m, collectSystemMetrics, config)
   }
 
   private def createIntervalAggregator(system : ActorSystem, namespace : MetricAddress, interval : FiniteDuration,
@@ -74,10 +83,55 @@ object MetricSystem {
   }
 
   def deadSystem(implicit system: ActorSystem) = {
-    MetricSystem(Root / "DEAD", Map[FiniteDuration, MetricInterval]())
+    MetricSystem(Root / "DEAD", Map[FiniteDuration, MetricInterval](), false, ConfigFactory.defaultReference())
   }
 
+  def apply()(implicit system : ActorSystem) : MetricSystem = {
+    apply("colossus.metrics")
+  }
+
+  def apply(name : String)(implicit system : ActorSystem) : MetricSystem = {
+    apply(name, ConfigFactory.load()) //reference?
+  }
+
+  def apply(name : String, config : Config)(implicit system : ActorSystem) : MetricSystem = {
+
+    import MetricSystemConfigHelpers._
+
+    val userPathObject = config.getObject(name)
+    val metricsObject = userPathObject.withFallback(config.getObject("colossus.metrics"))
+    val metricsConfig = metricsObject.toConfig
+    val mergedConfig = config.withValue("colossus.metrics", metricsObject) //<-- see, I told you
+
+    val collectSystemMetrics = metricsConfig.getBoolean("collect-system-metrics")
+    val metricIntervals = metricsConfig.getFiniteDurations("metric-intervals")
+    val metricAddress = metricsConfig.getString("metric-address")
+    MetricSystem(MetricAddress(metricAddress), metricIntervals, collectSystemMetrics, mergedConfig)
+  }
 }
+
+//has to be a better way
+object MetricSystemConfigHelpers {
+
+  implicit class FiniteDurationLoader(config : Config) {
+
+    import scala.collection.JavaConversions._
+
+    def getFiniteDurations(path : String) : Seq[FiniteDuration] = config.getStringList(path).map(finiteDurationOnly(_, path))
+
+    private def finiteDurationOnly(str : String, key : String) = {
+      Duration(str) match {
+        case duration : FiniteDuration => duration
+        case other => throw new FiniteDurationExpectedException(s"$str is not a valid FiniteDuration.  Expecting only finite for path $key.  Evaluted to $other")
+      }
+    }
+  }
+}
+
+private[metrics] class FiniteDurationExpectedException(str : String) extends Exception(str)
+
+
+
 
 
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -154,10 +154,15 @@ object MetricSystem {
     //This simplifies Collector creation.
     val mergedConfig = config.withValue(ConfigRoot, metricsObject)
 
-    val collectSystemMetrics = metricsConfig.getBoolean("collect-system-metrics")
-    val metricIntervals = metricsConfig.getFiniteDurations("collection-intervals")
-    val metricAddress = metricsConfig.getString("namespace")
-    MetricSystem(MetricAddress(metricAddress), metricIntervals, collectSystemMetrics, mergedConfig)
+    val enabled = metricsConfig.getBoolean("enabled")
+    if(enabled){
+      val collectSystemMetrics = metricsConfig.getBoolean("collect-system-metrics")
+      val metricIntervals = metricsConfig.getFiniteDurations("collection-intervals")
+      val metricAddress = metricsConfig.getString("namespace")
+      MetricSystem(MetricAddress(metricAddress), metricIntervals, collectSystemMetrics, mergedConfig)
+    }else{
+      deadSystem
+    }
   }
 }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -28,29 +28,43 @@ class MetricInterval private[metrics](val namespace : MetricAddress,
 }
 
 /**
- * The MetricSystem is a set of actors which handle the background operations of dealing with metrics. In most cases,
- * you only want to have one MetricSystem per application.
- *
- * Metrics are generated periodically by a Tick message published on the global event bus. By default this happens once
- * per second, but it can be configured to any time interval. So while events are being collected as they occur,
- * compiled metrics (such as rates and histogram percentiles) are generated once per tick.
- *
- * @param namespace the base of the url describing the location of metrics within the system
- * @param metricIntervals Map of all MetricIntervals for which this system collects Metrics.
- * @param config Config object from which Metric configurations will be sourced.
+  * The MetricSystem is a set of actors which handle the background operations of dealing with metrics. In most cases,
+  * you only want to have one MetricSystem per application.
+  *
+  * The currently provided metric types are [[colossus.metrics.Rate]], [[colossus.metrics.Histogram]] and [[colossus.metrics.Counter]].
+  * New metric types can be created by implementing the [[colossus.metrics.Collector]] trait.
+  *
+  * Namespace is the root of this MetricSystem's addressing.  All metrics which are registered within this MetricSystem will have their
+  * addresses prefixed with this value.
+  *
+  * Metrics are collected and reported for each collectionInterval specified.
+  *
+  * Metric Configuration
+  *
+  * A MetricSystem's configuration contains defaults for each metric type.  It can also contain configuration for individual metrics.
+  * When a new Metric is created, a MetricSystem will first look for a metric entry corresponding to the MetricAddress of the metric.
+  * If it finds one, it will use that entry overlaid on the default entry for that metric type to generate a complete configuration.
+  * If it does not find one, it will fallback to just using the default entry for that metric type.
+  *
+  * @param namespace Base url for all metrics within this MetricSystem
+  * @param collectionIntervals Intervals for which this MetricSystem reports its data.
+  * @param config Config object from which Metric configurations will be sourced.
  */
-case class MetricSystem private[metrics] (namespace: MetricAddress, metricIntervals : Map[FiniteDuration, MetricInterval],
+case class MetricSystem private[metrics] (namespace: MetricAddress, collectionIntervals : Map[FiniteDuration, MetricInterval],
                                           collectionSystemMetrics : Boolean, config : Config) {
 
-  implicit val base = new Collection(CollectorConfig(metricIntervals.keys.toSeq, config))
+  implicit val base = new Collection(CollectorConfig(collectionIntervals.keys.toSeq, config))
   registerCollection(base)
 
   def registerCollection(collection: Collection): Unit = {
-    metricIntervals.values.foreach(_.intervalAggregator ! IntervalAggregator.RegisterCollection(collection))
+    collectionIntervals.values.foreach(_.intervalAggregator ! IntervalAggregator.RegisterCollection(collection))
   }
 
 }
 
+/**
+  * Factory for [[colossus.metrics.MetricSystem]] instances
+  */
 object MetricSystem {
 
   val ConfigRoot = "colossus.metrics"
@@ -58,22 +72,22 @@ object MetricSystem {
   /**
    * Constructs a metric system
    *
-   * @param namespace the base of the url describing the location of metrics within the system
-   * @param metricIntervals How often to report metrics
+   * @param namespace Base url for all metrics within this MetricSystem
+   * @param collectionIntervals How often to report metrics
    * @param collectSystemMetrics whether to collect metrics from the system as well
-   * @param config Typesafe Config source which shoudl contain configuration for a MetricSystem.  This Configuration object is used during
+   * @param config Typesafe Config source which should contain configuration for a MetricSystem.  This Configuration object is used during
    *               Collector(Rate, Histogram specifically) creation.  If this Config does not have the corresponding colossus.metrics.collectors.defaults for those
    *               then Collector creation will fail if it tries to reference them.
    * @param system the actor system the metric system should use
    * @return
    */
-  def apply(namespace: MetricAddress, metricIntervals: Seq[FiniteDuration] = Seq(1.second, 1.minute),
+  def apply(namespace: MetricAddress, collectionIntervals: Seq[FiniteDuration] = Seq(1.second, 1.minute),
             collectSystemMetrics: Boolean = true, config : Config = ConfigFactory.defaultReference())
   (implicit system: ActorSystem): MetricSystem = {
     import system.dispatcher
 
 
-    val m : Map[FiniteDuration, MetricInterval] = metricIntervals.map{ interval =>
+    val m : Map[FiniteDuration, MetricInterval] = collectionIntervals.map{ interval =>
       val snap = Agent[MetricMap](Map())
       val aggregator : ActorRef = createIntervalAggregator(system, namespace, interval, snap, collectSystemMetrics)
       val i = new MetricInterval(namespace, interval, aggregator, snap)
@@ -88,13 +102,18 @@ object MetricSystem {
     system.actorOf(Props(classOf[IntervalAggregator], namespace, interval, snap, collectSystemMetrics))
   }
 
+  /**
+    * Create a system which does nothing.  Useful for testing/debugging.
+    * @param system
+    * @return
+    */
   def deadSystem(implicit system: ActorSystem) = {
     MetricSystem(Root / "DEAD", Map[FiniteDuration, MetricInterval](), false, ConfigFactory.defaultReference())
   }
 
   /**
     * Create a new MetricSystem, using only the defaults provided by the corresponding "colossus.metrics" config path.
-    * A Config object will be created via "ConfigFactory.load()"
+    * A Config object will be created via {{{ConfigFactory.load()}}}
     * @param system
     * @return
     */
@@ -105,7 +124,7 @@ object MetricSystem {
   /**
     * Create a new MetricSystem using the supplied configPath.  This configPath will be overlaid on top of the default "colossus.metrics"
     * config path.
-    * A Config object will be created via "ConfigFactory.load()"
+    * A Config object will be created via {{{ConfigFactory.load()}}}
     *
     * @param configPath  The path to the configuration.
     * @param system
@@ -136,8 +155,8 @@ object MetricSystem {
     val mergedConfig = config.withValue(ConfigRoot, metricsObject)
 
     val collectSystemMetrics = metricsConfig.getBoolean("collect-system-metrics")
-    val metricIntervals = metricsConfig.getFiniteDurations("metric-intervals")
-    val metricAddress = metricsConfig.getString("metric-address")
+    val metricIntervals = metricsConfig.getFiniteDurations("collection-intervals")
+    val metricAddress = metricsConfig.getString("namespace")
     MetricSystem(MetricAddress(metricAddress), metricIntervals, collectSystemMetrics, mergedConfig)
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -1,0 +1,17 @@
+package colossus.metrics
+
+import com.typesafe.config.Config
+
+private[metrics] trait CollectorConfigLoader {
+
+  def resolveConfig(config : Config,
+                    metricPath : String,
+                    defaultCollectorPath : String) : Config = {
+    if(config.hasPath(metricPath)) {
+      config.getConfig(metricPath).withFallback(config.getConfig(defaultCollectorPath))
+    }else{
+      config.getConfig(defaultCollectorPath)
+    }
+
+  }
+}

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -2,8 +2,6 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-case object CounterParameterDefaults extends CollectorParameterDefaults
-
 class Counter private[metrics](val address: MetricAddress)(implicit collection: Collection) extends Collector {
 
   private val counters = new CollectionMap[TagMap]

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -2,18 +2,53 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Counter private[metrics](val address: MetricAddress)(implicit collection: Collection) extends Collector {
+/**
+  * Metrics Collector which track Long values.
+  * A single Counter instance divides counter values up by tag maps and track each one independently.
+  * When they are collected and reported, all TagMaps will be reported under the same MetricAddress.
+  */
+trait Counter extends Collector {
+
+  /**
+    * Increment by the specified amount
+    * @param tags Tags to record with this value
+    * @param amount The amount to increment
+    */
+  def increment(tags: TagMap = TagMap.Empty, amount: Long = 1)
+
+  /**
+    * Decrement by the specified amount
+    * @param tags Tags to record with this value
+    * @param amount The amount to decrement
+    */
+  def decrement(tags: TagMap = TagMap.Empty, amount: Long = 1) = increment(tags, 0 - amount)
+
+  /**
+    * Set the Counter to the specified value
+    * @param tags Tags to record with this value
+    * @param value Value to be set.
+    */
+  def set(tags: TagMap = TagMap.Empty, value: Long)
+
+  /**
+    * Retrieve the value for the specified TagMap
+    * @param tags TagMap identifier for fetching the value
+    * @return
+    */
+  def get(tags: TagMap = TagMap.Empty): Long
+}
+
+//Working implementation of a Counter
+class DefaultCounter private[metrics](val address: MetricAddress)(implicit collection: Collection) extends Counter {
 
   private val counters = new CollectionMap[TagMap]
 
-  def increment(tags: TagMap = TagMap.Empty, num: Long = 1) {
-    counters.increment(tags, num)
+  def increment(tags: TagMap = TagMap.Empty, amount: Long = 1) {
+    counters.increment(tags, amount)
   }
 
-  def decrement(tags: TagMap = TagMap.Empty, num: Long = 1) = increment(tags, 0 - num)
-
-  def set(tags: TagMap = TagMap.Empty, num: Long) {
-    counters.set(tags, num)
+  def set(tags: TagMap = TagMap.Empty, value: Long) {
+    counters.set(tags, value)
   }
 
   def get(tags: TagMap = TagMap.Empty): Long = counters.get(tags).getOrElse(0)
@@ -22,13 +57,63 @@ class Counter private[metrics](val address: MetricAddress)(implicit collection: 
     val values = counters.snapshot(false, false)
     if (values.isEmpty) Map() else Map(address -> values)
   }
-    
-
 }
 
-object Counter {
+//Dummy implementation of a counter, used when "enabled=false" is specified at creation
+class NopCounter private[metrics](val address : MetricAddress) extends Counter {
+  val empty : MetricMap = Map()
+  override def tick(interval: FiniteDuration): MetricMap = empty
 
-  def apply(address: MetricAddress)(implicit collection: Collection): Counter = {
-    collection.getOrAdd(new Counter(address))
+  override def increment(tags: TagMap, amount: MetricValue): Unit = {}
+
+  override def set(tags: TagMap, value: MetricValue): Unit = {}
+
+  override def get(tags: TagMap): MetricValue = 0
+}
+
+object Counter extends CollectorConfigLoader{
+
+  private val DefaultConfigPath = "colossus.metrics.collectors-defaults.counter"
+
+  /**
+    * Create a Counter with the following address.  This will use the "colossus.metrics" config path to locate configuration.
+    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param collection The collection which will contain this Collector.
+    * @return
+    */
+  def apply(address : MetricAddress)(implicit collection : Collection) : Counter = {
+    apply(address, MetricSystem.ConfigRoot)
+  }
+
+  /**
+    * Create a Counter with following address.  Note, the address will be prefixed with the MetricSystem's root.
+    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
+    * passed into the MetricSystem.apply function):
+    * 1) configPath.address
+    * 2) metricSystemConfigPath.collectors-defaults.counter
+    * 3) colossus.metrics.collectors-defaults.counter
+    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path in the ConfigFile that this Histogram is located.
+    * @param collection The collection which will contain this Collector.
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Counter = {
+    val params = resolveConfig(collection.config.config, s"$configPath.$address", DefaultConfigPath)
+    apply(address, params.getBoolean("enabled"))
+  }
+
+  /**
+    * Create a Counter
+    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param enabled If this Counter will actually be collected and reported.
+    * @param collection The collection which will contain this Collector.
+    * @return
+    */
+  def apply(address: MetricAddress, enabled :Boolean = true)(implicit collection: Collection): Counter = {
+    if(enabled){
+      collection.getOrAdd(new DefaultCounter(address))
+    }else{
+      new NopCounter(address)
+    }
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -2,6 +2,8 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
+case object CounterParameterDefaults extends CollectorParameterDefaults
+
 class Counter private[metrics](val address: MetricAddress)(implicit collection: Collection) extends Collector {
 
   private val counters = new CollectionMap[TagMap]

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -224,10 +224,6 @@ class BaseHistogram(val bucketList: BucketList = Histogram.defaultBucketRanges) 
 
 }
 
-case class HistogramParameterDefaults(percentiles : Seq[Double] = Histogram.defaultPercentiles,
-                                      sampleRate : Double = 1.0,
-                                      pruneEmpty : Boolean = false) extends CollectorParameterDefaults
-
 class Histogram private[metrics](
   val address: MetricAddress,
   val percentiles: Seq[Double] = Histogram.defaultPercentiles,

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -48,11 +48,11 @@ object Histogram extends CollectorConfigLoader{
 
   /**
     * Create a Histogram with the following address.  Note, the address will be prefixed by the MetricSystem's root.
-    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the config path, if any, that was
+    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
     * passed into the MetricSystem.apply function):
     * 1) metricSystemConfigPath.address
-    * 2) metricSystemConfigPath.default-collectors.histogram
-    * 3) colossus.metrics.default-collectors.histogram
+    * 2) metricSystemConfigPath.collectors-defaults.histogram
+    * 3) colossus.metrics.collectors-defaults.histogram
     * @param address The address relative to the Collection's MetricSystem Root.
     * @param collection The Collection this Metric will become a part of.
     * @return Created Histogram.
@@ -70,11 +70,11 @@ object Histogram extends CollectorConfigLoader{
 
   /**
     * Create a Histogram with following address.  Note, the address will be prefixed by the MetricSystem's root.
-    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the config path, if any, that was
+    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
     * passed into the MetricSystem.apply function):
-    * 1) configPath.$address
-    * 2) metricSystemConfigPath.default-collectors.histogram
-    * 3) colossus.metrics.default-collectors.histogram
+    * 1) configPath.address
+    * 2) metricSystemConfigPath.collectors-defaults.histogram
+    * 3) colossus.metrics.collectors-defaults.histogram
     * @param address The address relative to the Collection's MetricSystem Root.
     * @param configPath The path in the ConfigFile that this Histogram is located.
     * @param collection The Collection this Metric will become a part of.

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -47,7 +47,7 @@ object Histogram extends CollectorConfigLoader{
   }
 
   /**
-    * Create a Rate with the following address.  This will use the "colossus.metrics" config path to locate configuration.
+    * Create a Rate with the following address.  See the documentation for [[colossus.metrics.MetricSystem for details on configuration]]
     * @param address The MetricAddress of this Histogram.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param collection The collection which will contain this Collector.
     * @return
@@ -57,14 +57,12 @@ object Histogram extends CollectorConfigLoader{
   }
 
   /**
-    * Create a Histogram with following address.  Note, the address will be prefixed with the MetricSystem's root.
-    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
-    * passed into the MetricSystem.apply function):
-    * 1) configPath.address
-    * 2) metricSystemConfigPath.collectors-defaults.histogram
-    * 3) colossus.metrics.collectors-defaults.histogram
+    * Create a Histogram with following address.
+    * This constructor tells the MetricSystem to look for this Metric's configuration outside of the configuration which
+    * was used to construct the MetricSystem.
     * @param address The MetricAddress of this Histogram.  Note, this will be relative to the containing MetricSystem's metricAddress.
-    * @param configPath The path in the ConfigFile that this Histogram is located.
+    * @param configPath The path in the ConfigFile that this Histogram is located.This will take precedent over any existing configuration
+    *                   inside the MetricSystem.
     * @param collection The collection which will contain this Collector.
     * @return
     */

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -47,37 +47,25 @@ object Histogram extends CollectorConfigLoader{
   }
 
   /**
-    * Create a Histogram with the following address.  Note, the address will be prefixed by the MetricSystem's root.
-    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
-    * passed into the MetricSystem.apply function):
-    * 1) metricSystemConfigPath.address
-    * 2) metricSystemConfigPath.collectors-defaults.histogram
-    * 3) colossus.metrics.collectors-defaults.histogram
-    * @param address The address relative to the Collection's MetricSystem Root.
-    * @param collection The Collection this Metric will become a part of.
-    * @return Created Histogram.
+    * Create a Rate with the following address.  This will use the "colossus.metrics" config path to locate configuration.
+    * @param address The MetricAddress of this Histogram.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param collection The collection which will contain this Collector.
+    * @return
     */
   def apply(address : MetricAddress)(implicit collection : Collection) : Histogram = {
-
-    import scala.collection.JavaConversions._
-
-    val params = resolveConfig(collection.config.config, s"colossus.metrics.$address", DefaultConfigPath)
-    val percentiles = params.getDoubleList("percentiles").map(_.toDouble)
-    val sampleRate = params.getDouble("sample-rate")
-    val pruneEmpty = params.getBoolean("prune-empty")
-    apply(address, percentiles, sampleRate, pruneEmpty)
+    apply(address, MetricSystem.ConfigRoot)
   }
 
   /**
-    * Create a Histogram with following address.  Note, the address will be prefixed by the MetricSystem's root.
+    * Create a Histogram with following address.  Note, the address will be prefixed with the MetricSystem's root.
     * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
     * passed into the MetricSystem.apply function):
     * 1) configPath.address
     * 2) metricSystemConfigPath.collectors-defaults.histogram
     * 3) colossus.metrics.collectors-defaults.histogram
-    * @param address The address relative to the Collection's MetricSystem Root.
+    * @param address The MetricAddress of this Histogram.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param configPath The path in the ConfigFile that this Histogram is located.
-    * @param collection The Collection this Metric will become a part of.
+    * @param collection The collection which will contain this Collector.
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Histogram = {
@@ -92,7 +80,14 @@ object Histogram extends CollectorConfigLoader{
     apply(address, percentiles, sampleRate, pruneEmpty)
   }
 
-
+  /**
+    * @param address The MetricAddress of this Histogram.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param percentiles The percentiles that this Histogram should distribute its values.
+    * @param sampleRate How often to collect values.
+    * @param pruneEmpty Instruct the collector to not report any values for tag combinations which were previously empty.
+    * @param collection The collection which will contain this Collector.
+    * @return
+    */
   def apply(
     address: MetricAddress,
     percentiles: Seq[Double] = Histogram.defaultPercentiles,

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -1,7 +1,5 @@
 package colossus.metrics
 
-import com.typesafe.config.Config
-
 import scala.concurrent.duration._
 
 class Rate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
@@ -33,7 +31,7 @@ object Rate extends CollectorConfigLoader {
   private val DefaultConfigPath = "colossus.metrics.collectors-defaults.rate"
 
   /**
-    * Create a Rate with the following address.  This will use the "colossus.metrics" config path to locate configuration.
+    * Create a Rate with the following address.  See the documentation for [[colossus.metrics.MetricSystem for details on configuration]]
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param collection The collection which will contain this Collector.
     * @return
@@ -42,15 +40,12 @@ object Rate extends CollectorConfigLoader {
     apply(address, MetricSystem.ConfigRoot)
   }
   /**
-    * Create a Rate with the following address.  Note, the address will be prefixed with the MetricSystem's root.
-    * Configuration is resolved and overlaid as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
-    * passed into the MetricSystem.apply function):
-    * 1) configPath.address
-    * 2) metricSystemConfigPath.collectors.defaults.rate
-    * 3) colossus.metrics.collectors.defaults.rate
- *
+    * Create a Rate with the following address.
+    * This constructor tells the MetricSystem to look for this Metric's configuration outside of the configuration which
+    * was used to construct the MetricSystem.
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
-    * @param configPath The path in the ConfigFile that this rate is located.
+    * @param configPath The path in the ConfigFile that this rate's configuration is located.  This will take precedent over any existing configuration
+    *                   inside the MetricSystem.
     * @param collection The collection which will contain this Collector.
     * @return
     */
@@ -71,20 +66,4 @@ object Rate extends CollectorConfigLoader {
     collection.getOrAdd(new Rate(address, pruneEmpty))
   }
 }
-
-private[metrics] trait CollectorConfigLoader {
-
-  def resolveConfig(config : Config,
-                    metricPath : String,
-                    defaultCollectorPath : String) : Config = {
-    if(config.hasPath(metricPath)) {
-      config.getConfig(metricPath).withFallback(config.getConfig(defaultCollectorPath))
-    }else{
-      config.getConfig(defaultCollectorPath)
-    }
-
-  }
-
-}
-
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -37,11 +37,11 @@ object Rate extends CollectorConfigLoader {
 
   /**
     * Create a Rate with the following address.  Note, the address will be prefixed by the MetricSystem's root.
-    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the config path, if any, that was
+    * Configuration is resolved and overlaid as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
     * passed into the MetricSystem.apply function):
     * 1) metricSystemConfigPath.address
-    * 2) metricSystemConfigPath.default-collectors.rate
-    * 3) colossus.metrics.default-collectors.rate
+    * 2) metricSystemConfigPath.collectors-defaults.rate
+    * 3) colossus.metrics.collectors-defaults.rate
  *
     * @param address The address relative to the Collection's MetricSystem Root.
     * @param collection The Collection this Metric will become a part of.
@@ -60,11 +60,11 @@ object Rate extends CollectorConfigLoader {
 
   /**
     * Create a Rate with the following address.  Note, the address will be prefixed by the MetricSystem's root.
-    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the config path, if any, that was
+    * Configuration is resolved and overlaid as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
     * passed into the MetricSystem.apply function):
-    * 1) configPath.$address
-    * 2) metricSystemConfigPath.default-collectors.rate
-    * 3) colossus.metrics.default-collectors.rate
+    * 1) configPath.address
+    * 2) metricSystemConfigPath.collectors.defaults.rate
+    * 3) colossus.metrics.collectors.defaults.rate
  *
     * @param address The address relative to the Collection's MetricSystem Root.
     * @param configPath The path in the ConfigFile that this rate is located.

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -36,39 +36,25 @@ object Rate extends CollectorConfigLoader {
   private val DefaultConfigPath = "colossus.metrics.collectors-defaults.rate"
 
   /**
-    * Create a Rate with the following address.  Note, the address will be prefixed by the MetricSystem's root.
-    * Configuration is resolved and overlaid as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
-    * passed into the MetricSystem.apply function):
-    * 1) metricSystemConfigPath.address
-    * 2) metricSystemConfigPath.collectors-defaults.rate
-    * 3) colossus.metrics.collectors-defaults.rate
- *
-    * @param address The address relative to the Collection's MetricSystem Root.
-    * @param collection The Collection this Metric will become a part of.
-    * @return Created Rate.
+    * Create a Rate with the following address.  This will use the "colossus.metrics" config path to locate configuration.
+    * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param collection The collection which will contain this Collector.
+    * @return
     */
   def apply(address : MetricAddress)(implicit collection : Collection) : Rate = {
-
-    /*
-      wait, you are lying! This isn't looking at the "metricSystemConfigPath"!
-      Yes, yes it is! Don't forget that in the MetricSystem.apply, we are merging the supplied path with the reference path and
-      writing that as "colossus.metrics".
-     */
-    val params = resolveConfig(collection.config.config, s"colossus.metrics.$address", DefaultConfigPath)
-    apply(address, params.getBoolean("prune-empty"))
+    apply(address, MetricSystem.ConfigRoot)
   }
-
   /**
-    * Create a Rate with the following address.  Note, the address will be prefixed by the MetricSystem's root.
+    * Create a Rate with the following address.  Note, the address will be prefixed with the MetricSystem's root.
     * Configuration is resolved and overlaid as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
     * passed into the MetricSystem.apply function):
     * 1) configPath.address
     * 2) metricSystemConfigPath.collectors.defaults.rate
     * 3) colossus.metrics.collectors.defaults.rate
  *
-    * @param address The address relative to the Collection's MetricSystem Root.
+    * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param configPath The path in the ConfigFile that this rate is located.
-    * @param collection The Collection this Metric will become a part of.
+    * @param collection The collection which will contain this Collector.
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Rate = {
@@ -77,6 +63,13 @@ object Rate extends CollectorConfigLoader {
     apply(address, params.getBoolean("prune-empty"))
   }
 
+  /**
+    * Create a new Rate which will be contained by the specified Collection
+    * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param pruneEmpty Instruct the collector to not report any values for tag combinations which were previously empty.
+    * @param collection The collection which will contain this Collector.
+    * @return
+    */
   def apply(address: MetricAddress, pruneEmpty: Boolean = false)(implicit collection: Collection): Rate = {
     collection.getOrAdd(new Rate(address, pruneEmpty))
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -2,16 +2,39 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Rate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
+/**
+  * Metrics Collector which increments a value and resets after collection.
+  */
+trait Rate extends Collector{
 
-  private val maps = collection.config.intervals.map{i => (i, new CollectionMap[TagMap])}.toMap
+  /**
+    * Increment value to this Rate for this specified TagMap
+    * A single Rate instance divides values amongst TagMaps, and tracks each one independently
+    * When they are collected and reported, all TagMaps will be reported under the same MetricAddress.
+    * @param tags Tags to record with this value
+    * @param amount The value to increment the rate
+    */
+  def hit(tags : TagMap = TagMap.Empty, amount : Long = 1)
+
+  /**
+    * Instruct the collector to not report any values for tag combinations which were previously empty.
+    * @return
+    */
+  def pruneEmpty : Boolean
+
+}
+
+//working implementation of a Rate
+class DefaultRate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)(implicit collection: Collection) extends Rate {
+
+  private val maps: Map[FiniteDuration, CollectionMap[TagMap]] = collection.config.intervals.map{ i => (i, new CollectionMap[TagMap])}.toMap
 
   //note - the totals are shared amongst all intervals, and we use the smallest
   //interval to update them
   private val totals = new CollectionMap[TagMap]
   private val minInterval = if (collection.config.intervals.size > 0) collection.config.intervals.min else Duration.Inf
 
-  def hit(tags: TagMap = TagMap.Empty, num: Long = 1) {
+  def hit(tags: TagMap = TagMap.Empty, amount: Long = 1) {
     maps.foreach{ case (_, map) => map.increment(tags) }
   }
 
@@ -24,6 +47,16 @@ class Rate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)
       Map(address -> snap, address / "count" -> totals.snapshot(pruneEmpty, false))
     }
   }
+}
+
+//Dummy implementation of a Rate, used when "enabled=false" is specified at creation
+class NopRate private[metrics](val address : MetricAddress, val pruneEmpty : Boolean)(implicit collection : Collection) extends Rate {
+
+  private val empty : MetricMap = Map()
+
+  override def tick(interval: FiniteDuration): MetricMap = empty
+
+  override def hit(tags: TagMap, value: MetricValue): Unit = {}
 }
 
 object Rate extends CollectorConfigLoader {
@@ -52,18 +85,23 @@ object Rate extends CollectorConfigLoader {
   def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Rate = {
 
     val params = resolveConfig(collection.config.config, s"$configPath.$address", DefaultConfigPath)
-    apply(address, params.getBoolean("prune-empty"))
+    apply(address, params.getBoolean("prune-empty"), params.getBoolean("enabled"))
   }
 
   /**
     * Create a new Rate which will be contained by the specified Collection
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param pruneEmpty Instruct the collector to not report any values for tag combinations which were previously empty.
+    * @param enabled If this Rate will actually be collected and reported.
     * @param collection The collection which will contain this Collector.
     * @return
     */
-  def apply(address: MetricAddress, pruneEmpty: Boolean = false)(implicit collection: Collection): Rate = {
-    collection.getOrAdd(new Rate(address, pruneEmpty))
+  def apply(address: MetricAddress, pruneEmpty: Boolean = false, enabled : Boolean = true)(implicit collection: Collection): Rate = {
+    if(enabled){
+      collection.getOrAdd(new DefaultRate(address, pruneEmpty))
+    }else{
+      new NopRate(address, pruneEmpty)
+    }
   }
 }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -1,8 +1,13 @@
 package colossus.metrics
 
+import com.typesafe.config.Config
+
 import scala.concurrent.duration._
 
-class Rate private[metrics](val address: MetricAddress, pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
+
+case class RateParameterDefaults(pruneEmpty : Boolean = false) extends CollectorParameterDefaults
+
+class Rate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
 
   private val maps = collection.config.intervals.map{i => (i, new CollectionMap[TagMap])}.toMap
 
@@ -24,15 +29,72 @@ class Rate private[metrics](val address: MetricAddress, pruneEmpty: Boolean)(imp
       Map(address -> snap, address / "count" -> totals.snapshot(pruneEmpty, false))
     }
   }
-    
-
 }
 
-object Rate {
+object Rate extends CollectorConfigLoader {
+
+  private val DefaultConfigPath = "colossus.metrics.collectors-defaults.rate"
+
+  /**
+    * Create a Rate with the following address.  Note, the address will be prefixed by the MetricSystem's root.
+    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the config path, if any, that was
+    * passed into the MetricSystem.apply function):
+    * 1) metricSystemConfigPath.address
+    * 2) metricSystemConfigPath.default-collectors.rate
+    * 3) colossus.metrics.default-collectors.rate
+ *
+    * @param address The address relative to the Collection's MetricSystem Root.
+    * @param collection The Collection this Metric will become a part of.
+    * @return Created Rate.
+    */
+  def apply(address : MetricAddress)(implicit collection : Collection) : Rate = {
+
+    /*
+      wait, you are lying! This isn't looking at the "metricSystemConfigPath"!
+      Yes, yes it is! Don't forget that in the MetricSystem.apply, we are merging the supplied path with the reference path and
+      writing that as "colossus.metrics".
+     */
+    val params = resolveConfig(collection.config.config, s"colossus.metrics.$address", DefaultConfigPath)
+    apply(address, params.getBoolean("prune-empty"))
+  }
+
+  /**
+    * Create a Rate with the following address.  Note, the address will be prefixed by the MetricSystem's root.
+    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the config path, if any, that was
+    * passed into the MetricSystem.apply function):
+    * 1) configPath.$address
+    * 2) metricSystemConfigPath.default-collectors.rate
+    * 3) colossus.metrics.default-collectors.rate
+ *
+    * @param address The address relative to the Collection's MetricSystem Root.
+    * @param configPath The path in the ConfigFile that this rate is located.
+    * @param collection The Collection this Metric will become a part of.
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Rate = {
+
+    val params = resolveConfig(collection.config.config, s"$configPath.$address", DefaultConfigPath)
+    apply(address, params.getBoolean("prune-empty"))
+  }
 
   def apply(address: MetricAddress, pruneEmpty: Boolean = false)(implicit collection: Collection): Rate = {
     collection.getOrAdd(new Rate(address, pruneEmpty))
   }
+}
+
+private[metrics] trait CollectorConfigLoader {
+
+  def resolveConfig(config : Config,
+                    metricPath : String,
+                    defaultCollectorPath : String) : Config = {
+    if(config.hasPath(metricPath)) {
+      config.getConfig(metricPath).withFallback(config.getConfig(defaultCollectorPath))
+    }else{
+      config.getConfig(defaultCollectorPath)
+    }
+
+  }
+
 }
 
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -4,9 +4,6 @@ import com.typesafe.config.Config
 
 import scala.concurrent.duration._
 
-
-case class RateParameterDefaults(pruneEmpty : Boolean = false) extends CollectorParameterDefaults
-
 class Rate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
 
   private val maps = collection.config.intervals.map{i => (i, new CollectionMap[TagMap])}.toMap

--- a/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
@@ -1,0 +1,223 @@
+package colossus.metrics
+
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration._
+
+class ConfigLoadingSpec extends MetricIntegrationSpec {
+
+  val PrefixRoot = "colossus.metrics."
+
+  val expectedPaths = Seq("collect-system-metrics", "metric-intervals", "metric-address", "collector-defaults.rate.prune-empty",
+                          "collector-defaults.histogram.prune-empty", "collector-defaults.histogram.sample-rate",
+                          "collector-defaults.histogram-percentiles")
+
+  "MetricSystem initialization" must {
+    "load defaults from reference implementation" in {
+
+      val ms = MetricSystem()
+      ms.namespace mustBe MetricAddress.Root
+      ms.metricIntervals.keys mustBe Set(1.second, 1.minute)
+      ms.collectionSystemMetrics mustBe true
+
+      expectedPaths.foreach{ x =>
+        ms.config.hasPath(s"$PrefixRoot$x")
+      }
+    }
+
+    "apply user overridden configuration" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |  metric-intervals : ["1 minute", "10 minutes"]
+          |  metric-address : "/mypath"
+          |  collectors-defaults {
+          |   rate {
+          |    prune-empty : true
+          |   }
+          |  }
+          |}
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+
+      val ms = MetricSystem("my-metrics", c)
+
+      ms.namespace mustBe MetricAddress("/mypath")
+      ms.metricIntervals.keys mustBe Set(1.minute, 10.minutes)
+      ms.collectionSystemMetrics mustBe true
+
+
+      expectedPaths.foreach{ x =>
+        ms.config.hasPath(s"$PrefixRoot$x")
+      }
+    }
+
+  }
+
+  "Rate initialization" must {
+    "load configuration in the right order" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |  /myrate {
+          |    prune-empty : false
+          |  }
+          |  metric-intervals : ["1 minute", "10 minutes"]
+          |  metric-address : "/mypath"
+          |  collectors-defaults {
+          |   rate {
+          |    prune-empty : true
+          |   }
+          |  }
+          |}
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val ms = MetricSystem("my-metrics", c)
+      implicit val m = ms.base
+
+      val r = Rate(MetricAddress("/myrate"))
+      r.pruneEmpty mustBe false
+
+      val r2 = Rate(MetricAddress("/foo"))
+      r2.pruneEmpty mustBe true
+
+    }
+
+    "fall back on default collector values" in {
+      val userOverridesNoDefaults =
+        """
+          |my-metrics{
+          |  "/myrate" {
+          |    prune-empty : false
+          |  }
+          |  metric-intervals : ["1 minute", "10 minutes"]
+          |}
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c2 = ConfigFactory.parseString(userOverridesNoDefaults).withFallback(ConfigFactory.defaultReference())
+      val ms2 = MetricSystem("my-metrics", c2)
+
+      implicit val m2 = ms2.base
+
+      val r3 = Rate(MetricAddress("/foo"))
+      r3.pruneEmpty mustBe false
+    }
+
+    "load configuration in the right order, when supplied with a configuration path" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |  metric-intervals : ["1 minute", "10 minutes"]
+          |  metric-address : "/mypath"
+          |  collectors-defaults {
+          |   rate {
+          |    prune-empty : true
+          |   }
+          |  }
+          |}
+          |my-app{
+          | "/myrate" {
+          |   prune-empty : false
+          | }
+          |}
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val ms = MetricSystem("my-metrics", c)
+
+      implicit val m = ms.base
+
+      val r = Rate(MetricAddress("/myrate"), "my-app")
+      r.pruneEmpty mustBe false
+
+      val r2 = Rate(MetricAddress("/foo"), "my-app")
+      r2.pruneEmpty mustBe true
+    }
+  }
+
+  "Histogram initialization" must {
+    "load configuration in the right order" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |  /myhist {
+          |    prune-empty : false
+          |    percentiles : [.50, .75]
+          |  }
+          |  metric-intervals : ["1 minute", "10 minutes"]
+          |  metric-address : "/mypath"
+          |  collectors-defaults {
+          |   histogram {
+          |    prune-empty : true
+          |    sample-rate : 1
+          |   }
+          |  }
+          |}
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val ms = MetricSystem("my-metrics", c)
+      implicit val m = ms.base
+
+      val h: Histogram = Histogram(MetricAddress("/myhist"))
+      h.percentiles mustBe Seq(.50, .75)
+      h.pruneEmpty mustBe false
+      h.sampleRate mustBe 1
+
+      val h2 = Histogram(MetricAddress("/foo"))
+      h2.pruneEmpty mustBe true
+      h2.sampleRate mustBe 1
+      h2.percentiles mustBe Seq(0.75, 0.9, 0.99, 0.999, 0.9999)
+    }
+
+    "load configuration in the right order, when supplied with a configuration path" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |  metric-intervals : ["1 minute", "10 minutes"]
+          |  metric-address : "/mypath"
+          |  collectors-defaults {
+          |   histogram {
+          |    prune-empty : true
+          |    sample-rate : 1
+          |   }
+          |  }
+          |}
+          |my-app{
+          | "/myhist" {
+          |   prune-empty : false
+          |   sample-rate : .5
+          | }
+          |}
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val ms = MetricSystem("my-metrics", c)
+
+      implicit val m = ms.base
+
+      val h = Histogram(MetricAddress("/myhist"), "my-app")
+      h.pruneEmpty mustBe false
+      h.sampleRate mustBe .5
+      h.percentiles mustBe Seq(0.75, 0.9, 0.99, 0.999, 0.9999)
+
+
+      val h2 = Histogram(MetricAddress("/foo"), "my-app")
+      h2.pruneEmpty mustBe true
+      h2.sampleRate mustBe 1
+      h2.percentiles mustBe Seq(0.75, 0.9, 0.99, 0.999, 0.9999)
+    }
+  }
+
+
+
+
+}

--- a/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
@@ -8,7 +8,7 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
 
   val PrefixRoot = "colossus.metrics."
 
-  val expectedPaths = Seq("collect-system-metrics", "metric-intervals", "metric-address", "collector-defaults.rate.prune-empty",
+  val expectedPaths = Seq("collect-system-metrics", "collection-intervals", "namespace", "collector-defaults.rate.prune-empty",
                           "collector-defaults.histogram.prune-empty", "collector-defaults.histogram.sample-rate",
                           "collector-defaults.histogram-percentiles")
 
@@ -17,7 +17,7 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
 
       val ms = MetricSystem()
       ms.namespace mustBe MetricAddress.Root
-      ms.metricIntervals.keys mustBe Set(1.second, 1.minute)
+      ms.collectionIntervals.keys mustBe Set(1.second, 1.minute)
       ms.collectionSystemMetrics mustBe true
 
       expectedPaths.foreach{ x =>
@@ -29,8 +29,8 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val userOverrides =
         """
           |my-metrics{
-          |  metric-intervals : ["1 minute", "10 minutes"]
-          |  metric-address : "/mypath"
+          |  collection-intervals : ["1 minute", "10 minutes"]
+          |  namespace : "/mypath"
           |  collectors-defaults {
           |   rate {
           |    prune-empty : true
@@ -45,7 +45,7 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val ms = MetricSystem("my-metrics", c)
 
       ms.namespace mustBe MetricAddress("/mypath")
-      ms.metricIntervals.keys mustBe Set(1.minute, 10.minutes)
+      ms.collectionIntervals.keys mustBe Set(1.minute, 10.minutes)
       ms.collectionSystemMetrics mustBe true
 
 
@@ -58,8 +58,8 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val userOverrides =
         """
           |my-metrics{
-          |  metric-intervals : ["Inf", "10 minutes"]
-          |  metric-address : "/mypath"
+          |  collection-intervals : ["Inf", "10 minutes"]
+          |  namespace : "/mypath"
           |  collectors-defaults {
           |   rate {
           |    prune-empty : true
@@ -77,8 +77,8 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val userOverrides =
         """
           |my-metrics{
-          |  metric-intervals : ["foo", "10 minutes"]
-          |  metric-address : "/mypath"
+          |  collection-intervals : ["foo", "10 minutes"]
+          |  namespace : "/mypath"
           |  collectors-defaults {
           |   rate {
           |    prune-empty : true
@@ -102,8 +102,8 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
           |  /myrate {
           |    prune-empty : false
           |  }
-          |  metric-intervals : ["1 minute", "10 minutes"]
-          |  metric-address : "/mypath"
+          |  collection-intervals : ["1 minute", "10 minutes"]
+          |  namespace : "/mypath"
           |  collectors-defaults {
           |   rate {
           |    prune-empty : true
@@ -132,7 +132,7 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
           |  "/myrate" {
           |    prune-empty : false
           |  }
-          |  metric-intervals : ["1 minute", "10 minutes"]
+          |  collection-intervals : ["1 minute", "10 minutes"]
           |}
         """.stripMargin
 
@@ -150,8 +150,8 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val userOverrides =
         """
           |my-metrics{
-          |  metric-intervals : ["1 minute", "10 minutes"]
-          |  metric-address : "/mypath"
+          |  collection-intervals : ["1 minute", "10 minutes"]
+          |  namespace : "/mypath"
           |  collectors-defaults {
           |   rate {
           |    prune-empty : true
@@ -188,8 +188,8 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
           |    prune-empty : false
           |    percentiles : [.50, .75]
           |  }
-          |  metric-intervals : ["1 minute", "10 minutes"]
-          |  metric-address : "/mypath"
+          |  collection-intervals : ["1 minute", "10 minutes"]
+          |  namespace : "/mypath"
           |  collectors-defaults {
           |   histogram {
           |    prune-empty : true
@@ -219,8 +219,8 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val userOverrides =
         """
           |my-metrics{
-          |  metric-intervals : ["1 minute", "10 minutes"]
-          |  metric-address : "/mypath"
+          |  collection-intervals : ["1 minute", "10 minutes"]
+          |  namespace : "/mypath"
           |  collectors-defaults {
           |   histogram {
           |    prune-empty : true
@@ -254,8 +254,4 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       h2.percentiles mustBe Seq(0.75, 0.9, 0.99, 0.999, 0.9999)
     }
   }
-
-
-
-
 }

--- a/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
@@ -54,6 +54,44 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       }
     }
 
+    "fail to load if metric intervals contains an infinite value" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |  metric-intervals : ["Inf", "10 minutes"]
+          |  metric-address : "/mypath"
+          |  collectors-defaults {
+          |   rate {
+          |    prune-empty : true
+          |   }
+          |  }
+          |}
+        """.stripMargin
+
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      a[FiniteDurationExpectedException] must be thrownBy MetricSystem("my-metrics", c)
+
+    }
+
+    "fail to load if metric intervals contains a non duration string" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |  metric-intervals : ["foo", "10 minutes"]
+          |  metric-address : "/mypath"
+          |  collectors-defaults {
+          |   rate {
+          |    prune-empty : true
+          |   }
+          |  }
+          |}
+        """.stripMargin
+
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      a[NumberFormatException] must be thrownBy MetricSystem("my-metrics", c)
+
+    }
+
   }
 
   "Rate initialization" must {

--- a/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration._
 
 class CounterSpec extends MetricIntegrationSpec {
 
-  def counter = new Counter("/foo")(new Collection(CollectorConfig(List(1.second))))
+  def counter = new DefaultCounter("/foo")(new Collection(CollectorConfig(List(1.second))))
 
   "Counter" must {
     "increment" in {
@@ -25,7 +25,7 @@ class CounterSpec extends MetricIntegrationSpec {
 
     "set" in {
       val c = counter
-      c.set(num = 3456)
+      c.set(value = 3456)
       c.get() must equal(3456)
     }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -24,8 +24,8 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
 
   "MetricSystem" must {
     "allow multiple systems to start without any conflicts" in {
-      val m1 = MetricSystem("/sys1")
-      val m2 = MetricSystem("/sys2")
+      val m1 = MetricSystem(MetricAddress("/sys1"))
+      val m2 = MetricSystem(MetricAddress("/sys2"))
       //no exceptions means the test passed
     }
 
@@ -43,7 +43,7 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
         )
       )
       val expected = parse(
-        """{"/foo" : [ 
+        """{"/foo" : [
           {"tags" : {"a" : "va"}, "value" : 3},
           {"tags" : {"b" : "vb"}, "value" : 4}
           ]}"""
@@ -61,7 +61,7 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
         )
       )
       val json = parse(
-        """{"/foo" : [ 
+        """{"/foo" : [
           {"tags" : {"a" : "va"}, "value" : 3},
           {"tags" : {"b" : "vb"}, "value" : 4}
           ]}"""

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -8,7 +8,7 @@ import akka.testkit.TestProbe
 class RateSpec extends MetricIntegrationSpec {
 
   implicit val c = new Collection(CollectorConfig(List(1.second, 1.minute)))
-  def rate() = new Rate("/foo", false)
+  def rate() = new DefaultRate("/foo", false)
 
   "Rate" must {
     "increment in all intervals" in {
@@ -54,7 +54,7 @@ class RateSpec extends MetricIntegrationSpec {
     }
 
     "prune empty values" in {
-      val r = new Rate("/foo", true)
+      val r = new DefaultRate("/foo", true)
       r.hit(Map("a" -> "b"))
       r.hit(Map("b" -> "c"))
       r.hit(Map("b" -> "c"))

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -68,12 +68,6 @@ class RateSpec extends MetricIntegrationSpec {
       //s2("foo/count").size must equal(1)
       s2("foo")(Map("a" -> "b")) must equal(1)
     }
-
-
-
-
   }
-
-
 }
 

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -101,15 +101,3 @@ metric-system{
 io-system{
 
 }
-
-
-
-imageReg{
-
-  metrics {
-    my-rate{
-      type : "Rate"
-    }
-  }
-
-}

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -93,3 +93,23 @@ colossus{
     }
   }
 }
+
+metric-system{
+  metric-address : "/"
+}
+
+io-system{
+
+}
+
+
+
+imageReg{
+
+  metrics {
+    my-rate{
+      type : "Rate"
+    }
+  }
+
+}

--- a/colossus/src/main/scala/colossus/core/IOSystem.scala
+++ b/colossus/src/main/scala/colossus/core/IOSystem.scala
@@ -60,7 +60,8 @@ case class IOSystemConfig(name: String, numWorkers: Int){
  * to keep in mind is that all actors in a single IOSystem will share event
  * loops.
  */
-case class IOSystem private[colossus](workerManager: ActorRef, config: IOSystemConfig, metrics: MetricSystem, actorSystem: ActorSystem) {
+case class
+IOSystem private[colossus](workerManager: ActorRef, config: IOSystemConfig, metrics: MetricSystem, actorSystem: ActorSystem) {
   import IOCommand._
 
   import akka.pattern.ask

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -139,7 +139,7 @@ with ServerConnectionHandler {
       val done = requestBuffer.remove()
       val comp = done.response
       if (requestMetrics) concurrentRequests.decrement()
-      pushResponse(done.request, comp, done.creationTime) 
+      pushResponse(done.request, comp, done.creationTime)
     }
     if (!canPush) {
       //this means the output buffer cannot accept any more messages, so we have
@@ -154,7 +154,7 @@ with ServerConnectionHandler {
     super.connectionClosed(cause)
     if (requestMetrics) {
       requestsPerConnection.add(numRequests)
-      concurrentRequests.decrement(num = requestBuffer.size)
+      concurrentRequests.decrement(amount = requestBuffer.size)
     }
     val exc = new DroppedReplyException
     while (requestBuffer.size > 0) {


### PR DESCRIPTION
This is just for colossus-metrics.

Specifically, this PR focuses on being able to load a MetricSystem, and MetricSystem Collectors(Rate, Histogram) from a TypeSafe config source.

I'm going to leave some details out of this only because I'm hoping the ScalaDocs are informative enough to describe it.  If is not, I will update both this PR and those docs.




