### PR TITLE
typesafe config integration for IOSystem take 1

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/Metric.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Metric.scala
@@ -1,7 +1,5 @@
 package colossus.metrics
 
-import scala.util.Try
-
 trait MetricFormatter[T] {
   def format(m: MetricFragment, timestamp: Long): T
 }
@@ -15,7 +13,7 @@ object OpenTsdbFormatter extends MetricFormatter[String] {
 
 
 case class MetricAddress(components: List[String]) {
-  def /(c: String): MetricAddress = copy(components = components :+ c)//.toLowercase removed for backwards compatability
+  def /(c: String): MetricAddress = /(MetricAddress(c))
 
   def /(m: MetricAddress): MetricAddress = copy(components = components ++ m.components)
 
@@ -61,19 +59,20 @@ case class MetricAddress(components: List[String]) {
 object MetricAddress {
   val Root = MetricAddress(Nil)
 
-  def fromString(str: String): Try[MetricAddress] = Try {
-    if (str == "/") MetricAddress.Root else {
-      val pieces = str.split("/")
-      if (pieces(0) != "") {
-        throw new IllegalArgumentException("Address must start with leading /")
+  def fromString(str: String): MetricAddress = {
+    str match {
+      case "" | "/" => MetricAddress.Root
+      case _ => {
+        val s = if (str startsWith "/") str else "/" + str
+        val pieces = s.split("/")
+        MetricAddress(pieces.toList.tail)
       }
-      MetricAddress(pieces.toList.tail)
     }
   }
 
-  def apply(str: String) = fromString(str).get
+  def apply(str: String) = fromString(str)
 
-  implicit def string2Address(s: String) : MetricAddress = fromString(if (s startsWith "/") s else "/" + s).get
+  implicit def string2Address(s: String) : MetricAddress = fromString(s)
 
 }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -82,7 +82,7 @@ object MetricSystem {
    * @return
    */
   def apply(namespace: MetricAddress, collectionIntervals: Seq[FiniteDuration] = Seq(1.second, 1.minute),
-            collectSystemMetrics: Boolean = true, config : Config = ConfigFactory.defaultReference())
+            collectSystemMetrics: Boolean = true, config : Config = ConfigFactory.load())
   (implicit system: ActorSystem): MetricSystem = {
     import system.dispatcher
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricAddressSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricAddressSpec.scala
@@ -1,0 +1,44 @@
+package colossus.metrics
+
+import org.scalatest.{MustMatchers, WordSpec}
+
+class MetricAddressSpec extends WordSpec with MustMatchers{
+
+  "MetricAddress" must {
+
+    "be created from an empty string" in {
+      MetricAddress("") mustBe MetricAddress.Root
+    }
+
+    "be created from a '/'" in {
+      MetricAddress("/") mustBe MetricAddress.Root
+    }
+
+    "be created from a string that begin with '/'" in {
+      val m = MetricAddress("/foo/bar")
+      m.components mustBe List("foo", "bar")
+    }
+
+    "be created from a string that doesn't begin with '/'" in {
+      val m = MetricAddress("foo/bar")
+      m.components mustBe List("foo", "bar")
+    }
+
+    "be appended to another MetricAddress" in {
+      val addr1 = MetricAddress("/foo")
+      val addr2 = MetricAddress("/bar")
+      addr1 / addr2 mustBe MetricAddress("/foo/bar")
+    }
+
+    "be able to have a string not prefixed with '/' appended to it" in {
+      val addr = MetricAddress("/foo")
+      addr / "bar" mustBe MetricAddress("/foo/bar")
+    }
+
+    "be able to have a string prefixed with '/' appended to it" in {
+      val addr = MetricAddress("/foo")
+      addr / "/bar" mustBe MetricAddress("/foo/bar")
+    }
+  }
+
+}

--- a/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
@@ -1,6 +1,7 @@
 package colossus
 package testkit
 
+import colossus.metrics.MetricSystem
 import core._
 
 import org.scalatest._
@@ -35,7 +36,7 @@ abstract class ColossusSpec(_system: ActorSystem) extends TestKit(_system) with 
    * @param f
    */
   def withIOSystem(f: IOSystem => Any) {
-    val sys = IOSystem("test-system-" + System.currentTimeMillis.toString, 2)
+    val sys = IOSystem("test-system-" + System.currentTimeMillis.toString, Some(2), MetricSystem.deadSystem)
     try {
       f(sys)
     } finally {
@@ -141,7 +142,7 @@ abstract class ColossusSpec(_system: ActorSystem) extends TestKit(_system) with 
     waitForServer(server)
     try {
       op
-    } finally {      
+    } finally {
       end(server)
     }
   }

--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -8,16 +8,15 @@ import service._
 import akka.agent.Agent
 import akka.actor._
 import akka.testkit.TestProbe
-import akka.testkit.CallingThreadDispatcher
 
-import scala.concurrent.{Await, ExecutionContext, Future, Promise}
+import scala.concurrent.{Await, Promise}
 import scala.concurrent.duration._
 
 case class FakeWorker(probe: TestProbe, worker: WorkerRef)
 
 object FakeIOSystem {
   def apply()(implicit system: ActorSystem): IOSystem = {
-    IOSystem(system.deadLetters, IOSystemConfig("FAKE", 0), MetricSystem.deadSystem, system)
+    IOSystem(system.deadLetters, "FAKE", 0, MetricSystem.deadSystem, system)
   }
 
   /**
@@ -62,7 +61,7 @@ object FakeIOSystem {
 
   def withManagerProbe()(implicit system: ActorSystem): (IOSystem, TestProbe) = {
     val probe = TestProbe()
-    val sys = IOSystem(probe.ref, IOSystemConfig("FAKE", 0), MetricSystem.deadSystem, system)
+    val sys = IOSystem(probe.ref, "FAKE", 0, MetricSystem.deadSystem, system)
     (sys, probe)
   }
 

--- a/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
@@ -1,6 +1,8 @@
 package colossus
 package testkit
 
+import colossus.metrics.MetricSystem
+
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import java.net.InetSocketAddress
@@ -14,7 +16,7 @@ abstract class ServiceSpec[C <: CodecDSL](implicit provider: CodecProvider[C], c
   type Request = C#Input
   type Response = C#Output
 
-  implicit val sys = IOSystem("test-system", 2)
+  implicit val sys = IOSystem("test-system", Some(2), MetricSystem.deadSystem)
 
   
   def service: ServerRef
@@ -59,8 +61,4 @@ abstract class ServiceSpec[C <: CodecDSL](implicit provider: CodecProvider[C], c
       }
     }
   }
-      
-
 }
-
-

--- a/colossus-tests/src/it/scala/colossus/BaseRedisITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/BaseRedisITSpec.scala
@@ -3,6 +3,7 @@ package colossus
 import java.net.InetSocketAddress
 
 import akka.util.ByteString
+import colossus.metrics.MetricSystem
 import colossus.protocols.redis.{Command, RedisClient, Reply}
 import colossus.service.{AsyncServiceClient, ClientConfig}
 import colossus.testkit.ColossusSpec
@@ -15,7 +16,7 @@ import scala.concurrent.duration._
 
 abstract class BaseRedisITSpec extends ColossusSpec with ScalaFutures with ScaledTimeSpans {
 
-  implicit val sys = IOSystem("test-system", 2)
+  implicit val sys = IOSystem("test-system", Some(2), MetricSystem.deadSystem)
 
   implicit val ec = system.dispatcher
 

--- a/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala
@@ -3,6 +3,7 @@ package colossus
 import java.net.InetSocketAddress
 
 import akka.util.ByteString
+import colossus.metrics.MetricSystem
 import colossus.protocols.memcache.MemcacheClient
 import colossus.protocols.memcache.MemcacheReply._
 import colossus.protocols.memcache.{MemcacheCommand, MemcacheReply}
@@ -27,7 +28,7 @@ class MemcacheITSpec extends ColossusSpec with ScalaFutures{
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(50, Millis))
 
-  implicit val sys = IOSystem("test-system", 2)
+  implicit val sys = IOSystem("test-system", Some(2), MetricSystem.deadSystem)
 
   val client = MemcacheClient.asyncClient(ClientConfig(new InetSocketAddress("localhost", 11211), 2.seconds, "memcache"))
 

--- a/colossus-tests/src/test/scala/colossus/IOSystemConfigSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/IOSystemConfigSpec.scala
@@ -1,0 +1,38 @@
+package colossus
+
+import colossus.metrics.MetricAddress
+import colossus.testkit.ColossusSpec
+import com.typesafe.config.ConfigFactory
+
+class IOSystemConfigSpec extends ColossusSpec{
+
+  "IOSystem creation" must {
+    "load defaults from reference implementation" in {
+      val io = IOSystem()
+      io.numWorkers mustBe Runtime.getRuntime.availableProcessors()
+      io.name mustBe "/"
+      io.metrics.namespace mustBe MetricAddress.Root
+      shutdownIOSystem(io)
+    }
+
+    "apply user overridden configuration" in {
+      val userConfig = """
+                        |my-io-system{
+                        |  name : "/my/path"
+                        |  metrics : {
+                        |    namespace : "/m"
+                        |  }
+                        |}
+                      """.stripMargin
+
+      //to imitate an already loaded configuration
+      val c = ConfigFactory.parseString(userConfig).withFallback(ConfigFactory.defaultReference())
+      val io = IOSystem("my-io-system", c)
+      io.numWorkers mustBe Runtime.getRuntime.availableProcessors()
+      io.metrics.namespace mustBe MetricAddress("/m")
+      io.name mustBe "/my/path"
+      io.namespace mustBe MetricAddress("/m/my/path")
+      shutdownIOSystem(io)
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -6,7 +6,6 @@ import colossus.service.{DecodedResult, Codec}
 import testkit._
 import akka.actor._
 import scala.concurrent.duration._
-import org.scalatest._
 
 trait TestInput {
   def source: Source[DataBuffer]
@@ -20,7 +19,7 @@ case class TestInputImpl(data: FiniteBytePipe) extends TestInput{
 case class TestOutput(data: Source[DataBuffer])
 
 
-class TestCodec(pipeSize: Int = 3) extends Codec[TestOutput, TestInput]{    
+class TestCodec(pipeSize: Int = 3) extends Codec[TestOutput, TestInput]{
   import parsing.Combinators._
   val parser: Parser[TestInputImpl] = intUntil('\r') <~ byte >> {num => TestInputImpl(new FiniteBytePipe(num))}
 
@@ -100,7 +99,7 @@ object TestController {
 
   def controller[I,O](codec: Codec[O,I])(implicit sys: ActorSystem): TypedMockConnection[T[I,O]] = {
     val con =MockConnection.server(
-      c => new Controller[I,O](codec, config, c.context) with TestController[I, O] with ServerConnectionHandler, 
+      c => new Controller[I,O](codec, config, c.context) with TestController[I, O] with ServerConnectionHandler,
       500
     )
     con.handler.connected(con)

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -1,27 +1,10 @@
 colossus{
 
-  metrics {
-    collect-system-metrics : true
-    metric-intervals : ["1 second", "1 minute"]
-    metric-address : "/"
-    collectors-defaults {
-      rate {
-        prune-empty : false
-      }
-      histogram {
-        percentiles : [0.75, 0.9, 0.99, 0.999, 0.9999]
-        sample-rate : 1.0
-        prune-empty : false
-      }
-      counter {
-
-      }
-    }
-  }
-
-  io-system{
-    num-workers : "CORE-COUNT"
-    metric-address : "iosystem"
+  io-system {
+    #If num-workers is omitted, it will default to the CPU core count on the host machine
+    #num-workers : 4
+    name : "/"
+    metrics : ${colossus.metrics}
   }
 
   server {
@@ -92,12 +75,4 @@ colossus{
       }
     }
   }
-}
-
-metric-system{
-  metric-address : "/"
-}
-
-io-system{
-
 }


### PR DESCRIPTION
Typesafe Integration for IOSystems.

This borrows the same pattern that I used for the MetricSystem constructors.