### PR TITLE
HttpRequest correctly encodes content length

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -36,7 +36,7 @@ class HttpSpec extends WordSpec with MustMatchers{
       )
       val request = HttpRequest(head, HttpBody(ByteString("hello")))
 
-      val expected = "POST /hello HTTP/1.1\r\nfoo: bar\r\n\r\nhello"
+      val expected = "POST /hello HTTP/1.1\r\nfoo: bar\r\nContent-Length: 5\r\n\r\nhello"
 
       request.bytes.utf8String must equal(expected)
     }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -68,7 +68,6 @@ case class HttpRequestHead(firstLine: FirstLine, headers: HttpHeaders) extends E
   def encode(buffer: core.DataOutBuffer) {
     firstLine encode buffer
     headers encode buffer
-    buffer write HttpParse.NEWLINE_ARRAY
   }
 
   def persistConnection: Boolean = {
@@ -107,8 +106,14 @@ case class HttpRequest(head: HttpRequestHead, body: HttpBody) extends Encoder {
 
   def encode(buffer: core.DataOutBuffer) {
     head encode buffer
-    //TODO : write content-length
-    body encode buffer
+    if (body.size == 0) {
+      buffer write HttpParse.NEWLINE_ARRAY
+    } else {
+      HttpHeader.encodeContentLength(buffer, body.size)
+      buffer write HttpParse.N2
+      body encode buffer
+    }
+      
   }
 
   def withHeader(key: String, value: String) = copy(head = head.withHeader(key, value))


### PR DESCRIPTION
This fixes a bug where HttpRequest was not including a content-length header when it has a body.  Also cleaned up some of the code so both requests and responses use the same code for encoding the content-length header.