### PR TITLE
remove context from lambda in become

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
@@ -55,7 +55,7 @@ object WebsocketExample {
     Server.basic("websocket", port){ ctx => new Service[Http](ctx) {
       def handle = {
         case UpgradeRequest(resp) => {
-          become(_ => new WebsocketServerHandler(ctx) with ProxyActor {
+          become(() => new WebsocketServerHandler(ctx) with ProxyActor {
 
             private var sending = false
 

--- a/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
@@ -55,7 +55,7 @@ class CoreHandlerSpec extends ColossusSpec {
     "become" in {
       val con = setup()
       val f = new BasicCoreHandler(con.typedHandler.context)
-      con.typedHandler.become(_ => f)
+      con.typedHandler.become(() => f)
       con.typedHandler.shutdownCalled must equal(true)
       val m = con.workerProbe.receiveOne(100.milliseconds).asInstanceOf[WorkerCommand.SwapHandler]
       m.newHandler must equal(f)

--- a/colossus/src/main/scala/colossus/core/CoreHandler.scala
+++ b/colossus/src/main/scala/colossus/core/CoreHandler.scala
@@ -8,7 +8,7 @@ sealed abstract class ShutdownAction(val rank: Int) {
 
 object ShutdownAction {
   case object DefaultDisconnect extends ShutdownAction(0)
-  case class Become(newHandler: Context => ConnectionHandler) extends ShutdownAction(1)
+  case class Become(newHandler: () => ConnectionHandler) extends ShutdownAction(1)
   case object Disconnect extends ShutdownAction(2)
 }
 
@@ -45,7 +45,9 @@ abstract class CoreHandler(ctx: Context) extends WorkerItem(ctx) with Connection
   private def setShutdownAction(action: ShutdownAction): Boolean = if (action >= shutdownAction) {
     shutdownAction = action
     true
-  } else false
+  } else {
+    false
+  }
 
   def connected(endpt: WriteEndpoint) {
     connectionState match {
@@ -82,10 +84,12 @@ abstract class CoreHandler(ctx: Context) extends WorkerItem(ctx) with Connection
    * Replace this connection handler with the given handler.  The actual swap
    * only occurs when the shutdown process complete
    */
-  final def become(nh: Context => ConnectionHandler): Boolean = if (setShutdownAction(ShutdownAction.Become(nh))) {
+  final def become(nh: () => ConnectionHandler): Boolean = if (setShutdownAction(ShutdownAction.Become(nh))) {
     shutdownRequest()
     true
-  } else false
+  } else {
+    false
+  }
 
   /**
    * Immediately terminate the connection.  this is a kill action and completely
@@ -112,7 +116,7 @@ abstract class CoreHandler(ctx: Context) extends WorkerItem(ctx) with Connection
     shutdownAction match {
       case ShutdownAction.DefaultDisconnect | ShutdownAction.Disconnect => forceDisconnect()
       case ShutdownAction.Become(newHandlerFactory) => {
-        worker.worker ! WorkerCommand.SwapHandler(newHandlerFactory(this.context))
+        worker.worker ! WorkerCommand.SwapHandler(newHandlerFactory())
       }
     }
   }


### PR DESCRIPTION
This fixes #359 

Connection type become lambda no longer takes a context.

@DanSimon @nsauro 