### PR TITLE
Server typesafe config

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -97,14 +97,8 @@ private[metrics] class CollectionMap[T] {
 
 class DuplicateMetricException(message: String) extends Exception(message)
 
-class Collection(val config: CollectorConfig) {
-
-  val collectors = new ConcurrentHashMap[MetricAddress, Collector]
-
-  //not used
-  def add(collector: Collector) {
-    collectors.put(collector.address, collector)
-  }
+class Collection(val config: CollectorConfig,
+                 val collectors : ConcurrentHashMap[MetricAddress, Collector] = new ConcurrentHashMap[MetricAddress, Collector]()) {
 
   /**
    * Retrieve a collector of a specific type by address, creating a new one if

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -195,7 +195,7 @@ object MetricSystem {
     */
   def apply(configPath : String, config : Config)(implicit system : ActorSystem) : MetricSystem = {
 
-    import MetricSystemConfigHelpers._
+    import ConfigHelpers._
 
     val userPathObject = config.getObject(configPath)
     val metricsObject = userPathObject.withFallback(config.getObject(ConfigRoot))
@@ -218,13 +218,29 @@ object MetricSystem {
 }
 
 //has to be a better way
-object MetricSystemConfigHelpers {
+object ConfigHelpers {
 
-  implicit class FiniteDurationLoader(config : Config) {
+  implicit class ConfigExtractors(config : Config) {
 
     import scala.collection.JavaConversions._
 
+    def getIntOption(path : String) : Option[Int] = getOption(path, config.getInt)
+
+    def getLongOption(path : String) : Option[Long] = getOption(path, config.getLong)
+
+    private def getOption[T](path : String, f : String => T) : Option[T] = {
+      if(config.hasPath(path)){
+        Some(f(path))
+      }else{
+        None
+      }
+    }
+
     def getFiniteDurations(path : String) : Seq[FiniteDuration] = config.getStringList(path).map(finiteDurationOnly(_, path))
+
+    def getFiniteDuration(path : String) : FiniteDuration = finiteDurationOnly(config.getString(path), path)
+
+    def getScalaDuration(path : String) : Duration =  Duration(config.getString(path))
 
     private def finiteDurationOnly(str : String, key : String) = {
       Duration(str) match {

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -11,7 +11,6 @@ private[metrics] trait CollectorConfigLoader {
     * @return
     */
   def resolveConfig(config : Config, paths : String*) : Config = {
-    //starting from empty, walk back from the lowest priority, stacking higher priorities on top of it.
     paths.reverse.foldLeft(ConfigFactory.empty()) {
       case (acc, path) =>if(config.hasPath(path)){
         config.getConfig(path).withFallback(acc)

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -6,6 +6,7 @@ private[metrics] trait CollectorConfigLoader {
 
   /**
     * Build a Config by stacking config objects specified by the paths elements
+    *
     * @param config
     * @param paths Ordered list of config paths, ordered by highest precedence.
     * @return
@@ -19,5 +20,11 @@ private[metrics] trait CollectorConfigLoader {
         acc
       }
     }
+  }
+
+  def resolveConfig(fullAddress : MetricAddress, msConfig : Config,  externalConfig: Option[Config], paths : String*) : Config = {
+    val addressPath = fullAddress.pieceString.replace('/','.')
+    val c = externalConfig.getOrElse(msConfig)
+    resolveConfig(c,(addressPath +: paths):_*)
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -11,6 +11,7 @@ private[metrics] trait CollectorConfigLoader {
     * @return
     */
   def resolveConfig(config : Config, paths : String*) : Config = {
+    //starting from empty, walk back from the lowest priority, stacking higher priorities on top of it.
     paths.reverse.foldLeft(ConfigFactory.empty()) {
       case (acc, path) =>if(config.hasPath(path)){
         config.getConfig(path).withFallback(acc)

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -1,5 +1,7 @@
 package colossus.metrics
 
+import com.typesafe.config.Config
+
 import scala.concurrent.duration._
 
 /**
@@ -102,9 +104,28 @@ object Counter extends CollectorConfigLoader{
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Counter = {
+    addToNamespace(address, configPath, None)
+  }
+
+  /**
+    * Create a Counter with the following address.  Source the config from the provided Config object,
+    * instead of the MetricNamespace's Config
+    *
+    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path to this Counter's configuration within the `externalConfig`.
+    * @param externalConfig  A Config object which is expected to contain all the necessary fields for creating a Counter
+    * @param ns
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String, externalConfig : Config)(implicit ns : MetricNamespace) : Counter = {
+    addToNamespace(address, configPath, Some(externalConfig))
+  }
+
+  private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Counter = {
     ns.getOrAdd(address){ (fullAddress, config) =>
       val addressPath = fullAddress.pieceString.replace('/','.')
-      val params = resolveConfig(config.config, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val c = externalConfig.getOrElse(config.config)
+      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createCounter(address, params.getBoolean("enabled"))
     }
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -123,9 +123,7 @@ object Counter extends CollectorConfigLoader{
 
   private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Counter = {
     ns.getOrAdd(address){ (fullAddress, config) =>
-      val addressPath = fullAddress.pieceString.replace('/','.')
-      val c = externalConfig.getOrElse(config.config)
-      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val params = resolveConfig(fullAddress, config.config, externalConfig, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createCounter(address, params.getBoolean("enabled"))
     }
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -127,9 +127,7 @@ object Histogram extends CollectorConfigLoader{
     ns.getOrAdd(address){(fullAddress, config) =>
       import scala.collection.JavaConversions._
 
-      val addressPath = fullAddress.pieceString.replace('/','.')
-      val c = externalConfig.getOrElse(config.config)
-      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val params = resolveConfig(fullAddress, config.config, externalConfig, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       val percentiles = params.getDoubleList("percentiles").map(_.toDouble)
       val sampleRate = params.getDouble("sample-rate")
       val pruneEmpty = params.getBoolean("prune-empty")

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -3,6 +3,8 @@ package colossus.metrics
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ThreadLocalRandom
+import com.typesafe.config.Config
+
 import scala.concurrent.duration._
 
 /**
@@ -104,12 +106,30 @@ object Histogram extends CollectorConfigLoader{
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Histogram = {
+    addToNamespace(address, configPath, None)
+  }
 
+  /**
+    * Create a Histogram with the following address.  Source the config from the provided Config object,
+    * instead of the MetricNamespace's Config
+    *
+    * @param address The MetricAddress of this Histogram.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path to this Histogram's configuration within the `externalConfig`.
+    * @param externalConfig  A Config object which is expected to contain all the necessary fields for creating a Histogram
+    * @param ns
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String, externalConfig : Config)(implicit ns : MetricNamespace) : Histogram = {
+    addToNamespace(address, configPath, Some(externalConfig))
+  }
+
+  private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Histogram = {
     ns.getOrAdd(address){(fullAddress, config) =>
       import scala.collection.JavaConversions._
 
       val addressPath = fullAddress.pieceString.replace('/','.')
-      val params = resolveConfig(config.config, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val c = externalConfig.getOrElse(config.config)
+      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       val percentiles = params.getDoubleList("percentiles").map(_.toDouble)
       val sampleRate = params.getDouble("sample-rate")
       val pruneEmpty = params.getBoolean("prune-empty")

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -108,9 +108,7 @@ object Rate extends CollectorConfigLoader {
 
   private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Rate = {
     ns.getOrAdd(address){(fullAddress, config) =>
-      val addressPath = fullAddress.pieceString.replace('/','.')
-      val c = externalConfig.getOrElse(config.config)
-      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val params = resolveConfig(fullAddress, config.config, externalConfig, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createRate(fullAddress, params.getBoolean("prune-empty"), params.getBoolean("enabled"), config.intervals)
     }
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -1,5 +1,7 @@
 package colossus.metrics
 
+import com.typesafe.config.Config
+
 import scala.concurrent.duration._
 
 /**
@@ -11,6 +13,7 @@ trait Rate extends Collector{
     * Increment value to this Rate for this specified TagMap
     * A single Rate instance divides values amongst TagMaps, and tracks each one independently
     * When they are collected and reported, all TagMaps will be reported under the same MetricAddress.
+    *
     * @param tags Tags to record with this value
     * @param amount The value to increment the rate
     */
@@ -18,6 +21,7 @@ trait Rate extends Collector{
 
   /**
     * Instruct the collector to not report any values for tag combinations which were previously empty.
+    *
     * @return
     */
   def pruneEmpty : Boolean
@@ -67,6 +71,7 @@ object Rate extends CollectorConfigLoader {
 
   /**
     * Create a Rate with the following address.  See the documentation for [[colossus.metrics.MetricSystem]] for details on configuration
+    *
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param ns The namespace to which this Metric is relative.
     * @return
@@ -76,6 +81,7 @@ object Rate extends CollectorConfigLoader {
   }
   /**
     * Create a Rate with the following address, whose definitions is contained the specified configPath.
+    *
     * @param address    The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param configPath The path in the config that this rate's configuration is located.  This is relative to the MetricSystem config
     *                   definition.
@@ -83,15 +89,35 @@ object Rate extends CollectorConfigLoader {
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Rate = {
+    addToNamespace(address, configPath, None)
+  }
+
+  /**
+    * Create a Rate with the following address.  Source the config from the provided Config object,
+    * instead of the MetricNamespace's Config
+    *
+    * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path to this Rate's configuration within the `externalConfig`.
+    * @param externalConfig  A Config object which is expected to contain all the necessary fields for creating a Rate
+    * @param ns
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String, externalConfig : Config)(implicit ns : MetricNamespace) : Rate = {
+    addToNamespace(address, configPath, Some(externalConfig))
+  }
+
+  private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Rate = {
     ns.getOrAdd(address){(fullAddress, config) =>
       val addressPath = fullAddress.pieceString.replace('/','.')
-      val params = resolveConfig(config.config, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val c = externalConfig.getOrElse(config.config)
+      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createRate(fullAddress, params.getBoolean("prune-empty"), params.getBoolean("enabled"), config.intervals)
     }
   }
 
   /**
     * Create a new Rate which will be contained by the specified Collection
+    *
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param pruneEmpty Instruct the collector to not report any values for tag combinations which were previously empty.
     * @param enabled If this Rate will actually be collected and reported.

--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -1,6 +1,7 @@
 package colossus
 package testkit
 
+import com.typesafe.config.ConfigFactory
 import core._
 import metrics._
 import service._
@@ -16,7 +17,7 @@ case class FakeWorker(probe: TestProbe, worker: WorkerRef)
 
 object FakeIOSystem {
   def apply()(implicit system: ActorSystem): IOSystem = {
-    new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, (x,y) => system.deadLetters)
+    new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, ConfigFactory.empty(), (x,y,c) => system.deadLetters)
   }
 
   /**
@@ -61,7 +62,7 @@ object FakeIOSystem {
 
   def withManagerProbe()(implicit system: ActorSystem): (IOSystem, TestProbe) = {
     val probe = TestProbe()
-    val sys = new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, (x,y) => probe.ref)
+    val sys = new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, ConfigFactory.empty(), (x,y,c) => probe.ref)
     (sys, probe)
   }
 

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -1,0 +1,80 @@
+package colossus.core
+
+import colossus.EchoHandler
+import colossus.metrics.MetricAddress
+import colossus.testkit.ColossusSpec
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration._
+
+class ServerConfigLoadingSpec  extends ColossusSpec {
+
+  "Server configuration loading" should {
+    "load defaults" in {
+      withIOSystem{ implicit io =>
+        val s = Server.basic()(context => new EchoHandler(context))
+        waitForServer(s)
+        s.name mustBe MetricAddress.Root
+        val settings = s.config.settings
+        settings.bindingAttemptDuration mustBe PollingDuration(200.milliseconds, None)
+        settings.delegatorCreationDuration mustBe PollingDuration(500.milliseconds, None)
+        settings.highWatermarkPercentage mustBe 0.85
+        settings.lowWatermarkPercentage mustBe 0.75
+        settings.maxConnections mustBe 1000
+        settings.maxIdleTime mustBe Duration.Inf
+        settings.port mustBe 9876
+        settings.shutdownTimeout mustBe 100.milliseconds
+        settings.tcpBacklogSize mustBe None
+      }
+    }
+
+    "load user overrides" in {
+      val userOverrides =
+        """{
+          | my-server{
+          |   name = "mine"
+          |    port : 9888
+          |    max-connections : 1000
+          |    max-idle-time : "1 second"
+          |    tcp-backlog-size : 100
+          |    shutdown-timeout : "2 seconds"
+          | }
+          |}
+        """.stripMargin
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      withIOSystem{ implicit io =>
+        val s = Server.basic("my-server", c)(context => new EchoHandler(context))
+        waitForServer(s)
+        s.name mustBe MetricAddress("mine")
+        val settings = s.config.settings
+        settings.bindingAttemptDuration mustBe PollingDuration(200.milliseconds, None)
+        settings.delegatorCreationDuration mustBe PollingDuration(500.milliseconds, None)
+        settings.highWatermarkPercentage mustBe 0.85
+        settings.lowWatermarkPercentage mustBe 0.75
+        settings.maxConnections mustBe 1000
+        settings.maxIdleTime mustBe 1.second
+        settings.port mustBe 9888
+        settings.shutdownTimeout mustBe 2.seconds
+        settings.tcpBacklogSize mustBe Some(100)
+      }
+    }
+
+    "quick config" in {
+      withIOSystem{ implicit io =>
+        val s = Server.basic("quick-server", 8989)(context => new EchoHandler(context))
+        waitForServer(s)
+        s.name mustBe MetricAddress("quick-server")
+        val settings = s.config.settings
+        settings.bindingAttemptDuration mustBe PollingDuration(200.milliseconds, None)
+        settings.delegatorCreationDuration mustBe PollingDuration(500.milliseconds, None)
+        settings.highWatermarkPercentage mustBe 0.85
+        settings.lowWatermarkPercentage mustBe 0.75
+        settings.maxConnections mustBe 1000
+        settings.maxIdleTime mustBe Duration.Inf
+        settings.port mustBe 8989
+        settings.shutdownTimeout mustBe 100.milliseconds
+        settings.tcpBacklogSize mustBe None
+      }
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -76,5 +76,13 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         settings.tcpBacklogSize mustBe None
       }
     }
+    "not explode if there is no 'metrics' configuration" in {
+      withIOSystem{ implicit io =>
+        //this loads the entire config, but the this constructor wants a Config which is pointing at a Server configuration
+        val s = Server.basic("my-server", ServerSettings(8989), ConfigFactory.load())(context => new EchoHandler(context))
+        waitForServer(s)
+        //no explosions, means we are good
+      }
+    }
   }
 }

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -5,6 +5,19 @@ colossus{
     #num-workers : 4
     name : "/"
     metrics : ${colossus.metrics}
+    metrics : {
+      worker-event-loops : {
+        enabled : true
+        prune-empty : false
+      }
+      worker-connections : {
+        enabled : true
+      }
+      worker-rejected-connections : {
+        enabled : true
+        prune-empty : false
+      }
+    }
   }
 
   server {

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -8,17 +8,18 @@ colossus{
   }
 
   server {
+    name = "/"
     port : 9876
     max-connections : 1000
-    max-idle-time : "INFINITY"
+    max-idle-time : "Inf"
     low-watermark-percentage : 0.75
     high-watermark-percentage : 0.85
     highwater-max-idle-time : "100 milliseconds"
-    tcp-backlog-size : -1 #placeholder, this is an option
+    #tcp-backlog-size : 100  #optional
     binding-attempt-interval : "200 milliseconds"
-    binding-attempt-max-duration : "INFINITY"
+    #binding-attempt-max-tries : 3 #optional
     delegator-creation-interval : "500 milliseconds"
-    delegator-creation-max-duration : "INFINITY"
+   # delegator-creation-max-tries: 3 #optional
     shutdown-timeout : "100 milliseconds"
     metrics {
       connections {

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -25,7 +25,7 @@ colossus{
       connections {
         enabled : true
       }
-      refused {
+      refused-connections {
         enabled : true
         prune-empty : false
       }

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -217,8 +217,14 @@ private[colossus] class Server(io: IOSystem, serverConfig: ServerConfig,
   //see if there is local configuration for metrics, if there is, overlay that on the iosystem's metrics config
   //TODO: cache config
   val metricsConfig = if(config.hasPath("metrics")){
-    val serverMetrics = config.getConfig("metrics")
-    serverMetrics.withFallback(io.metrics.config)
+    //TODO : rethink this
+    /*
+    This is a bit tricky.  MetricSystem, when it is created has a modified version of the entire Config object.  The modification
+    being that it overwrites the 'colossus.metrics' path with generated config(userOverrides + MS reference defaults).
+    We want to now overlay the Server'smetrics definitions on top of that, and use that as the Config source
+     */
+    val serverMetrics = config.getObject("metrics").withFallback(io.metrics.config.getConfig(MetricSystem.ConfigRoot))
+    io.metrics.config.withValue(MetricSystem.ConfigRoot, serverMetrics)
   }else{
     log.debug(s"Could not find the 'metrics' path in supplied config, defaulting to the IOSystem's MetricSystem config")
     io.metrics.config

--- a/colossus/src/main/scala/colossus/core/ServerDSL.scala
+++ b/colossus/src/main/scala/colossus/core/ServerDSL.scala
@@ -170,7 +170,7 @@ trait ServerDSL {
     val userPathObject = config.getObject(configPath)
     val serverConfig = userPathObject.withFallback(config.getObject(ConfigRoot)).toConfig
     val name = serverConfig.getString("name")
-    basic(name, ServerSettings.extract(serverConfig), config)(handlerFactory)
+    basic(name, ServerSettings.extract(serverConfig), serverConfig)(handlerFactory)
   }
 
   /**

--- a/colossus/src/main/scala/colossus/core/ServerDSL.scala
+++ b/colossus/src/main/scala/colossus/core/ServerDSL.scala
@@ -5,6 +5,8 @@ object ServerDSL {
   type Receive = PartialFunction[Any, Unit]
 }
 import ServerDSL._
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 /**
  * An instance of this is handed to every new server connection handler
@@ -37,30 +39,165 @@ class DSLDelegator(server : ServerRef, _worker : WorkerRef, initializer: Initial
 //this is mixed in by Server
 trait ServerDSL {
 
+  val ConfigRoot = "colossus.server"
+
+  /**
+    * Create a new Server, using only the defaults provided by the corresponding "colossus.server" config path.
+    * A Config object will be created via {{{ConfigFactory.load()}}}
+    *
+    * @param initializer
+    * @param io
+    * @return
+    */
+  def start()(initializer: WorkerRef => Initializer)(implicit io: IOSystem) : ServerRef = {
+    start(ConfigRoot)(initializer)
+  }
+
+  /**
+    * Create a new Server using the supplied configPath.  This configPath will be overlaid on top of the default "colossus.server"
+    * config path.
+    * A Config object will be created via {{{ConfigFactory.load()}}}
+    *
+    * @param configPath The path to the configuration.
+    * @param initializer
+    * @param io
+    * @return
+    */
+  def start(configPath : String)(initializer: WorkerRef => Initializer)(implicit io: IOSystem) : ServerRef = {
+    start(configPath, ConfigFactory.load())(initializer)
+  }
+
+  /**
+    * Create a new Server by loading its config from the specified configPath.
+    * This configPath will be overlaid on top of the default "colossus.server" config path.
+    *
+    * @param configPath The path to the configuration.
+    * @param config The Config source to query
+    * @param initializer
+    * @param io
+    * @return
+    */
+  def start(configPath : String, config : Config)(initializer: WorkerRef => Initializer)(implicit io: IOSystem) : ServerRef = {
+    val userPathObject = config.getObject(configPath)
+    val serverConfig = userPathObject.withFallback(config.getObject(ConfigRoot)).toConfig
+    val name = serverConfig.getString("name")
+    start(name, ServerSettings.extract(serverConfig))(initializer)
+  }
+
+  /**
+    * Convenience function for starting a server using the specified name and port.  This will be overlaid on top of the default
+    * "colossus.server" configuration path.
+    *
+    * @param name Name of this Server. Name is also the MetricAddress relative to the containing IOSystem's MetricNamespace
+    * @param port Port to run on
+    * @param initializer
+    * @param io
+    * @return
+    */
+  def start(name: String, port: Int)(initializer: WorkerRef => Initializer)(implicit io: IOSystem): ServerRef = {
+
+    val user =
+      s"""
+        |user-settings{
+        |  name : "$name"
+        |  port : $port
+        |}
+      """.stripMargin
+    val userConfig = ConfigFactory.parseString(user)
+
+    start("user-settings",userConfig.withFallback(ConfigFactory.load()))(initializer)
+  }
+
+  /**
+    * Create a new Server.
+    *
+    * @param name Name of this Server. Name is also the MetricAddress relative to the containing IOSystem's MetricNamespace.
+    * @param settings Settings for this Server.
+    * @param initializer
+    * @param io
+    * @return
+    */
   def start(name: String, settings: ServerSettings)(initializer: WorkerRef => Initializer)(implicit io: IOSystem) : ServerRef = {
     val serverConfig = ServerConfig(
       name = name,
-      settings = settings,
-      delegatorFactory = (s,w) => new DSLDelegator(s,w, initializer(w))
+      settings = settings, delegatorFactory = (s,w) => new DSLDelegator(s,w, initializer(w))
     )
     Server(serverConfig)
 
   }
 
-  def start(name: String, port: Int)(initializer: WorkerRef => Initializer)(implicit io: IOSystem): ServerRef = start(name, ServerSettings(port))(initializer)
+  /**
+    * Create a new Server, using only the defaults provided by the corresponding "colossus.server" config path.
+    * A Config object will be created via {{{ConfigFactory.load()}}}
+    *
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
+  def basic()(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem) : ServerRef = {
+    basic(ConfigRoot)(handlerFactory)
+  }
 
+  /**
+    * Create a new Server using the supplied configPath.  This configPath will be overlaid on top of the default "colossus.server"
+    * config path.
+    * A Config object will be created via {{{ConfigFactory.load()}}}
+    *
+    * @param configPath The path to the configuration.
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
+  def basic(configPath : String)(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem) : ServerRef = {
+    basic(configPath, ConfigFactory.load())(handlerFactory)
+  }
 
+  /**
+    * Create a new Server by loading its config from the specified configPath.
+    * This configPath will be overlaid on top of the default "colossus.server" config path.
+    *
+    * @param configPath The path to the configuration.
+    * @param config The Config source to query
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
+  def basic(configPath : String, config : Config)(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem) : ServerRef = {
+    val userPathObject = config.getObject(configPath)
+    val serverConfig = userPathObject.withFallback(config.getObject(ConfigRoot)).toConfig
+    val name = serverConfig.getString("name")
+    basic(name, ServerSettings.extract(serverConfig))(handlerFactory)
+  }
+
+  /**
+    * Convenience function for starting a server using the specified name and port.  This will be overlaid on top of the default
+    * "colossus.server" configuration path.
+    *
+    * @param name Name of this Server. Name is also the MetricAddress relative to the containing IOSystem's MetricNamespace
+    * @param port Port to run on
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
   def basic(name: String, port: Int)(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem): ServerRef = {
     start(name, port){worker => new Initializer(worker){
       def onConnect = handlerFactory
     }}
   }
 
+  /**
+    * Create a new Server.
+    *
+    * @param name Name of this Server. Name is also the MetricAddress relative to the containing IOSystem's MetricNamespace
+    * @param settings Settings for this Server.
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
   def basic(name: String, settings: ServerSettings)(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem): ServerRef = {
     start(name, settings)(worker => new Initializer(worker) {
       def onConnect = handlerFactory
     })
   }
-
 }
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -3,6 +3,7 @@ package core
 
 import akka.actor._
 import akka.event.LoggingAdapter
+import com.typesafe.config.Config
 import metrics._
 import service.CallbackExecution
 
@@ -24,14 +25,15 @@ import scala.util.control.NonFatal
  */
 case class WorkerConfig(
   io: IOSystem,
+  ioConfig : Config,
   workerId: Int
 )
 
 /**
  * This is a Worker's public interface.  This is what can be used to communicate with a Worker, as it
  * wraps the Worker's ActorRef, as well as providing some additional information which can be made public.
+ *
  * @param id The Worker's id.
- * @param metrics The Metrics associated with this Worker
  * @param worker The ActorRef of the Worker
  * @param system The IOSystem to which this Worker belongs
  */
@@ -140,7 +142,6 @@ class WorkerItemManager(worker: WorkerRef, log: LoggingAdapter) {
 }
 
 
-
 private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLogging with CallbackExecution {
   import Server._
   import Worker._
@@ -156,10 +157,10 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
 
   private val workerIdTag = Map("worker" -> (io.name + "-" + workerId.toString))
 
-  implicit val ns = io.namespace
-  val eventLoops              = Rate("worker/event_loops")
-  val numConnections          = Counter("worker/connections")
-  val rejectedConnections     = Rate("worker/rejected_connections")
+  implicit val ns = io.namespace.withConfigOverrides(ioConfig)
+  val eventLoops              = Rate("worker/event_loops", "worker-event-loops")
+  val numConnections          = Counter("worker/connections", "worker-connections")
+  val rejectedConnections     = Rate("worker/rejected_connections", "worker-rejected-connections")
 
   val selector: Selector = Selector.open()
   val buffer = ByteBuffer.allocateDirect(1024 * 128)
@@ -573,7 +574,8 @@ object Worker {
   case class ConnectionSummary(infos: Seq[ConnectionSnapshot])
 
   /** Sent from Servers
-   * @param sc the underlying socketchannel of the connection
+    *
+    * @param sc the underlying socketchannel of the connection
    * @param attempt used when a worker refuses a connection, which can happen if a worker has just restarted and hasn't yet re-registered servers
    */
   private[core] case class NewConnection(sc: SocketChannel, attempt: Int = 1)

--- a/colossus/src/main/scala/colossus/core/WorkerManager.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerManager.scala
@@ -6,8 +6,7 @@ import akka.agent.Agent
 import akka.pattern.ask
 import akka.routing.RoundRobinGroup
 import akka.util.Timeout
-
-import metrics.MetricSystem
+import com.typesafe.config.Config
 
 import java.net.InetSocketAddress
 
@@ -22,9 +21,11 @@ import scala.util.{Failure, Success}
  * A WorkerManager is just that, an Actor who is responsible for managing all of the Worker Actors in an IOSystem.
  * It is responsible for creating, killing, restarting, relaying messages, etc.
  *
- * @param config configuration parameters
+ * @param workerAgent WorkerRefs that this WorkerManager manages
+ * @param ioSystem Containing IOSystem
+ * @param ioConfig IOSystem config
  */
-private[colossus] class WorkerManager(workerAgent: Agent[IndexedSeq[WorkerRef]], ioSystem: IOSystem) 
+private[colossus] class WorkerManager(workerAgent: Agent[IndexedSeq[WorkerRef]], ioSystem: IOSystem, ioConfig : Config)
 extends Actor with ActorLogging with Stash {
   import WorkerManager._
   import akka.actor.OneForOneStrategy
@@ -47,7 +48,8 @@ extends Actor with ActorLogging with Stash {
   val workers = (1 to numWorkers).map{i =>
     val workerConfig = WorkerConfig(
       workerId = i,
-      io = ioSystem
+      io = ioSystem,
+      ioConfig = ioConfig
     )
     val worker = context.actorOf(Props(classOf[Worker],workerConfig ).withDispatcher("server-dispatcher"), name = s"worker-$i")
     context.watch(worker)

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -57,13 +57,7 @@ package object http extends HttpBodyEncoders {
       implicit val httpClientDefaults = new ClientDefaults
 
     }
-  
-
   }
-
-
-
-
 
   class ReturnCodeTagDecorator[C <: BaseHttp] extends TagDecorator[C#Input, C#Output] {
     override def tagsFor(request: C#Input, response: C#Output): TagMap = {


### PR DESCRIPTION
## What
Ability to configure Servers via typesafe config

## How
Following the same pattern as `IOSystem` and `MetricSystem`'s constructor functions.  This one is a bit different, due to the `ServerDSL` trait, which has a bunch of convenience functions for creating `Server`s.  I followed the pattern for IO/MetricSystem on there, instead of the `Server.apply` functions.  

Some difficulty snuck in with configuring a Server's metrics: 

A `MetricSystem` during its creation, takes any user overrides and applies them onto the defaults.  This merged object is then placed back onto the original Config, and this modified Config is then set on the `MetricSystem` as its configuration source.  `Collector`s then use this already merged config source to pull their configurations from, vs having to manage the overrides and defaults themselves.

`Server`s can provide their own `metrics` definition, which contains configuration for its internal metrics.  This configuration needs to be overlaid on top of the underlying `MetricSystem`'s merged configuration in order for them to be properly applied.  Since this happens after a `MetricSystem` creation, this new config needs to somehow be surfaced to the `Server`'s metric constructors, so that they can be properly configured.

The `Server` creates this new configuration, by overlaying its `metrics` configuration (if it exists) on the underlying `MetricSystem`'s configuration.  From there, there were 2 options(probably more), that presented themselves:

- Inside `Server`, create a new `MetricNamespace`, whose underlying `Collection`, contained a pointer to the new configuration, and use that `MetricNamespace` in the `Collector`'s constructors.  

- Modify the contructors for `Collector`s to allow them to specify a Config object.  This Config object would take precedence over the underlying `MetricSystem`'s configuration.

I opted for the second, only because I thought of it first, and it was pretty straightforward.  The only problem is now all `Collector`s have this new constructor, which is kind of not great.  However, having this extra constructor does afford more obvious configuration options for `Collector` creators, which I think is a good thing.

I'm still slightly torn on which way is better(or if there is a better option all together), but think for a first pass this works, and we can always improve on it.  If there is strong opinion to go another route, I'm all ears.



