### PR TITLE
Metric address as config path

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -1,17 +1,16 @@
 package colossus.metrics
 
-import com.typesafe.config.Config
+import com.typesafe.config.{ConfigFactory, Config}
 
 private[metrics] trait CollectorConfigLoader {
 
-  def resolveConfig(config : Config,
-                    metricPath : String,
-                    defaultCollectorPath : String) : Config = {
-    if(config.hasPath(metricPath)) {
-      config.getConfig(metricPath).withFallback(config.getConfig(defaultCollectorPath))
-    }else{
-      config.getConfig(defaultCollectorPath)
+  def resolveConfig(config : Config, paths : String*) : Config = {
+    paths.reverse.foldLeft(ConfigFactory.empty()) {
+      case (acc, path) =>if(config.hasPath(path)){
+        config.getConfig(path).withFallback(acc)
+      } else{
+        acc
+      }
     }
-
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -4,7 +4,14 @@ import com.typesafe.config.{ConfigFactory, Config}
 
 private[metrics] trait CollectorConfigLoader {
 
+  /**
+    * Build a Config by stacking config objects specified by the paths elements
+    * @param config
+    * @param paths Ordered list of config paths, ordered by highest precedence.
+    * @return
+    */
   def resolveConfig(config : Config, paths : String*) : Config = {
+    //starting from empty, walk back from the lowest priority, stacking higher priorities on top of it.
     paths.reverse.foldLeft(ConfigFactory.empty()) {
       case (acc, path) =>if(config.hasPath(path)){
         config.getConfig(path).withFallback(acc)

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -105,7 +105,7 @@ object Counter extends CollectorConfigLoader{
     ns.getOrAdd(address){ (fullAddress, config) =>
       val addressPath = fullAddress.pieceString.replace('/','.')
       val params = resolveConfig(config.config, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
-      createCounter(address, params.getBoolean("enabled"), config.intervals)
+      createCounter(address, params.getBoolean("enabled"))
     }
   }
 
@@ -119,11 +119,11 @@ object Counter extends CollectorConfigLoader{
     */
   def apply(address: MetricAddress, enabled: Boolean = true)(implicit ns : MetricNamespace): Counter = {
     ns.getOrAdd(address){(fullAddress, config) =>
-      createCounter(fullAddress, enabled, config.intervals)
+      createCounter(fullAddress, enabled)
     }
   }
 
-  private def createCounter(address : MetricAddress, enabled : Boolean, intervals : Seq[FiniteDuration]) : Counter = {
+  private def createCounter(address : MetricAddress, enabled : Boolean) : Counter = {
     if(enabled){
       new DefaultCounter(address)
     }else{

--- a/colossus-metrics/src/test/scala/colossus/metrics/CollectorConfigLoaderSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CollectorConfigLoaderSpec.scala
@@ -1,0 +1,33 @@
+package colossus.metrics
+
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{MustMatchers, WordSpec}
+
+class CollectorConfigLoaderSpec extends WordSpec with MustMatchers with CollectorConfigLoader{
+
+  "CollectorConfigLoader" must {
+    "load a sequence of paths, omitting non existent paths" in {
+      val configValues =
+        """
+          |a{
+          |  foo = "aFoo"
+          |}
+          |b{
+          |  foo = "bFoo"
+          |  bar = "bBar"
+          |}
+          |c{
+          |  foo = "cFoo"
+          |  bar = "cBar"
+          |  baz = "cBaz"
+          |}
+        """.stripMargin
+
+      val c = ConfigFactory.parseString(configValues)
+      val result = resolveConfig(c, "a", "b", "c", "d")
+      result.getString("foo") mustBe "aFoo"
+      result.getString("bar") mustBe "bBar"
+      result.getString("baz") mustBe "cBaz"
+    }
+  }
+}

--- a/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
@@ -125,6 +125,9 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
         |   }
         |  }
         |}
+        |mypath.config-rate{
+        |  prune-empty : false
+        |}
       """.stripMargin
     implicit val ms = metricSystem(userOverrides)
 
@@ -150,6 +153,10 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val r = Rate(MetricAddress("/some-rate"), enabled = false)
       r mustBe a[NopRate]
     }
+    "use a MetricAddress as the primary config source" in {
+      val r = Rate(MetricAddress("config-rate"))
+      r.pruneEmpty mustBe false
+    }
   }
 
   "Histogram initialization" must {
@@ -171,6 +178,10 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
         |    sample-rate : 1
         |   }
         |  }
+        |}
+        |mypath.config-hist{
+        |  sample-rate : .33
+        |  percentiles : [.25]
         |}
       """.stripMargin
     implicit val ms = metricSystem(userOverrides)
@@ -203,6 +214,11 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       val r = Histogram(MetricAddress("/some-hist"), enabled = false)
       r mustBe a[NopHistogram]
     }
+    "use a MetricAddress as the primary config source" in {
+      val r = Histogram(MetricAddress("config-hist"))
+      r.sampleRate mustBe 0.33
+      r.percentiles mustBe Seq(0.25)
+    }
   }
 
   "Counter initialization" must {
@@ -213,6 +229,9 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
         |  off-counter{
         |    enabled : false
         |  }
+        |}
+        |config-counter{
+        |  enabled : false
         |}
       """.stripMargin
     implicit val ms = metricSystem(userOverrides)
@@ -234,6 +253,10 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
 
     "load a NopCounter when the 'enabled' flag is set" in {
       val r = Counter(MetricAddress("/some-counter"), enabled = false)
+      r mustBe a[NopCounter]
+    }
+    "use a MetricAddress as the primary config source" in {
+      val r = Counter(MetricAddress("config-counter"))
       r mustBe a[NopCounter]
     }
   }

--- a/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration._
 
 class CounterSpec extends MetricIntegrationSpec {
 
-  def counter = new DefaultCounter("/foo")(MetricContext("/", new Collection(CollectorConfig(List(1.second)))))
+  def counter = new DefaultCounter("/foo")
 
   "Counter" must {
     "increment" in {

--- a/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
@@ -95,7 +95,4 @@ class HistogramSpec extends MetricIntegrationSpec {
       m2(addr).get(Map("foo" -> "baz", "label" -> "min")).isEmpty must equal(true)
     }
   }
-
-
-
 }

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricNamespaceSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricNamespaceSpec.scala
@@ -1,0 +1,46 @@
+package colossus.metrics
+
+import org.scalatest.{MustMatchers, WordSpec}
+import scala.concurrent.duration._
+
+class MetricNamespaceSpec extends WordSpec with MustMatchers{
+
+  "MetricNamespace" must {
+    "allow for subspaces to create Metrics with the same name" in {
+
+      import scala.collection.JavaConversions._
+      //not using implicits here, just to illustrate the point.
+      val namespace = MetricContext("/", new Collection(CollectorConfig(Seq(1.minute, 1.second))))
+      val subName = namespace / "bar"
+
+      //create 2 rates in the parent namespace
+      Rate("bar", false, true)(namespace)
+      Rate("baz", false, true)(namespace)
+      //create 2 metrics in the sub namespace, with the same name
+      Counter("bar", true)(subName)
+      Rate("baz", true)(subName)
+
+      //all 4 should be registered
+      namespace.collection.collectors must have size 4
+
+      //dupes should not be registered
+      Rate("bar", false, true)(namespace)
+      namespace.collection.collectors must have size 4
+
+      val bar = MetricAddress("/bar")
+      val baz = MetricAddress("/baz")
+      val barBaz = MetricAddress("/bar/baz")
+      val barBar = MetricAddress("/bar/bar")
+
+      val expected = Set(bar, baz, barBaz, barBar)
+      namespace.collection.collectors.keySet().toSet mustBe expected
+
+      //paranoid much?
+      namespace.collection.collectors.get(bar) mustBe a[Rate]
+      namespace.collection.collectors.get(baz) mustBe a[Rate]
+      namespace.collection.collectors.get(barBar) mustBe a[Counter]
+      namespace.collection.collectors.get(barBaz) mustBe a[Rate]
+      //yes
+    }
+  }
+}

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -2,13 +2,9 @@ package colossus.metrics
 
 import scala.concurrent.duration._
 
-
-import akka.testkit.TestProbe
-
 class RateSpec extends MetricIntegrationSpec {
 
-  implicit val c = MetricContext("/", new Collection(CollectorConfig(List(1.second, 1.minute))))
-  def rate() = new DefaultRate("/foo", false)
+  def rate() = new DefaultRate("/foo", false, List(1.second, 1.minute))
 
   "Rate" must {
     "increment in all intervals" in {
@@ -54,7 +50,7 @@ class RateSpec extends MetricIntegrationSpec {
     }
 
     "prune empty values" in {
-      val r = new DefaultRate("/foo", true)
+      val r = new DefaultRate("/foo", true, List(1.second, 1.minute))
       r.hit(Map("a" -> "b"))
       r.hit(Map("b" -> "c"))
       r.hit(Map("b" -> "c"))

--- a/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
+++ b/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
@@ -3,17 +3,12 @@ package task
 
 import testkit._
 
-import core._
-
 import akka.actor._
 import akka.testkit.TestProbe
 
 import scala.concurrent.duration._
 
-import org.scalatest.Tag
-
 class TaskTest extends ColossusSpec {
-  import IOCommand.BindWorkerItem
 
   /* 
    * Notice in these tests we have to explicitly provide the sender when

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -2,12 +2,9 @@ package colossus
 package protocols
 
 import colossus.metrics.TagMap
-import colossus.parsing.DataSize
-import core.{Context, ServerContext, WorkerRef}
+import core.ServerContext
 import service._
 
-import akka.util.ByteString
-import scala.concurrent.ExecutionContext
 
 package object http extends HttpBodyEncoders {
 

--- a/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
@@ -2,15 +2,12 @@ package colossus
 package protocols.memcache
 
 import akka.util.ByteString
-import colossus.core.Context
-import colossus.parsing.DataSize
 import colossus.protocols.memcache.MemcacheCommand._
 import colossus.protocols.memcache.MemcacheReply._
 import service._
 
 import scala.language.higherKinds
 
-import scala.concurrent.{ExecutionContext, Future}
 
   /**
    * This trait houses the Memcache API.  It contains implementations for most(not all commands.

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
@@ -1,12 +1,9 @@
 package colossus
 package protocols.redis
 
-import akka.util.{ByteString, ByteStringBuilder}
-import colossus.core.{Context, WorkerRef}
-import colossus.parsing.DataSize
+import akka.util.ByteString
 import colossus.service._
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.language.higherKinds
 

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -2,8 +2,8 @@ package colossus
 package service
 
 import akka.actor.ActorRef
-import core.{WorkerItem, WorkerRef, Context}
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import core.{WorkerItem, WorkerRef}
+import scala.concurrent.Promise
 import scala.reflect.ClassTag
 
 import java.net.InetSocketAddress


### PR DESCRIPTION
A few things in here:

- MetricAddresses are now used as a config path, and are the first place a Metric is configured from
- Fixed #364.  MetricNamespace now exposes a getOrAdd function to ensure that addresses are properly prefixed when added to a Collection.  At some point, we might want to make Collection fully private, but that will be a bit of a change which we can punt on for now
- import cleanup, to remove compiler warnings
