### PR TITLE
Metric system config loading updates

### DIFF
--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -3,25 +3,28 @@ colossus {
     collect-system-metrics: true
     collection-intervals: ["1 second", "1 minute"]
     namespace: "/"
-    enabled : true
+    enabled: true
     collectors-defaults {
       rate {
-        enabled : true
+        enabled: true
         prune-empty: false
       }
       histogram {
-        enabled : true
+        enabled: true
         percentiles: [0.75, 0.9, 0.99, 0.999, 0.9999]
         sample-rate: 1.0
         prune-empty: false
       }
       counter {
-        enabled : true
+        enabled: true
       }
     }
-    ##Metrics can be listed here as well:
-    # /my/path/to/my/histogram {
-     # ...configuration
-    ##}
+    # Metric configuration definitions can be listed here:
+    # pruned-rate{
+    #    prune-empty : true
+    # }
+    # down-sampled-histogram{
+    #  sample-rate : .25
+    # }
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -7,9 +7,8 @@ import scala.concurrent.duration._
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 
-
 /**
- * This is passed to new event collectors in addition to their own config.
+  * This is passed to new event collectors in addition to their own config.
  *
  * TODO: we might want to include global tags in here as well, and remove them
  * from CollectionContext.  This would mean event collectors would be
@@ -29,12 +28,14 @@ trait Collector {
 
   /**
     * The MetricAddress of this Collector.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    *
     * @return
     */
   def address: MetricAddress
 
   /**
     * TODO
+    *
     * @param interval
     * @return
     */
@@ -98,6 +99,7 @@ class Collection(val config: CollectorConfig) {
 
   val collectors = new ConcurrentHashMap[MetricAddress, Collector]
 
+  //not used
   def add(collector: Collector) {
     collectors.put(collector.address, collector)
   }
@@ -105,11 +107,22 @@ class Collection(val config: CollectorConfig) {
   //The MetricAddress here should be identical to the MetricAddress that comes from T.
   //Created is 'call by name', as to only invoke it if it is missing from from the collectors Map
   //This is to prevent potential expensive operations, like configuration loading, from happening if the Metric is already present.
+  //TODO: Fix compiler warnings.  Look into TypeTags or ClassTags to fix this.
+  //This does not throw a DuplicateMetricException, rather it throws a ClassCastException for bad adds.
   def getOrAdd[T <: Collector](address : MetricAddress)(created : => T): T = {
-    collectors.putIfAbsent(address, created) match {
-      case null => created
-      case exists: T => exists
-      case other => throw new DuplicateMetricException(s"An event collector of type ${other.getClass.getSimpleName} already exists")
+    if(collectors.containsKey(address)){
+      val x = collectors.get(address)
+      collectors.get(address) match {
+        case exists : T => exists
+        case other => throw new DuplicateMetricException(s"An event collector of type ${other.getClass.getSimpleName} already exists")
+      }
+    }else{
+      val c = created //invoke it
+      collectors.putIfAbsent(address, c) match {
+        case null => c
+        case exists: T => exists
+        case other => throw new DuplicateMetricException(s"An event collector of type ${other.getClass.getSimpleName} already exists")
+      }
     }
   }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -102,7 +102,7 @@ class Collection(val config: CollectorConfig) {
     collectors.put(collector.address, collector)
   }
 
-  def getOrAdd[T <: Collector](created: T): T = {
+  def getOrAdd[T <: Collector](created : => T): T = {
     collectors.putIfAbsent(created.address, created) match {
       case null => created
       case exists: T => exists

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -102,8 +102,11 @@ class Collection(val config: CollectorConfig) {
     collectors.put(collector.address, collector)
   }
 
-  def getOrAdd[T <: Collector](created : => T): T = {
-    collectors.putIfAbsent(created.address, created) match {
+  //The MetricAddress here should be identical to the MetricAddress that comes from T.
+  //Created is 'call by name', as to only invoke it if it is missing from from the collectors Map
+  //This is to prevent potential expensive operations, like configuration loading, from happening if the Metric is already present.
+  def getOrAdd[T <: Collector](address : MetricAddress)(created : => T): T = {
+    collectors.putIfAbsent(address, created) match {
       case null => created
       case exists: T => exists
       case other => throw new DuplicateMetricException(s"An event collector of type ${other.getClass.getSimpleName} already exists")

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -39,12 +39,21 @@ class MetricInterval private[metrics](val namespace : MetricAddress,
   *
   * Metrics are collected and reported for each collectionInterval specified.
   *
-  * Metric Configuration
+  * A MetricSystem's configuration contains defaults for each metric type.  It can also contain configuration for additional metric definitions
   *
-  * A MetricSystem's configuration contains defaults for each metric type.  It can also contain configuration for individual metrics.
-  * When a new Metric is created, a MetricSystem will first look for a metric entry corresponding to the MetricAddress of the metric.
-  * If it finds one, it will use that entry overlaid on the default entry for that metric type to generate a complete configuration.
-  * If it does not find one, it will fallback to just using the default entry for that metric type.
+  * Metric Creation & Configuration
+  *
+  * All Metrics have 3 constructors.  Using [[colossus.metrics.Rate]] as an example:
+  *
+  *  - Rate(MetricAddress) => This will create a Rate with the MetricAddress, and use MetricSystem definition's default Rate configuration
+  *  - Rate(MetricAddress, configPath) => This will create a Rate with the MetricAddress.  configPath is relative to the MetricSystem's definition root.
+  *                                       Note, this configPath will fallback on the default Rate configuration if it is missing, or missing values.
+  *  - Rate(parameters) => Bypasses config, and creates the Rate directly with the passed in parameters
+  *
+  * Metric Disabling
+  * There are 2 ways to disable a Metric:
+  *  - set 'enabled : false' in its configuration. This will affect any Rate using that definition
+  *  - Directly at the construction site, set enabled = false
   *
   * @param namespace Base url for all metrics within this MetricSystem
   * @param collectionIntervals Intervals for which this MetricSystem reports its data.

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -102,7 +102,7 @@ object Counter extends CollectorConfigLoader{
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Counter = {
-    collection.getOrAdd{
+    collection.getOrAdd(address){
       val params = resolveConfig(collection.config.config, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createCounter(address, params.getBoolean("enabled"))
     }
@@ -117,7 +117,7 @@ object Counter extends CollectorConfigLoader{
     * @return
     */
   def apply(address: MetricAddress, enabled: Boolean = true)(implicit collection: Collection): Counter = {
-    collection.getOrAdd(createCounter(address, enabled))
+    collection.getOrAdd(address)(createCounter(address, enabled))
   }
 
   private def createCounter(address : MetricAddress, enabled : Boolean)(implicit collection : Collection) : Counter = {

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -105,7 +105,7 @@ object Histogram extends CollectorConfigLoader{
     */
   def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Histogram = {
 
-    collection.getOrAdd{
+    collection.getOrAdd(address){
       import scala.collection.JavaConversions._
 
       val params = resolveConfig(collection.config.config, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
@@ -133,7 +133,7 @@ object Histogram extends CollectorConfigLoader{
     pruneEmpty: Boolean = false,
     enabled : Boolean = true
   )(implicit collection: Collection): Histogram = {
-    collection.getOrAdd(createHistogram(address, percentiles, sampleRate, pruneEmpty, enabled))
+    collection.getOrAdd(address)(createHistogram(address, percentiles, sampleRate, pruneEmpty, enabled))
   }
 
   private def createHistogram(address : MetricAddress,

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -61,31 +61,32 @@ class NopRate private[metrics](val address : MetricAddress, val pruneEmpty : Boo
 
 object Rate extends CollectorConfigLoader {
 
-  private val DefaultConfigPath = "colossus.metrics.collectors-defaults.rate"
+  import MetricSystem.ConfigRoot
+
+  private val DefaultConfigPath = "collectors-defaults.rate"
 
   /**
-    * Create a Rate with the following address.  See the documentation for [[colossus.metrics.MetricSystem for details on configuration]]
+    * Create a Rate with the following address.  See the documentation for [[colossus.metrics.MetricSystem]] for details on configuration
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param collection The collection which will contain this Collector.
     * @return
     */
   def apply(address : MetricAddress)(implicit collection : Collection) : Rate = {
-    apply(address, MetricSystem.ConfigRoot)
+    apply(address, DefaultConfigPath)
   }
   /**
-    * Create a Rate with the following address.
-    * This constructor tells the MetricSystem to look for this Metric's configuration outside of the configuration which
-    * was used to construct the MetricSystem.
-    * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
-    * @param configPath The path in the ConfigFile that this rate's configuration is located.  This will take precedent over any existing configuration
-    *                   inside the MetricSystem.
+    * Create a Rate with the following address, whose definitions is contained the specified configPath.
+    * @param address    The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path in the config that this rate's configuration is located.  This is relative to the MetricSystem config
+    *                   definition.
     * @param collection The collection which will contain this Collector.
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Rate = {
-
-    val params = resolveConfig(collection.config.config, s"$configPath.$address", DefaultConfigPath)
-    apply(address, params.getBoolean("prune-empty"), params.getBoolean("enabled"))
+    collection.getOrAdd{
+      val params = resolveConfig(collection.config.config, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      createRate(address, params.getBoolean("prune-empty"), params.getBoolean("enabled"))
+    }
   }
 
   /**
@@ -97,8 +98,12 @@ object Rate extends CollectorConfigLoader {
     * @return
     */
   def apply(address: MetricAddress, pruneEmpty: Boolean = false, enabled : Boolean = true)(implicit collection: Collection): Rate = {
+    collection.getOrAdd(createRate(address, pruneEmpty, enabled))
+  }
+
+  private def createRate(address: MetricAddress, pruneEmpty: Boolean, enabled : Boolean)(implicit collection : Collection) : Rate = {
     if(enabled){
-      collection.getOrAdd(new DefaultRate(address, pruneEmpty))
+      new DefaultRate(address, pruneEmpty)
     }else{
       new NopRate(address, pruneEmpty)
     }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -83,7 +83,7 @@ object Rate extends CollectorConfigLoader {
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit collection : Collection) : Rate = {
-    collection.getOrAdd{
+    collection.getOrAdd(address){
       val params = resolveConfig(collection.config.config, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createRate(address, params.getBoolean("prune-empty"), params.getBoolean("enabled"))
     }
@@ -98,7 +98,7 @@ object Rate extends CollectorConfigLoader {
     * @return
     */
   def apply(address: MetricAddress, pruneEmpty: Boolean = false, enabled : Boolean = true)(implicit collection: Collection): Rate = {
-    collection.getOrAdd(createRate(address, pruneEmpty, enabled))
+    collection.getOrAdd(address)(createRate(address, pruneEmpty, enabled))
   }
 
   private def createRate(address: MetricAddress, pruneEmpty: Boolean, enabled : Boolean)(implicit collection : Collection) : Rate = {

--- a/colossus-metrics/src/test/scala/colossus/metrics/CollectionMapSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CollectionMapSpec.scala
@@ -1,0 +1,62 @@
+package colossus.metrics
+
+import org.scalatest._
+
+class CollectionMapSpec extends WordSpec with MustMatchers with BeforeAndAfterAll{
+
+  "CollectionMap" must {
+      
+    "increment a non-existing value" in {
+      val c = new CollectionMap[String]
+      c.get("foo") must equal(None)
+      c.increment("foo")
+      c.get("foo") must equal(Some(1))
+    }
+
+    "increment different keys" in {
+      val c = new CollectionMap[String]
+      c.get("foo") must equal(None)
+      c.get("bar") must equal(None)
+      c.increment("foo")
+      c.increment("bar")
+      c.increment("bar")
+      c.get("foo") must equal(Some(1))
+      c.get("bar") must equal(Some(2))
+    }
+
+    "set a non-existing value" in {
+      val c = new CollectionMap[String]
+      c.get("foo") must equal(None)
+      c.set("foo", 234)
+      c.get("foo") must equal(Some(234))
+    }
+
+    "snapshot" in {
+      val c = new CollectionMap[String]
+      c.set("foo", 1)
+      c.set("bar", 3)
+      c.snapshot(false, false) must equal(Map("foo" -> 1, "bar" -> 3))
+      //do again to ensure no reset
+      c.snapshot(false, false) must equal(Map("foo" -> 1, "bar" -> 3))
+    }
+
+    "snapshot (with reset)" in {
+      val c = new CollectionMap[String]
+      c.set("foo", 1)
+      c.set("bar", 3)
+      c.snapshot(false, true) must equal(Map("foo" -> 1, "bar" -> 3))
+      c.snapshot(false, true) must equal(Map("foo" -> 0, "bar" -> 0))
+    }
+
+    "snapshot (with prune empty)" in {
+      val c = new CollectionMap[String]
+      c.set("foo", 1)
+      c.set("bar", 3)
+      c.snapshot(false, true) must equal(Map("foo" -> 1, "bar" -> 3))
+      c.snapshot(true, true) must equal(Map())
+    }
+
+  }
+
+}
+

--- a/colossus-metrics/src/test/scala/colossus/metrics/CollectionSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CollectionSpec.scala
@@ -1,62 +1,45 @@
 package colossus.metrics
 
-import org.scalatest._
+import org.scalatest.{MustMatchers, WordSpec}
+import scala.concurrent.duration._
 
-class CollectionSpec extends WordSpec with MustMatchers with BeforeAndAfterAll{
+class CollectionSpec extends WordSpec with MustMatchers{
 
-  "CollectionMap" must {
-      
-    "increment a non-existing value" in {
-      val c = new CollectionMap[String]
-      c.get("foo") must equal(None)
-      c.increment("foo")
-      c.get("foo") must equal(Some(1))
+  "Collection" must {
+
+    implicit val collection = new Collection(CollectorConfig(Seq(1.minute, 1.second)))
+
+    "getOrAdd should add a new Collector" in {
+      //note, this constructor implicitly adds its constructed object into this collection
+      val foo = MetricAddress("foo")
+      val rate = Rate(foo, false, true)
+
+      val x = collection.collectors.get(foo)
+      x mustBe a[Rate]
+      //this is a reference check, since we are not overriding .equals yet
+      x.asInstanceOf[Rate] mustBe rate
     }
 
-    "increment different keys" in {
-      val c = new CollectionMap[String]
-      c.get("foo") must equal(None)
-      c.get("bar") must equal(None)
-      c.increment("foo")
-      c.increment("bar")
-      c.increment("bar")
-      c.get("foo") must equal(Some(1))
-      c.get("bar") must equal(Some(2))
+    "getOrAdd should return an existing Collector" in {
+      //note, this constructor implicitly adds its constructed object into this collection
+      val bar = MetricAddress("bar")
+
+      val rate = Rate(bar, false, true)
+      val rate2 = Rate(bar, false, true)
+      val x = collection.collectors.get(bar)
+      x mustBe a[Rate]
+      //reference check again, this should be pointing at the first, since the second should have never got added
+      x.asInstanceOf[Rate] mustBe rate
     }
 
-    "set a non-existing value" in {
-      val c = new CollectionMap[String]
-      c.get("foo") must equal(None)
-      c.set("foo", 234)
-      c.get("foo") must equal(Some(234))
+    "getOrAdd should throw if a metric with the same address, but different type is used" in {
+      val bar = MetricAddress("baz")
+      val rate = Rate(bar, false, true)
+      //TODO FIX ME I need to be a DuplicateMetricException
+      intercept[ClassCastException]{
+        Counter(bar, false)
+      }
     }
-
-    "snapshot" in {
-      val c = new CollectionMap[String]
-      c.set("foo", 1)
-      c.set("bar", 3)
-      c.snapshot(false, false) must equal(Map("foo" -> 1, "bar" -> 3))
-      //do again to ensure no reset
-      c.snapshot(false, false) must equal(Map("foo" -> 1, "bar" -> 3))
-    }
-
-    "snapshot (with reset)" in {
-      val c = new CollectionMap[String]
-      c.set("foo", 1)
-      c.set("bar", 3)
-      c.snapshot(false, true) must equal(Map("foo" -> 1, "bar" -> 3))
-      c.snapshot(false, true) must equal(Map("foo" -> 0, "bar" -> 0))
-    }
-
-    "snapshot (with prune empty)" in {
-      val c = new CollectionMap[String]
-      c.set("foo", 1)
-      c.set("bar", 3)
-      c.snapshot(false, true) must equal(Map("foo" -> 1, "bar" -> 3))
-      c.snapshot(true, true) must equal(Map())
-    }
-
   }
 
 }
-


### PR DESCRIPTION
- Changed Metric constructors to only process Configuration within a getOrAdd block, as to avoid unnecessarily loading Config for Metrics which already exist
- Changed how Metric configuration definitions are looked up a bit.  Now, it only looks in the defaults or in the metricSytemRoot.configPath.
- Cleaned up ConfigLoadingSpec
- Cleaned up ScalaDocs a bit