### PR TITLE
handle parse exceptions gracefully

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -61,7 +61,7 @@ object RawProtocol {
   implicit object RawCodecProvider extends CodecProvider[Raw] {
     def provideCodec() = RawCodec
 
-    def errorResponse(request: ByteString, reason: Throwable) = ByteString(s"Error (${reason.getClass.getName}): ${reason.getMessage}")
+    def errorResponse(error: ProcessingFailure[ByteString]) = ByteString(s"Error (${error.reason.getClass.getName}): ${error.reason.getMessage}")
   }
 
   implicit object RawClientCodecProvider extends ClientCodecProvider[Raw] {

--- a/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
@@ -69,6 +69,7 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers{
       val con = static(config)
       con.typedHandler.receivedData(DataBuffer(input))
       con.typedHandler.received.isEmpty must equal(true)
+      con.readsEnabled must equal(false)
     }
     /*
 

--- a/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
@@ -67,11 +67,8 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers{
       val input = ByteString("hello")
       val config = ControllerConfig(4, 50.milliseconds, "test-controller", 2L)
       val con = static(config)
-      intercept[ParseException] {
-        con.typedHandler.receivedData(DataBuffer(input))
-        con.typedHandler.received.size must equal(1)
-        con.typedHandler.received.head must equal(input)
-      }
+      con.typedHandler.receivedData(DataBuffer(input))
+      con.typedHandler.received.isEmpty must equal(true)
     }
     /*
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -19,9 +19,9 @@ class ErrorTestDSL(probe: ActorRef) extends CodecProvider[Raw] {
 
     def provideCodec() = RawCodec
 
-    def errorResponse(request: ByteString, reason: Throwable) = {
-      probe ! reason
-      ByteString(s"Error (${reason.getClass.getName}): ${reason.getMessage}")
+    def errorResponse(error: ProcessingFailure[ByteString]) = {
+      probe ! error.reason
+      ByteString(s"Error (${error.reason.getClass.getName}): ${error.reason.getMessage}")
     }
   
 }
@@ -96,9 +96,9 @@ class ServiceDSLSpec extends ColossusSpec {
 
     "override error handler" in {
       withIOSystem{ implicit system =>
-        val server = Server.basic("test", TEST_PORT)( new Service[Raw](_) { 
+        val server = Server.basic("test", TEST_PORT)( new Service[Raw](_) {
             override def onError = {
-              case (request, c: UnhandledRequestException) => ByteString("OVERRIDE")
+              case error => ByteString("OVERRIDE")
             }
             def handle = {
               case x if (false) => ByteString("NOPE")

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -30,7 +30,7 @@ class ServiceServerSpec extends ColossusSpec {
       codec = RawCodec,
       serverContext = srv
   ) {
-    // def processFailure(request: ByteString, reason: Throwable) = ByteString("ERROR")
+
     def processFailure(error: ProcessingFailure[ByteString]) = ByteString("ERROR")
 
     def processRequest(input: ByteString) = handler(input)

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -30,7 +30,8 @@ class ServiceServerSpec extends ColossusSpec {
       codec = RawCodec,
       serverContext = srv
   ) {
-    def processFailure(request: ByteString, reason: Throwable) = ByteString("ERROR")
+    // def processFailure(request: ByteString, reason: Throwable) = ByteString("ERROR")
+    def processFailure(error: ProcessingFailure[ByteString]) = ByteString("ERROR")
 
     def processRequest(input: ByteString) = handler(input)
 

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -63,7 +63,7 @@ trait MasterController[Input, Output] extends ConnectionHandler {
  * "response" message, the controller make no such pairing.  Thus a controller
  * can be thought of as a duplex stream of messages.
  */
-abstract class Controller[Input, Output](val codec: Codec[Output, Input], val controllerConfig: ControllerConfig, context: Context) 
+abstract class Controller[Input, Output](val codec: Codec[Output, Input], val controllerConfig: ControllerConfig, context: Context)
 extends CoreHandler(context) with InputController[Input, Output] with OutputController[Input, Output] {
   import ConnectionState._
 
@@ -95,6 +95,15 @@ extends CoreHandler(context) with InputController[Input, Output] with OutputCont
     checkControllerGracefulDisconnect()
   }
   
+  def fatalInputError(reason: Throwable) = {
+    
+    processBadRequest(reason).foreach { output =>
+      push(output) { _ => {} }
+    }
+    disconnect()
+    //throw reason
+  }
+  
   /**
    * Checks the status of the shutdown procedure.  Only when both the input and
    * output sides are terminated do we call shutdownRequest on the parent
@@ -104,7 +113,7 @@ extends CoreHandler(context) with InputController[Input, Output] with OutputCont
       case (ShuttingDown(endpoint), InputState.Terminated, OutputState.Terminated) => {
         super.shutdown()
       }
-      case _ => {} 
+      case _ => {}
     }
   }
 

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -1,13 +1,10 @@
 package colossus
 package controller
 
-import colossus.controller.OutputResult.Failure
 import colossus.metrics.Histogram
 import colossus.parsing.ParserSizeTracker
 import core._
 import colossus.service.{DecodedResult, NotConnectedException}
-
-import scala.util.{Success, Try, Failure => TFailure}
 
 sealed trait InputState
 object InputState {
@@ -152,7 +149,8 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
             }
           } catch {
             case reason: Throwable =>
-              processBadRequest(reason)
+              decoding = false
+              fatalInputError(reason)
           }
         }
       }
@@ -211,13 +209,11 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
       case other => throw new InvalidInputStateException(other)
     }
   }
-
+  
+  protected def fatalInputError(reason: Throwable)
 
   protected def processMessage(message: Input)
   
-  protected def processBadRequest(reason: Throwable): Output = {
-    disconnect()
-    throw reason
-  }
+  protected def processBadRequest(reason: Throwable): Option[Output] = None
 
 }

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -148,9 +148,10 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
               }
             }
           } catch {
-            case reason: Throwable =>
+            case reason: Throwable => {
               decoding = false
               fatalInputError(reason)
+            }
           }
         }
       }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -2,10 +2,7 @@ package colossus
 package protocols.http
 import scala.language.higherKinds
 
-import core._
 import service._
-import scala.concurrent.{ExecutionContext, Future}
-
 trait HttpClient[M[_]] extends LiftedClient[Http, M] {
 
 }

--- a/colossus/src/main/scala/colossus/protocols/redis/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/package.scala
@@ -2,7 +2,7 @@ package colossus
 package protocols
 
 import akka.util.{ByteString, ByteStringBuilder}
-import service._
+import colossus.service._
 
 
 package object redis {
@@ -17,7 +17,7 @@ package object redis {
 
       implicit val serverDefaults = new CodecProvider[Redis] {
         def provideCodec() = new RedisServerCodec
-        def errorResponse(request: Command, reason: Throwable) = ErrorReply(s"Error (${reason.getClass.getName}): ${reason.getMessage}")
+        def errorResponse(error: ProcessingFailure[Command]) = ErrorReply(s"Error (${error.reason.getClass.getName}): ${error.reason.getMessage}")
       }
 
       implicit val clientDefaults = new ClientCodecProvider[Redis] {

--- a/colossus/src/main/scala/colossus/protocols/telnet/Telnet.scala
+++ b/colossus/src/main/scala/colossus/protocols/telnet/Telnet.scala
@@ -21,7 +21,7 @@ package object telnet {
   implicit object TelnetProvider extends CodecProvider[Telnet] {
     def provideCodec() = TelnetServerCodec
 
-    def errorResponse(request: TelnetCommand, reason: Throwable) = TelnetReply(s"Error: $reason")
+    def errorResponse(error: ProcessingFailure[TelnetCommand]) = TelnetReply(s"Error: ${error.reason}")
   }
 
   case class TelnetCommand(args: List[String])

--- a/colossus/src/main/scala/colossus/protocols/websocket/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/package.scala
@@ -30,7 +30,7 @@ package object websocket {
     def provideCodec() = new WebsocketCodec
 
     //TODO : looks like we need to break this out from codec provider
-    def errorResponse(request: Frame, reason: Throwable): Frame = ???
+    def errorResponse(error: ProcessingFailure[Frame]): Frame = ???
   }
     
 

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -95,11 +95,11 @@ class StaleClientException(msg : String) extends Exception(msg)
  * TODO: make underlying output controller data size configurable
  */
 class ServiceClient[P <: Protocol](
-  codec: Codec[P#Input,P#Output], 
+  codec: Codec[P#Input,P#Output],
   val config: ClientConfig,
   context: Context
 )(implicit tagDecorator: TagDecorator[P#Input,P#Output] = TagDecorator.default[P#Input,P#Output])
-extends Controller[P#Output,P#Input](codec, ControllerConfig(config.pendingBufferSize, config.requestTimeout, config.name, config.maxResponseSize), context) 
+extends Controller[P#Output,P#Input](codec, ControllerConfig(config.pendingBufferSize, config.requestTimeout, config.name, config.maxResponseSize), context)
 with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
 
   type I = P#Input
@@ -179,7 +179,7 @@ with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
     } else if (isConnected || !failFast) {
       val pushed = push(request, queueTime){
         case OutputResult.Success         => {
-          val s = SourcedRequest(request, handler, queueTime, System.currentTimeMillis) 
+          val s = SourcedRequest(request, handler, queueTime, System.currentTimeMillis)
           sentBuffer.enqueue(s)
           this.queueTime.add((s.sendTime - s.queueTime).toInt, hpTags)
           if (sentBuffer.size >= config.sentBufferSize) {

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -121,7 +121,6 @@ extends ServiceServer[C#Input, C#Output](codec, config, srv) {
     
   protected def processRequest(i: C#Input): Callback[C#Output] = handler(i)
   
-  //protected def processFailure(request: C#Input, reason: Throwable): C#Output = errorHandler((request, reason))
   protected def processFailure(error: ProcessingFailure[C#Input]): C#Output = errorHandler(error)
 
 

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -220,15 +220,13 @@ with ServerConnectionHandler {
   }
   
   override def processBadRequest(reason: Throwable) = {
-    handleFailure(IrrecoverableError(reason))
+    Some(handleFailure(IrrecoverableError(reason)))
   }
 
   private def handleFailure(error: ProcessingFailure[I]): O = {
     error match {
       case RecoverableError(request, reason) => addError(request, reason)
-      case _: IrrecoverableError[I] =>
-        // TODO: tick/log w/o request
-        disconnect()
+      case _: IrrecoverableError[I] => // TODO: tick/log w/o request
     }
     processFailure(error)
   }
@@ -256,7 +254,7 @@ with ServerConnectionHandler {
   
 }
 
-trait ProcessingFailure[C] {
+sealed trait ProcessingFailure[C] {
   def reason: Throwable
 }
 

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -1,18 +1,14 @@
 package colossus
 package service
 
-import colossus.parsing.DataSize
+import colossus.parsing.{ParseException, DataSize}
 import colossus.parsing.DataSize._
 import core._
 import controller._
-
 import akka.event.Logging
 import metrics._
-
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
-
 import Codec._
 
 /**
@@ -20,7 +16,7 @@ import Codec._
  * @param requestTimeout how long to wait until we timeout the request
  * @param requestBufferSize how many concurrent requests a single connection can be processing
  * @param logErrors if true, any uncaught exceptions or service-level errors will be logged
- * @param requestMetrics
+ * @param requestMetrics toggle request metrics
  * @param maxRequestSize max size allowed for requests
  * TODO: remove name from config, this should be the same as a server's name and
  * pulled from the ServerRef, though this requires giving the ServiceServer
@@ -130,7 +126,7 @@ with ServerConnectionHandler {
     val time = System.currentTimeMillis
     while (requestBuffer.size > 0 && requestBuffer.peek.isTimedOut(time)) {
       //notice - completing the response will call checkBuffer which will write the error immediately
-      requestBuffer.peek.complete(handleFailure(requestBuffer.peek.request, new TimeoutError))
+      requestBuffer.peek.complete(handleFailure(RecoverableError(requestBuffer.peek.request, new TimeoutError)))
 
     }
   }
@@ -205,25 +201,36 @@ with ServerConnectionHandler {
      */
     val response: Callback[O] = if (requestBuffer.size <= requestBufferSize) {
       try {
-        processRequest(request) 
+        processRequest(request)
       } catch {
+        case t: ParseException =>
+          Callback.successful(handleFailure(IrrecoverableError(t)))
         case t: Throwable => {
-          Callback.successful(handleFailure(request, t))
+          Callback.successful(handleFailure(RecoverableError(request, t)))
         }
       }
     } else {
-      Callback.successful(handleFailure(request, new RequestBufferFullException))
+      Callback.successful(handleFailure(RecoverableError(request, new RequestBufferFullException)))
     }
     if (requestMetrics) concurrentRequests.increment()
     response.execute{
       case Success(res) => promise.complete(res)
-      case Failure(err) => promise.complete(handleFailure(promise.request, err))
+      case Failure(err) => promise.complete(handleFailure(RecoverableError(promise.request, err)))
     }
   }
+  
+  override def processBadRequest(reason: Throwable) = {
+    handleFailure(IrrecoverableError(reason))
+  }
 
-  private def handleFailure(request: I, reason: Throwable): O = {
-    addError(request, reason)
-    processFailure(request, reason)
+  private def handleFailure(error: ProcessingFailure[I]): O = {
+    error match {
+      case RecoverableError(request, reason) => addError(request, reason)
+      case _: IrrecoverableError[I] =>
+        // TODO: tick/log w/o request
+        disconnect()
+    }
+    processFailure(error)
   }
 
   private def checkGracefulDisconnect() {
@@ -243,9 +250,18 @@ with ServerConnectionHandler {
   protected def processRequest(request: I): Callback[O]
 
   //DO NOT CALL THIS METHOD INTERNALLY, use handleFailure!!
-  protected def processFailure(request: I, reason: Throwable): O
-
+ 
+ // protected def processFailure(request: I, reason: Throwable): O
+  protected def processFailure(error: ProcessingFailure[I]): O
+  
 }
+
+trait ProcessingFailure[C] {
+  def reason: Throwable
+}
+
+case class IrrecoverableError[C](reason: Throwable) extends ProcessingFailure[C]
+case class RecoverableError[C](request: C, reason: Throwable) extends ProcessingFailure[C]
 
 object ServiceServer {
   class TimeoutError extends Error("Request Timed out")


### PR DESCRIPTION
Adding support to handle parse exception at service level instead of killing the connection immediately, this allows to return a proper response.

error handling functions take in a `ProcessingFailure` instead of `request`, `reason` so service can reply back even if there is not valid requests.

@DanSimon @nsauro  