### PR TITLE
client API cleanup, new HttpRequestBuilder traits

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
@@ -33,7 +33,7 @@ abstract class ServiceSpec[C <: Protocol](implicit provider: CodecProvider[C], c
     requestTimeout = timeout
   )
 
-  def client(timeout: FiniteDuration = requestTimeout) = AsyncServiceClient(clientConfig(timeout))//, clientProvider.clientCodec)
+  def client(timeout: FiniteDuration = requestTimeout) = AsyncServiceClient[C](clientConfig(timeout))//, clientProvider.clientCodec)
 
   def withClient(f: AsyncServiceClient[Request, Response] => Unit) {
     val c = client()

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -84,7 +84,7 @@ object TestClient {
       failFast = true,
       connectionAttempts = connectionAttempts
     )
-    val client = AsyncServiceClient[Raw](config)(io, RawClientCodecProvider)
+    val client = AsyncServiceClient[Raw](config)(RawClientCodecProvider, io)
     if (waitForConnected) {
       TestClient.waitForConnected(client)
     }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpRequestSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpRequestSpec.scala
@@ -1,0 +1,22 @@
+package colossus
+package protocols.http
+
+import HttpMethod._
+
+import testkit._
+
+class HttpRequestSpec extends ColossusSpec {
+
+
+  "HttpRequestBuilder" must {
+    "build a request" in {
+
+      HttpRequest.get("/foo") must equal(HttpRequest.base.withMethod(Get).withPath("/foo"))
+      HttpRequest.post("/foo") must equal(HttpRequest.base.withMethod(Post).withPath("/foo"))
+      HttpRequest.put("/foo") must equal(HttpRequest.base.withMethod(Put).withPath("/foo"))
+      HttpRequest.delete("/foo") must equal(HttpRequest.base.withMethod(Delete).withPath("/foo"))
+    }
+  }
+
+
+}

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -9,7 +9,7 @@ import akka.testkit.TestProbe
 import akka.util.ByteString
 
 import scala.concurrent.duration._
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 
 import Callback.Implicits._
 
@@ -121,6 +121,17 @@ class ServiceDSLSpec extends ColossusSpec {
         //this test passes if it compiles
         val s = Http.futureClient("localhost", TEST_PORT)
         val t = Memcache.futureClient("localhost", TEST_PORT)
+      }
+    }
+
+    "be able to lift a sender to a type-specific client" in {
+      withIOSystem{ implicit sys => 
+        import protocols.http._
+        import Http.defaults._
+
+        val s = AsyncServiceClient[Http]("localhost", TEST_PORT)
+        val t = Http.futureClient(s)
+        val q : HttpClient[Future] = t
       }
     }
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -200,9 +200,13 @@ class HttpHeaders(private val headers: JList[HttpHeader]) {
 
   def connection: Option[Connection] = firstValue(HttpHeaders.Connection).flatMap(Connection.unapply)
 
-  def + (kv: (String, String)) = {
+  def + (kv: (String, String)): HttpHeaders = {
     val n = HttpHeader(kv._1, kv._2)
-    HttpHeaders.fromSeq(toSeq :+ n)
+    this + n
+  }
+
+  def + (header: HttpHeader): HttpHeaders = {
+    HttpHeaders.fromSeq(toSeq :+ header)
   }
 
   def size = headers.size

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -2,13 +2,19 @@ package colossus
 package protocols.http
 import scala.language.higherKinds
 
-import core._
 import service._
 import scala.concurrent.{ExecutionContext, Future}
 
-trait HttpClient[M[_]] extends LiftedClient[Http, M] {
+trait HttpClient[M[_]] extends LiftedClient[Http, M] with HttpRequestBuilder[M[HttpResponse]]{
+
+  protected def build(req: HttpRequest) = client.send(req)
+
+  val base = HttpRequest.base
+
 
 }
+
+
 
 object HttpClient {
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -32,8 +32,29 @@ case class BuildFL(method: HttpMethod, path: String, version: HttpVersion) exten
   }
 }
 
+case class BuiltHead(firstLine: BuildFL, headers: HttpHeaders) extends HttpRequestHead
 
-case class HttpRequestHead(firstLine: FirstLine, headers: HttpHeaders) extends Encoder {
+case class ParsedHead(firstLine: ParsedFL, headers: HttpHeaders) extends HttpRequestHead
+
+trait HttpRequestHead extends Encoder {
+  def firstLine: FirstLine
+  def headers: HttpHeaders
+
+  def copy(
+    method  : HttpMethod  = firstLine.method, 
+    path    : String      = firstLine.path,
+    version : HttpVersion = firstLine.version,
+    headers : HttpHeaders = headers
+  ): HttpRequestHead = {
+    BuiltHead(BuildFL(method, path, version), headers)
+  }
+
+  override def hashCode = firstLine.hashCode + headers.hashCode
+
+  override def equals(that: Any) = that match {
+    case that : HttpRequestHead => this.firstLine == that.firstLine && this.headers == that.headers
+    case _ => false
+  }
 
   lazy val method = firstLine.method
   lazy val url = firstLine.path
@@ -84,14 +105,18 @@ case class HttpRequestHead(firstLine: FirstLine, headers: HttpHeaders) extends E
 object HttpRequestHead {
   
   def apply(method: HttpMethod, url: String, version: HttpVersion, headers: HttpHeaders): HttpRequestHead = {
-    HttpRequestHead(BuildFL(method, url, version), headers)
-
+    BuiltHead(BuildFL(method, url, version), headers)
   }
+
 }
 
-case class HttpRequest(head: HttpRequestHead, body: HttpBody) extends Encoder {
+case class HttpRequest(head: HttpRequestHead, body: HttpBody) extends Encoder with HttpRequestBuilding[HttpRequest] {
   import head._
   import HttpCodes._
+
+  protected def current = this
+
+  protected def next(req: HttpRequest) = req
 
   def respond[T : HttpBodyEncoder](code: HttpCode, data: T, headers: HttpHeaders = HttpHeaders.Empty) = {
     HttpResponse(HttpResponseHead(version, code, headers), HttpBody(data))
@@ -116,13 +141,53 @@ case class HttpRequest(head: HttpRequestHead, body: HttpBody) extends Encoder {
       
   }
 
-  def withHeader(key: String, value: String) = copy(head = head.withHeader(key, value))
 }
 
-object HttpRequest {
+trait HttpRequestBuilding[T] {
+
+  protected def current: HttpRequest
+
+  protected def next(req: HttpRequest): T
+
+  protected def transformHead(f: HttpRequestHead => HttpRequestHead): T = next(current.copy(head = f(current.head)))
+
+
+  def withHeader(header: HttpHeader): T = transformHead(_.copy(headers = (current.head.headers + header)))
+
+  def withHeader(key: String, value: String): T = withHeader(HttpHeader(key, value))
+
+  def withPath(path: String): T = transformHead(_.copy(path = path))
+
+  def withMethod(method: HttpMethod): T = transformHead(_.copy(method = method))
+
+  def withVersion(version: HttpVersion) : T = transformHead(_.copy(version = version))
+
+  def withBody(body: HttpBody): T = next(current.copy(body = body))
+
+}
+
+trait HttpRequestBuilder[T] {
+
+  def base: HttpRequest
+
+  protected def build(f: HttpRequest): T
+
+  def startMethod(method: HttpMethod, path: String) = build(base.withMethod(method).withPath(path))
+
+  def get(path: String)     = startMethod(HttpMethod.Get, path)
+  def post(path: String)    = startMethod(HttpMethod.Post, path)
+  def put(path: String)     = startMethod(HttpMethod.Put, path)
+  def delete(path: String)  = startMethod(HttpMethod.Delete, path)
+}
+
+object HttpRequest extends HttpRequestBuilder[HttpRequest]{
+
+  val base = HttpRequest(HttpMethod.Get, "/", HttpHeaders(), HttpBody.NoBody)
+
+  protected def build(r: HttpRequest) = r
 
   def apply[T : HttpBodyEncoder](method: HttpMethod, url: String, headers: HttpHeaders, body: T): HttpRequest = {
-    val head = HttpRequestHead(BuildFL(method, url, HttpVersion.`1.1`), headers)
+    val head = BuiltHead(BuildFL(method, url, HttpVersion.`1.1`), headers)
     HttpRequest(head, HttpBody(body))
   }
 
@@ -130,5 +195,4 @@ object HttpRequest {
     HttpRequest(method, url, HttpHeaders.Empty, body)
   }
 
-  def get(url: String) = HttpRequest(HttpMethod.Get, url, HttpBody.NoBody)
 }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -174,10 +174,10 @@ trait HttpRequestBuilder[T] {
 
   def startMethod(method: HttpMethod, path: String) = build(base.withMethod(method).withPath(path))
 
-  def get(path: String)     = startMethod(HttpMethod.Get, path)
-  def post(path: String)    = startMethod(HttpMethod.Post, path)
-  def put(path: String)     = startMethod(HttpMethod.Put, path)
-  def delete(path: String)  = startMethod(HttpMethod.Delete, path)
+  def get(path: String)    : T = startMethod(HttpMethod.Get, path)
+  def post(path: String)   : T = startMethod(HttpMethod.Post, path)
+  def put(path: String)    : T = startMethod(HttpMethod.Put, path)
+  def delete(path: String) : T = startMethod(HttpMethod.Delete, path)
 }
 
 object HttpRequest extends HttpRequestBuilder[HttpRequest]{

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
@@ -28,7 +28,7 @@ object HttpRequestParser {
 
   protected def httpHead = firstLine ~ headers >> {case fl ~ headersBuilder => 
     HeadResult(
-      HttpRequestHead(fl, headersBuilder.buildHeaders), 
+      ParsedHead(fl, headersBuilder.buildHeaders), 
       headersBuilder.contentLength,
       headersBuilder.transferEncoding
     )

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -113,11 +113,13 @@ object AsyncServiceClient {
   case object Disconnect extends ClientCommand
   case class GetConnectionStatus(promise: Promise[ConnectionStatus] = Promise()) extends ClientCommand
 
-  def apply[C <: Protocol](config: ClientConfig)(implicit io: IOSystem, provider: ClientCodecProvider[C]): AsyncServiceClient[C#Input, C#Output] with FutureClient[C] = {
+  def create[C <: Protocol](config: ClientConfig)(implicit io: IOSystem, provider: ClientCodecProvider[C]): AsyncServiceClient[C#Input, C#Output] with FutureClient[C] = {
     val gen = new AsyncHandlerGenerator(config, provider.clientCodec())
     val actor = io.actorSystem.actorOf(Props(classOf[ClientProxy], config, io, gen.handlerFactory))
     gen.client(actor, config)
   }
+
+  def apply[C <: Protocol] = ClientFactory.futureClientFactory[C]
 }
 
 /**

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -169,7 +169,7 @@ object Service {
 
 
 /**
- * This has to be implemented per codec per sender type (ServiceClient, AsyncServiceClient, etc)
+ * This has to be implemented per codec in order to lift generic Sender traits to a type-specific trait
  *
  * For example this is how we go from ServiceClient[HttpRequest, HttpResponse] to HttpClient[Callback]
  */
@@ -197,6 +197,7 @@ trait ClientFactory[C <: Protocol, M[_], T <: Sender[C,M], E] {
     apply(config)
   }
 
+
 }
 
 
@@ -214,7 +215,7 @@ object ClientFactory {
   implicit def futureClientFactory[C <: Protocol] = new ClientFactory[C, Future, FutureClient[C], IOSystem] {
     
     def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], io: IOSystem) = {
-      AsyncServiceClient(config)(io, provider)
+      AsyncServiceClient.create(config)(io, provider)
     }
 
   }
@@ -226,8 +227,10 @@ class CodecClientFactory[C <: Protocol, M[_], B <: Sender[C, M], T[M[_]] <: Send
 extends ClientFactory[C,M,T[M],E] {
 
   def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], env: E): T[M] =  {
-    lifter.lift(baseFactory(config))(builder.build(env))
+    apply(baseFactory(config))
   }
+
+  def apply(sender: Sender[C,M])(implicit env: E): T[M] = lifter.lift(sender)(builder.build(env))
 
 }
 


### PR DESCRIPTION
* Fixes #352 - Or at least this is a start for adding more functionality to `HttpClient`.  The new `HttpRequestBuilder` and `HttpRequestBuilding` traits should make it much easier to build http requests.  Since `HttpRequest` itself implements these methods, you can do something like  `val req = HttpReqeust.get("/foo").withHeader("bar", "baz")`

* Fixes #350 , now you can create a type-specific client of protocol `P` from any generic `Sender[P,M]`.