### PR TITLE
uniquely named codec defaults implicits

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -112,6 +112,20 @@ class ServiceDSLSpec extends ColossusSpec {
       }
     }
 
+    "be able to create two clients of differing codecs" in {
+      withIOSystem{ implicit sys =>
+        import protocols.http._
+        import protocols.memcache._
+        import Http.defaults._
+        import Memcache.defaults._
+        //this test passes if it compiles
+        val s = Http.futureClient("localhost", TEST_PORT)
+        val t = Memcache.futureClient("localhost", TEST_PORT)
+      }
+    }
+
+      
+
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -47,11 +47,11 @@ package object http extends HttpBodyEncoders {
       def name = "http"
     }
 
-    object defaults extends CodecDefaults[Http] {
+    object defaults  {
       
-      implicit val serverDefaults = new ServerDefaults
+      implicit val httpServerDefaults = new ServerDefaults
 
-      implicit val clientDefaults = new ClientDefaults
+      implicit val httpClientDefaults = new ClientDefaults
 
     }
   
@@ -82,7 +82,7 @@ package object http extends HttpBodyEncoders {
   }
 
   abstract class HttpService(config: ServiceConfig, context: ServerContext) 
-    extends BaseHttpServiceHandler[Http](config, Http.defaults.serverDefaults, context)
+    extends BaseHttpServiceHandler[Http](config, Http.defaults.httpServerDefaults, context)
 
   abstract class StreamingHttpService(config: ServiceConfig, context: ServerContext) extends BaseHttpServiceHandler[StreamingHttp](config, StreamingHttpProvider, context)
 

--- a/colossus/src/main/scala/colossus/protocols/memcache/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/package.scala
@@ -15,9 +15,9 @@ package object memcache {
 
   object Memcache extends ClientFactories[Memcache, MemcacheClient] {
 
-    object defaults extends ClientDefaults[Memcache] {
+    object defaults extends  {
 
-      implicit val clientDefaults = new ClientCodecProvider[Memcache] {
+      implicit val memcacheClientDefaults = new ClientCodecProvider[Memcache] {
         def clientCodec = new MemcacheClientCodec
         def name = "memcache"
       }

--- a/colossus/src/main/scala/colossus/protocols/redis/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/package.scala
@@ -13,14 +13,14 @@ package object redis {
   }
 
   object Redis extends ClientFactories[Redis, RedisClient]{
-    object defaults extends CodecDefaults[Redis] {
+    object defaults {
 
-      implicit val serverDefaults = new CodecProvider[Redis] {
+      implicit val redisServerDefaults = new CodecProvider[Redis] {
         def provideCodec() = new RedisServerCodec
         def errorResponse(request: Command, reason: Throwable) = ErrorReply(s"Error (${reason.getClass.getName}): ${reason.getMessage}")
       }
 
-      implicit val clientDefaults = new ClientCodecProvider[Redis] {
+      implicit val redisClientDefaults = new ClientCodecProvider[Redis] {
         def clientCodec() = new RedisClientCodec
         val name = "redis"
       }

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -59,22 +59,6 @@ trait ClientCodecProvider[C <: Protocol] {
 }
 
 
-/**
- * Mixed into base protocol objects to provide a default codec provider
- */
-trait ServerDefaults[C <: Protocol] {
-  implicit def serverDefaults : CodecProvider[C]
-
-}
-
-/**
- * Mixed into base protocol objects to provide a default client codec provider
- */
-trait ClientDefaults[C <: Protocol] {
-  implicit def clientDefaults : ClientCodecProvider[C]
-}
-
-trait CodecDefaults[C <: Protocol] extends ServerDefaults[C] with ClientDefaults[C]
 
 
 class UnhandledRequestException(message: String) extends Exception(message)


### PR DESCRIPTION
Fixes #353 

Now you can import defaults for multiple codecs without them stepping over each other.