### PR TITLE
service codec provider extends codec provider

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
@@ -11,7 +11,7 @@ import core.ServerRef
 import service._
 import scala.reflect.ClassTag
 
-abstract class ServiceSpec[C <: Protocol](implicit provider: CodecProvider[C], clientProvider: ClientCodecProvider[C]) extends ColossusSpec {
+abstract class ServiceSpec[C <: Protocol](implicit provider: ServiceCodecProvider[C], clientProvider: ClientCodecProvider[C]) extends ColossusSpec {
   
   type Request = C#Input
   type Response = C#Output

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -58,7 +58,7 @@ object RawProtocol {
 
   
 
-  implicit object RawCodecProvider extends CodecProvider[Raw] {
+  implicit object RawCodecProvider extends ServiceCodecProvider[Raw] {
     def provideCodec() = RawCodec
 
     def errorResponse(error: ProcessingFailure[ByteString]) = ByteString(s"Error (${error.reason.getClass.getName}): ${error.reason.getMessage}")

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -15,7 +15,7 @@ import Callback.Implicits._
 
 import RawProtocol.{RawCodec, Raw}
 
-class ErrorTestDSL(probe: ActorRef) extends CodecProvider[Raw] {
+class ErrorTestDSL(probe: ActorRef) extends ServiceCodecProvider[Raw] {
 
     def provideCodec() = RawCodec
 

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -33,7 +33,7 @@ package object http extends HttpBodyEncoders {
 
   object Http extends ClientFactories[Http, HttpClient] {
 
-    class ServerDefaults extends CodecProvider[Http] {
+    class ServerDefaults extends ServiceCodecProvider[Http] {
       def provideCodec = new HttpServerCodec
       def errorResponse(error: ProcessingFailure[HttpRequest]) = error match {
         case RecoverableError(request, reason) => reason match {
@@ -75,7 +75,7 @@ package object http extends HttpBodyEncoders {
   }
 
   abstract class BaseHttpServiceHandler[D <: BaseHttp]
-  (config: ServiceConfig, provider: CodecProvider[D], context: ServerContext)
+  (config: ServiceConfig, provider: ServiceCodecProvider[D], context: ServerContext)
   extends Service[D](config, context)(provider) {
 
     override def tagDecorator = new ReturnCodeTagDecorator
@@ -87,13 +87,13 @@ package object http extends HttpBodyEncoders {
 
   }
 
-  abstract class HttpService(config: ServiceConfig, context: ServerContext) 
+  abstract class HttpService(config: ServiceConfig, context: ServerContext)
     extends BaseHttpServiceHandler[Http](config, Http.defaults.httpServerDefaults, context)
 
   abstract class StreamingHttpService(config: ServiceConfig, context: ServerContext)
     extends BaseHttpServiceHandler[StreamingHttp](config, StreamingHttpProvider, context)
 
-  implicit object StreamingHttpProvider extends CodecProvider[StreamingHttp] {
+  implicit object StreamingHttpProvider extends ServiceCodecProvider[StreamingHttp] {
     def provideCodec = new StreamingHttpServerCodec
     def errorResponse(error: ProcessingFailure[HttpRequest]) = error match {
       case RecoverableError(request, reason) => reason match {

--- a/colossus/src/main/scala/colossus/protocols/redis/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/package.scala
@@ -15,7 +15,7 @@ package object redis {
   object Redis extends ClientFactories[Redis, RedisClient]{
     object defaults {
 
-      implicit val redisServerDefaults = new CodecProvider[Redis] {
+      implicit val redisServerDefaults = new ServiceCodecProvider[Redis] {
         def provideCodec() = new RedisServerCodec
         def errorResponse(error: ProcessingFailure[Command]) = ErrorReply(s"Error (${error.reason.getClass.getName}): ${error.reason.getMessage}")
       }

--- a/colossus/src/main/scala/colossus/protocols/telnet/Telnet.scala
+++ b/colossus/src/main/scala/colossus/protocols/telnet/Telnet.scala
@@ -18,7 +18,7 @@ package object telnet {
     type Output = TelnetReply
   }
 
-  implicit object TelnetProvider extends CodecProvider[Telnet] {
+  implicit object TelnetProvider extends ServiceCodecProvider[Telnet] {
     def provideCodec() = TelnetServerCodec
 
     def errorResponse(error: ProcessingFailure[TelnetCommand]) = TelnetReply(s"Error: ${error.reason}")

--- a/colossus/src/main/scala/colossus/protocols/websocket/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/package.scala
@@ -29,8 +29,6 @@ package object websocket {
 
     def provideCodec() = new WebsocketCodec
 
-    //TODO : looks like we need to break this out from codec provider
-    def errorResponse(error: ProcessingFailure[Frame]): Frame = ???
   }
     
 


### PR DESCRIPTION
@DanSimon @nsauro 

Added `ServiceCodecProvider` which extends `CodecProvider` and moved `errorResponse` to it. This way codecs used by server but not services won't have to implement `errorResponse`.