### PR TITLE
Metrics enabling/disabling

### DIFF
--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -3,6 +3,7 @@ colossus {
     collect-system-metrics: true
     collection-intervals: ["1 second", "1 minute"]
     namespace: "/"
+    enabled : true
     collectors-defaults {
       rate {
         enabled : true

--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -5,15 +5,17 @@ colossus {
     namespace: "/"
     collectors-defaults {
       rate {
+        enabled : true
         prune-empty: false
       }
       histogram {
+        enabled : true
         percentiles: [0.75, 0.9, 0.99, 0.999, 0.9999]
         sample-rate: 1.0
         prune-empty: false
       }
       counter {
-
+        enabled : true
       }
     }
     ##Metrics can be listed here as well:

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -41,7 +41,7 @@ trait Collector {
   def tick(interval: FiniteDuration): MetricMap
 }
 
-class CollectionMap[T] {
+private[metrics] class CollectionMap[T] {
 
   private val map = new ConcurrentHashMap[T, AtomicLong]
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -154,10 +154,15 @@ object MetricSystem {
     //This simplifies Collector creation.
     val mergedConfig = config.withValue(ConfigRoot, metricsObject)
 
-    val collectSystemMetrics = metricsConfig.getBoolean("collect-system-metrics")
-    val metricIntervals = metricsConfig.getFiniteDurations("collection-intervals")
-    val metricAddress = metricsConfig.getString("namespace")
-    MetricSystem(MetricAddress(metricAddress), metricIntervals, collectSystemMetrics, mergedConfig)
+    val enabled = metricsConfig.getBoolean("enabled")
+    if(enabled){
+      val collectSystemMetrics = metricsConfig.getBoolean("collect-system-metrics")
+      val metricIntervals = metricsConfig.getFiniteDurations("collection-intervals")
+      val metricAddress = metricsConfig.getString("namespace")
+      MetricSystem(MetricAddress(metricAddress), metricIntervals, collectSystemMetrics, mergedConfig)
+    }else{
+      deadSystem
+    }
   }
 }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -68,7 +68,7 @@ class NopCounter private[metrics](val address : MetricAddress) extends Counter {
 
   override def set(tags: TagMap, value: MetricValue): Unit = {}
 
-  override def get(tags: TagMap): MetricValue = -1
+  override def get(tags: TagMap): MetricValue = 0
 }
 
 object Counter extends CollectorConfigLoader{

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -2,18 +2,53 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Counter private[metrics](val address: MetricAddress)(implicit collection: Collection) extends Collector {
+/**
+  * Metrics Collector which track Long values.
+  * A single Counter instance divides counter values up by tag maps and track each one independently.
+  * When they are collected and reported, all TagMaps will be reported under the same MetricAddress.
+  */
+trait Counter extends Collector {
+
+  /**
+    * Increment by the specified amount
+    * @param tags Tags to record with this value
+    * @param amount The amount to increment
+    */
+  def increment(tags: TagMap = TagMap.Empty, amount: Long = 1)
+
+  /**
+    * Decrement by the specified amount
+    * @param tags Tags to record with this value
+    * @param amount The amount to decrement
+    */
+  def decrement(tags: TagMap = TagMap.Empty, amount: Long = 1) = increment(tags, 0 - amount)
+
+  /**
+    * Set the Counter to the specified value
+    * @param tags Tags to record with this value
+    * @param value Value to be set.
+    */
+  def set(tags: TagMap = TagMap.Empty, value: Long)
+
+  /**
+    * Retrieve the value for the specified TagMap
+    * @param tags TagMap identifier for fetching the value
+    * @return
+    */
+  def get(tags: TagMap = TagMap.Empty): Long
+}
+
+//Working implementation of a Counter
+class DefaultCounter private[metrics](val address: MetricAddress)(implicit collection: Collection) extends Counter {
 
   private val counters = new CollectionMap[TagMap]
 
-  def increment(tags: TagMap = TagMap.Empty, num: Long = 1) {
-    counters.increment(tags, num)
+  def increment(tags: TagMap = TagMap.Empty, amount: Long = 1) {
+    counters.increment(tags, amount)
   }
 
-  def decrement(tags: TagMap = TagMap.Empty, num: Long = 1) = increment(tags, 0 - num)
-
-  def set(tags: TagMap = TagMap.Empty, num: Long) {
-    counters.set(tags, num)
+  def set(tags: TagMap = TagMap.Empty, value: Long) {
+    counters.set(tags, value)
   }
 
   def get(tags: TagMap = TagMap.Empty): Long = counters.get(tags).getOrElse(0)
@@ -22,13 +57,63 @@ class Counter private[metrics](val address: MetricAddress)(implicit collection: 
     val values = counters.snapshot(false, false)
     if (values.isEmpty) Map() else Map(address -> values)
   }
-    
-
 }
 
-object Counter {
+//Dummy implementation of a counter, used when "enabled=false" is specified at creation
+class NopCounter private[metrics](val address : MetricAddress) extends Counter {
+  val empty : MetricMap = Map()
+  override def tick(interval: FiniteDuration): MetricMap = empty
 
-  def apply(address: MetricAddress)(implicit collection: Collection): Counter = {
-    collection.getOrAdd(new Counter(address))
+  override def increment(tags: TagMap, amount: MetricValue): Unit = {}
+
+  override def set(tags: TagMap, value: MetricValue): Unit = {}
+
+  override def get(tags: TagMap): MetricValue = -1
+}
+
+object Counter extends CollectorConfigLoader{
+
+  private val DefaultConfigPath = "colossus.metrics.collectors-defaults.counter"
+
+  /**
+    * Create a Counter with the following address.  This will use the "colossus.metrics" config path to locate configuration.
+    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param collection The collection which will contain this Collector.
+    * @return
+    */
+  def apply(address : MetricAddress)(implicit collection : Collection) : Counter = {
+    apply(address, MetricSystem.ConfigRoot)
+  }
+
+  /**
+    * Create a Counter with following address.  Note, the address will be prefixed with the MetricSystem's root.
+    * Configuration is resolved and overlayed as follows('metricSystemConfigPath' is the configPath parameter, if any, that was
+    * passed into the MetricSystem.apply function):
+    * 1) configPath.address
+    * 2) metricSystemConfigPath.collectors-defaults.counter
+    * 3) colossus.metrics.collectors-defaults.counter
+    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path in the ConfigFile that this Histogram is located.
+    * @param collection The collection which will contain this Collector.
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Counter = {
+    val params = resolveConfig(collection.config.config, s"$configPath.$address", DefaultConfigPath)
+    apply(address, params.getBoolean("enabled"))
+  }
+
+  /**
+    * Create a Counter
+    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param enabled If this Counter will actually be collected and reported.
+    * @param collection The collection which will contain this Collector.
+    * @return
+    */
+  def apply(address: MetricAddress, enabled :Boolean = true)(implicit collection: Collection): Counter = {
+    if(enabled){
+      collection.getOrAdd(new DefaultCounter(address))
+    }else{
+      new NopCounter(address)
+    }
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -2,16 +2,39 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-class Rate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)(implicit collection: Collection) extends Collector {
+/**
+  * Metrics Collector which increments a value and resets after collection.
+  */
+trait Rate extends Collector{
 
-  private val maps = collection.config.intervals.map{i => (i, new CollectionMap[TagMap])}.toMap
+  /**
+    * Increment value to this Rate for this specified TagMap
+    * A single Rate instance divides values amongst TagMaps, and tracks each one independently
+    * When they are collected and reported, all TagMaps will be reported under the same MetricAddress.
+    * @param tags Tags to record with this value
+    * @param amount The value to increment the rate
+    */
+  def hit(tags : TagMap = TagMap.Empty, amount : Long = 1)
+
+  /**
+    * Instruct the collector to not report any values for tag combinations which were previously empty.
+    * @return
+    */
+  def pruneEmpty : Boolean
+
+}
+
+//working implementation of a Rate
+class DefaultRate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)(implicit collection: Collection) extends Rate {
+
+  private val maps: Map[FiniteDuration, CollectionMap[TagMap]] = collection.config.intervals.map{ i => (i, new CollectionMap[TagMap])}.toMap
 
   //note - the totals are shared amongst all intervals, and we use the smallest
   //interval to update them
   private val totals = new CollectionMap[TagMap]
   private val minInterval = if (collection.config.intervals.size > 0) collection.config.intervals.min else Duration.Inf
 
-  def hit(tags: TagMap = TagMap.Empty, num: Long = 1) {
+  def hit(tags: TagMap = TagMap.Empty, amount: Long = 1) {
     maps.foreach{ case (_, map) => map.increment(tags) }
   }
 
@@ -24,6 +47,16 @@ class Rate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean)
       Map(address -> snap, address / "count" -> totals.snapshot(pruneEmpty, false))
     }
   }
+}
+
+//Dummy implementation of a Rate, used when "enabled=false" is specified at creation
+class NopRate private[metrics](val address : MetricAddress, val pruneEmpty : Boolean)(implicit collection : Collection) extends Rate {
+
+  private val empty : MetricMap = Map()
+
+  override def tick(interval: FiniteDuration): MetricMap = empty
+
+  override def hit(tags: TagMap, value: MetricValue): Unit = {}
 }
 
 object Rate extends CollectorConfigLoader {
@@ -52,18 +85,23 @@ object Rate extends CollectorConfigLoader {
   def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Rate = {
 
     val params = resolveConfig(collection.config.config, s"$configPath.$address", DefaultConfigPath)
-    apply(address, params.getBoolean("prune-empty"))
+    apply(address, params.getBoolean("prune-empty"), params.getBoolean("enabled"))
   }
 
   /**
     * Create a new Rate which will be contained by the specified Collection
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param pruneEmpty Instruct the collector to not report any values for tag combinations which were previously empty.
+    * @param enabled If this Rate will actually be collected and reported.
     * @param collection The collection which will contain this Collector.
     * @return
     */
-  def apply(address: MetricAddress, pruneEmpty: Boolean = false)(implicit collection: Collection): Rate = {
-    collection.getOrAdd(new Rate(address, pruneEmpty))
+  def apply(address: MetricAddress, pruneEmpty: Boolean = false, enabled : Boolean = true)(implicit collection: Collection): Rate = {
+    if(enabled){
+      collection.getOrAdd(new DefaultRate(address, pruneEmpty))
+    }else{
+      new NopRate(address, pruneEmpty)
+    }
   }
 }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
@@ -177,6 +177,29 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val r2 = Rate(MetricAddress("/foo"), "my-app")
       r2.pruneEmpty mustBe true
     }
+
+    "load a NopRate when disabled" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |   /disabledRate {
+          |    enabled : false
+          |   }
+          |  }
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val ms = MetricSystem("my-metrics", c)
+
+      implicit val m = ms.base
+
+      val r = Rate(MetricAddress("/disabledRate"))
+      r mustBe a[NopRate]
+
+      val r2 = Rate(MetricAddress("/foo"))
+      r2 mustBe a[DefaultRate]
+    }
   }
 
   "Histogram initialization" must {
@@ -252,6 +275,54 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       h2.pruneEmpty mustBe true
       h2.sampleRate mustBe 1
       h2.percentiles mustBe Seq(0.75, 0.9, 0.99, 0.999, 0.9999)
+    }
+
+    "load a NopHistogram when disabled" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |   /disabledHistogram {
+          |    enabled : false
+          |   }
+          |  }
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val ms = MetricSystem("my-metrics", c)
+
+      implicit val m = ms.base
+
+      val h = Histogram(MetricAddress("/disabledHistogram "))
+      h mustBe a[NopHistogram]
+
+      val h2 = Histogram(MetricAddress("/foo"))
+      h2 mustBe a[DefaultHistogram]
+    }
+  }
+
+  "Counter initialization" must {
+    "load a NopCounter when disabled" in {
+      val userOverrides =
+        """
+          |my-metrics{
+          |   /disabledCounter {
+          |    enabled : false
+          |   }
+          |  }
+        """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val ms = MetricSystem("my-metrics", c)
+
+      implicit val m = ms.base
+
+      val c1 = Counter(MetricAddress("/disabledCounter"))
+      c1 mustBe a[NopCounter]
+
+      val c2 = Counter(MetricAddress("/foo"))
+      c2 mustBe a[DefaultCounter]
     }
   }
 }

--- a/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
@@ -91,6 +91,17 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       a[NumberFormatException] must be thrownBy MetricSystem("my-metrics", c)
 
     }
+    "load a dead system if the MetricSystem is disabled" in {
+      val userOverrides = """
+        |my-metrics{
+        |  enabled : false
+        |}
+      """.stripMargin
+
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val ms = MetricSystem("my-metrics", c)
+      ms.namespace mustBe MetricAddress.Root / "DEAD"
+    }
 
   }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration._
 
 class CounterSpec extends MetricIntegrationSpec {
 
-  def counter = new Counter("/foo")(new Collection(CollectorConfig(List(1.second))))
+  def counter = new DefaultCounter("/foo")(new Collection(CollectorConfig(List(1.second))))
 
   "Counter" must {
     "increment" in {
@@ -25,7 +25,7 @@ class CounterSpec extends MetricIntegrationSpec {
 
     "set" in {
       val c = counter
-      c.set(num = 3456)
+      c.set(value = 3456)
       c.get() must equal(3456)
     }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -8,7 +8,7 @@ import akka.testkit.TestProbe
 class RateSpec extends MetricIntegrationSpec {
 
   implicit val c = new Collection(CollectorConfig(List(1.second, 1.minute)))
-  def rate() = new Rate("/foo", false)
+  def rate() = new DefaultRate("/foo", false)
 
   "Rate" must {
     "increment in all intervals" in {
@@ -54,7 +54,7 @@ class RateSpec extends MetricIntegrationSpec {
     }
 
     "prune empty values" in {
-      val r = new Rate("/foo", true)
+      val r = new DefaultRate("/foo", true)
       r.hit(Map("a" -> "b"))
       r.hit(Map("b" -> "c"))
       r.hit(Map("b" -> "c"))

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -139,7 +139,7 @@ with ServerConnectionHandler {
       val done = requestBuffer.remove()
       val comp = done.response
       if (requestMetrics) concurrentRequests.decrement()
-      pushResponse(done.request, comp, done.creationTime) 
+      pushResponse(done.request, comp, done.creationTime)
     }
     if (!canPush) {
       //this means the output buffer cannot accept any more messages, so we have
@@ -154,7 +154,7 @@ with ServerConnectionHandler {
     super.connectionClosed(cause)
     if (requestMetrics) {
       requestsPerConnection.add(numRequests)
-      concurrentRequests.decrement(num = requestBuffer.size)
+      concurrentRequests.decrement(amount = requestBuffer.size)
     }
     val exc = new DroppedReplyException
     while (requestBuffer.size > 0) {


### PR DESCRIPTION
This PR allows for metrics to be enabled or disabled by either specifying it directly via parameter passing into a constructor, or by including it into the Metric's configuration.

I opted to lift a Trait out for each metric type, and then provide a "Default" and "Nop" version implementations.  The Default implementations are the original implementations, whereas the Nop versions do not perform any function.  This was to avoid having to sully up the Default implementations with additional state.  I also wanted to avoid having a situation where a Metric was disabled, and still collecting values, which would be the beginnings of a memory leak(especially for a Histogram).

In addition to this new functionality, I decided to add some ScalaDocs to the existing APIs, since you know..docs are usually good, unless they are poorly written, in which case they are just bad.  I don't think I wrote bad docs, though they might not be complete.  I would def appreciate a quick once over to make sure that my docs(and me) aren't lying through our teeth.

