### PR TITLE
CoreHandler calls shutdown in NotConnected State, fixing ServiceClient

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -301,7 +301,7 @@ class ServiceClientSpec extends ColossusSpec {
       probe.expectMsg(100.milliseconds, WorkerCommand.Disconnect(client.id))
     }
 
-    "not attempt reconnect if connection is lost during graceful disconnect" taggedAs(org.scalatest.Tag("test")) in {
+    "not attempt reconnect if connection is lost during graceful disconnect" in {
       val cmd1 = Command(CMD_GET, "foo")
       val (endpoint, client, probe) = newClient(true, 10)
       client.send(cmd1).execute()
@@ -403,6 +403,28 @@ class ServiceClientSpec extends ColossusSpec {
           TestClient.waitForStatus(client, ConnectionStatus.NotConnected)
         }
       }
+    }
+
+    "not try to reconnect if disconnect is called while failing to connect" taggedAs(org.scalatest.Tag("test")) in {
+      val fakeWorker = FakeIOSystem.fakeWorker
+      implicit val w = fakeWorker.worker
+      val client = ServiceClient[Raw]("localhost", TEST_PORT)
+
+      fakeWorker.probe.expectMsgType[WorkerCommand.Bind](100.milliseconds)
+      client.setBind()
+      fakeWorker.probe.expectMsgType[WorkerCommand.Connect](50.milliseconds)
+
+      client.connectionTerminated(DisconnectCause.ConnectFailed(new Exception("HI!!")))
+      fakeWorker.probe.expectMsgType[WorkerCommand.Schedule](50.milliseconds)
+
+      client.disconnect()
+      //no disconnect message is sent because it's not connected
+      fakeWorker.probe.expectNoMsg(50.milliseconds)
+
+      client.connectionTerminated(DisconnectCause.ConnectFailed(new Exception("HI!!")))
+      fakeWorker.probe.expectMsg(50.milliseconds, WorkerCommand.UnbindWorkerItem(client.id))
+      fakeWorker.probe.expectNoMsg(50.milliseconds)
+
     }
 
     "shutdown the connection when an in-flight request times out" in {

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -97,6 +97,10 @@ extends CoreHandler(context) with InputController[Input, Output] with OutputCont
       case (ShuttingDown(endpoint), InputState.Terminated, OutputState.Terminated) => {
         super.shutdown()
       }
+      case (NotConnected, _, _) => {
+        //can happen when disconnect is called before being connected
+        super.shutdown()
+      }
       case _ => {} 
     }
   }

--- a/colossus/src/main/scala/colossus/core/CoreHandler.scala
+++ b/colossus/src/main/scala/colossus/core/CoreHandler.scala
@@ -104,6 +104,7 @@ abstract class CoreHandler(ctx: Context) extends WorkerItem(ctx) with Connection
         _connectionState = ShuttingDown(endpoint)
         shutdown()
       }
+      case NotConnected => shutdown()
       case _ => {}
     }
   }

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -71,7 +71,7 @@ class ClientProxy(config: ClientConfig, system: IOSystem, handlerFactory: ActorR
   def dying: Receive = {
     case Unbound => context.become(dead)
     case AsyncServiceClient.GetConnectionStatus(promise) => {
-      promise.success(ConnectionStatus.Connected)  //we have to fulfill this since it will never reach the handler
+      promise.success(ConnectionStatus.NotConnected)  //we have to fulfill this since it will never reach the handler
     }
   }
 

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -139,7 +139,9 @@ with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
   }
 
 
+  //set to true on either a call to disconnect or forceDisconnect()
   private var manuallyDisconnected = false
+
   private var connectionAttempts = 0
   private val sentBuffer    = mutable.Queue[SourcedRequest]()
   private var disconnecting: Boolean = false //set to true during graceful disconnect
@@ -266,7 +268,7 @@ with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
 
   private def attemptReconnect() {
     connectionAttempts += 1
-    if(!disconnecting) {
+    if(!disconnecting && !manuallyDisconnected) {
       if(canReconnect) {
         log.warning(s"attempting to reconnect to ${address.toString} after $connectionAttempts unsuccessful attempts.")
         worker ! Schedule(config.connectionAttempts.interval, Connect(address, id))


### PR DESCRIPTION
Fixes #278 .  Now service clients will properly stop trying to connect if `disconnect` is called during the connection process.  This was basically solved by having `CoreHandler`invoke the shutdown process while in the `NotConnected`state.  Previously it would only do it in the `Connected` state.