### PR TITLE
Server typesafe config

### DIFF
--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -1,22 +1,24 @@
 colossus {
   metrics {
-    collect-system-metrics: true
-    collection-intervals: ["1 second", "1 minute"]
-    namespace: "/"
-    enabled: true
-    collectors-defaults {
-      rate {
-        enabled: true
-        prune-empty: false
-      }
-      histogram {
-        enabled: true
-        percentiles: [0.75, 0.9, 0.99, 0.999, 0.9999]
-        sample-rate: 1.0
-        prune-empty: false
-      }
-      counter {
-        enabled: true
+    system {
+      collect-system-metrics: true
+      collection-intervals: ["1 second", "1 minute"]
+      namespace: "/"
+      enabled: true
+      collectors-defaults {
+        rate {
+          enabled: true
+          prune-empty: false
+        }
+        histogram {
+          enabled: true
+          percentiles: [0.75, 0.9, 0.99, 0.999, 0.9999]
+          sample-rate: 1.0
+          prune-empty: false
+        }
+        counter {
+          enabled: true
+        }
       }
     }
     # Metric configuration definitions can be listed here:
@@ -26,5 +28,9 @@ colossus {
     # down-sampled-histogram{
     #  sample-rate : .25
     # }
+    # full addresses as well
+    # path.to.my.metric{
+    #
+    #}
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -97,8 +97,9 @@ private[metrics] class CollectionMap[T] {
 
 class DuplicateMetricException(message: String) extends Exception(message)
 
-class Collection(val config: CollectorConfig,
-                 val collectors : ConcurrentHashMap[MetricAddress, Collector] = new ConcurrentHashMap[MetricAddress, Collector]()) {
+class Collection(val config: CollectorConfig) {
+
+  val collectors : ConcurrentHashMap[MetricAddress, Collector] = new ConcurrentHashMap[MetricAddress, Collector]()
 
   /**
    * Retrieve a collector of a specific type by address, creating a new one if
@@ -143,7 +144,6 @@ class Collection(val config: CollectorConfig,
 
 object Collection{
   def withReferenceConf(intervals : Seq[FiniteDuration]) : Collection = {
-    new Collection(CollectorConfig(intervals, ConfigFactory.defaultReference().getConfig(MetricSystem.ConfigRoot)),
-      new ConcurrentHashMap[MetricAddress, Collector]())
+    new Collection(CollectorConfig(intervals, ConfigFactory.defaultReference().getConfig(MetricSystem.ConfigRoot)))
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -21,7 +21,7 @@ import scala.reflect.ClassTag
  * @param intervals The aggregation intervals configured for the MetricSystem this collection belongs to
  * @param config The Configuration of the underlying [[MetricSystem]]
  */
-case class CollectorConfig(intervals: Seq[FiniteDuration], config : Config = ConfigFactory.defaultReference())
+case class CollectorConfig(intervals: Seq[FiniteDuration], config : Config)
 
 /**
   * Base trait required by all metric types.
@@ -139,4 +139,11 @@ class Collection(val config: CollectorConfig,
     build
   }
 
+}
+
+object Collection{
+  def withReferenceConf(intervals : Seq[FiniteDuration]) : Collection = {
+    new Collection(CollectorConfig(intervals, ConfigFactory.defaultReference().getConfig(MetricSystem.ConfigRoot)),
+      new ConcurrentHashMap[MetricAddress, Collector]())
+  }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -97,14 +97,8 @@ private[metrics] class CollectionMap[T] {
 
 class DuplicateMetricException(message: String) extends Exception(message)
 
-class Collection(val config: CollectorConfig) {
-
-  val collectors = new ConcurrentHashMap[MetricAddress, Collector]
-
-  //not used
-  def add(collector: Collector) {
-    collectors.put(collector.address, collector)
-  }
+class Collection(val config: CollectorConfig,
+                 val collectors : ConcurrentHashMap[MetricAddress, Collector] = new ConcurrentHashMap[MetricAddress, Collector]()) {
 
   /**
    * Retrieve a collector of a specific type by address, creating a new one if

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -142,6 +142,8 @@ class Collection(val config: CollectorConfig) {
 
 }
 
+//Used as a convenience function in tests.  Used in both both colossus-tests and in colossus-metrics tests, which means
+//this project is the lowest common denominator for both.
 object Collection{
   def withReferenceConf(intervals : Seq[FiniteDuration]) : Collection = {
     new Collection(CollectorConfig(intervals, ConfigFactory.defaultReference().getConfig(MetricSystem.ConfigRoot)))

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -195,7 +195,7 @@ object MetricSystem {
     */
   def apply(configPath : String, config : Config)(implicit system : ActorSystem) : MetricSystem = {
 
-    import MetricSystemConfigHelpers._
+    import ConfigHelpers._
 
     val userPathObject = config.getObject(configPath)
     val metricsObject = userPathObject.withFallback(config.getObject(ConfigRoot))
@@ -218,13 +218,29 @@ object MetricSystem {
 }
 
 //has to be a better way
-object MetricSystemConfigHelpers {
+object ConfigHelpers {
 
-  implicit class FiniteDurationLoader(config : Config) {
+  implicit class ConfigExtractors(config : Config) {
 
     import scala.collection.JavaConversions._
 
+    def getIntOption(path : String) : Option[Int] = getOption(path, config.getInt)
+
+    def getLongOption(path : String) : Option[Long] = getOption(path, config.getLong)
+
+    private def getOption[T](path : String, f : String => T) : Option[T] = {
+      if(config.hasPath(path)){
+        Some(f(path))
+      }else{
+        None
+      }
+    }
+
     def getFiniteDurations(path : String) : Seq[FiniteDuration] = config.getStringList(path).map(finiteDurationOnly(_, path))
+
+    def getFiniteDuration(path : String) : FiniteDuration = finiteDurationOnly(config.getString(path), path)
+
+    def getScalaDuration(path : String) : Duration =  Duration(config.getString(path))
 
     private def finiteDurationOnly(str : String, key : String) = {
       Duration(str) match {

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -11,7 +11,6 @@ private[metrics] trait CollectorConfigLoader {
     * @return
     */
   def resolveConfig(config : Config, paths : String*) : Config = {
-    //starting from empty, walk back from the lowest priority, stacking higher priorities on top of it.
     paths.reverse.foldLeft(ConfigFactory.empty()) {
       case (acc, path) =>if(config.hasPath(path)){
         config.getConfig(path).withFallback(acc)

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -6,6 +6,7 @@ private[metrics] trait CollectorConfigLoader {
 
   /**
     * Build a Config by stacking config objects specified by the paths elements
+    *
     * @param config
     * @param paths Ordered list of config paths, ordered by highest precedence.
     * @return
@@ -19,5 +20,11 @@ private[metrics] trait CollectorConfigLoader {
         acc
       }
     }
+  }
+
+  def resolveConfig(fullAddress : MetricAddress, msConfig : Config,  externalConfig: Option[Config], paths : String*) : Config = {
+    val addressPath = fullAddress.pieceString.replace('/','.')
+    val c = externalConfig.getOrElse(msConfig)
+    resolveConfig(c,(addressPath +: paths):_*)
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -1,6 +1,6 @@
 package colossus.metrics
 
-import com.typesafe.config.{ConfigFactory, Config}
+import com.typesafe.config.Config
 
 private[metrics] trait CollectorConfigLoader {
 
@@ -8,23 +8,13 @@ private[metrics] trait CollectorConfigLoader {
     * Build a Config by stacking config objects specified by the paths elements
     *
     * @param config
+    * @param address Address of the Metric, turned into a path and used as a config source.
     * @param paths Ordered list of config paths, ordered by highest precedence.
     * @return
     */
-  def resolveConfig(config : Config, paths : String*) : Config = {
-    //starting from empty, walk back from the lowest priority, stacking higher priorities on top of it.
-    paths.reverse.foldLeft(ConfigFactory.empty()) {
-      case (acc, path) =>if(config.hasPath(path)){
-        config.getConfig(path).withFallback(acc)
-      } else{
-        acc
-      }
-    }
-  }
-
-  def resolveConfig(fullAddress : MetricAddress, msConfig : Config,  externalConfig: Option[Config], paths : String*) : Config = {
-    val addressPath = fullAddress.pieceString.replace('/','.')
-    val c = externalConfig.getOrElse(msConfig)
-    resolveConfig(c,(addressPath +: paths):_*)
+  def resolveConfig(config : Config, address : MetricAddress, paths : String*) : Config = {
+    import ConfigHelpers._
+    val p = address.pieceString.replace('/','.') +: paths
+    config.withFallbacks(p : _*)
   }
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/CollectorConfigLoader.scala
@@ -11,6 +11,7 @@ private[metrics] trait CollectorConfigLoader {
     * @return
     */
   def resolveConfig(config : Config, paths : String*) : Config = {
+    //starting from empty, walk back from the lowest priority, stacking higher priorities on top of it.
     paths.reverse.foldLeft(ConfigFactory.empty()) {
       case (acc, path) =>if(config.hasPath(path)){
         config.getConfig(path).withFallback(acc)

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -1,5 +1,7 @@
 package colossus.metrics
 
+import com.typesafe.config.Config
+
 import scala.concurrent.duration._
 
 /**
@@ -102,9 +104,28 @@ object Counter extends CollectorConfigLoader{
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Counter = {
+    addToNamespace(address, configPath, None)
+  }
+
+  /**
+    * Create a Counter with the following address.  Source the config from the provided Config object,
+    * instead of the MetricNamespace's Config
+    *
+    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path to this Counter's configuration within the `externalConfig`.
+    * @param externalConfig  A Config object which is expected to contain all the necessary fields for creating a Counter
+    * @param ns
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String, externalConfig : Config)(implicit ns : MetricNamespace) : Counter = {
+    addToNamespace(address, configPath, Some(externalConfig))
+  }
+
+  private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Counter = {
     ns.getOrAdd(address){ (fullAddress, config) =>
       val addressPath = fullAddress.pieceString.replace('/','.')
-      val params = resolveConfig(config.config, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val c = externalConfig.getOrElse(config.config)
+      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createCounter(address, params.getBoolean("enabled"))
     }
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -1,7 +1,5 @@
 package colossus.metrics
 
-import com.typesafe.config.Config
-
 import scala.concurrent.duration._
 
 /**
@@ -79,9 +77,7 @@ class NopCounter private[metrics](val address : MetricAddress) extends Counter {
 
 object Counter extends CollectorConfigLoader{
 
-  import MetricSystem.ConfigRoot
-
-  private val DefaultConfigPath = "collectors-defaults.counter"
+  private val DefaultConfigPath = "system.collectors-defaults.counter"
 
   /**
     * Create a Counter with the following address.   See the documentation for [[colossus.metrics.MetricSystem]] for details on configuration
@@ -96,6 +92,7 @@ object Counter extends CollectorConfigLoader{
 
   /**
     * Create a Counter with following address, whose definitions is contained the specified configPath.
+    * See the documentation for [[colossus.metrics.MetricSystem]]
     *
     * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param configPath The path in the config that this counter's configuration is located.  This is relative to the MetricSystem config
@@ -104,26 +101,8 @@ object Counter extends CollectorConfigLoader{
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Counter = {
-    addToNamespace(address, configPath, None)
-  }
-
-  /**
-    * Create a Counter with the following address.  Source the config from the provided Config object,
-    * instead of the MetricNamespace's Config
-    *
-    * @param address The MetricAddress of this Counter.  Note, this will be relative to the containing MetricSystem's metricAddress.
-    * @param configPath The path to this Counter's configuration within the `externalConfig`.
-    * @param externalConfig  A Config object which is expected to contain all the necessary fields for creating a Counter
-    * @param ns
-    * @return
-    */
-  def apply(address : MetricAddress, configPath : String, externalConfig : Config)(implicit ns : MetricNamespace) : Counter = {
-    addToNamespace(address, configPath, Some(externalConfig))
-  }
-
-  private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Counter = {
     ns.getOrAdd(address){ (fullAddress, config) =>
-      val params = resolveConfig(fullAddress, config.config, externalConfig, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val params = resolveConfig(config.config, fullAddress, configPath, DefaultConfigPath)
       createCounter(address, params.getBoolean("enabled"))
     }
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -123,9 +123,7 @@ object Counter extends CollectorConfigLoader{
 
   private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Counter = {
     ns.getOrAdd(address){ (fullAddress, config) =>
-      val addressPath = fullAddress.pieceString.replace('/','.')
-      val c = externalConfig.getOrElse(config.config)
-      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val params = resolveConfig(fullAddress, config.config, externalConfig, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createCounter(address, params.getBoolean("enabled"))
     }
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -127,9 +127,7 @@ object Histogram extends CollectorConfigLoader{
     ns.getOrAdd(address){(fullAddress, config) =>
       import scala.collection.JavaConversions._
 
-      val addressPath = fullAddress.pieceString.replace('/','.')
-      val c = externalConfig.getOrElse(config.config)
-      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val params = resolveConfig(fullAddress, config.config, externalConfig, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       val percentiles = params.getDoubleList("percentiles").map(_.toDouble)
       val sampleRate = params.getDouble("sample-rate")
       val pruneEmpty = params.getBoolean("prune-empty")

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -3,6 +3,8 @@ package colossus.metrics
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ThreadLocalRandom
+import com.typesafe.config.Config
+
 import scala.concurrent.duration._
 
 /**
@@ -104,12 +106,30 @@ object Histogram extends CollectorConfigLoader{
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Histogram = {
+    addToNamespace(address, configPath, None)
+  }
 
+  /**
+    * Create a Histogram with the following address.  Source the config from the provided Config object,
+    * instead of the MetricNamespace's Config
+    *
+    * @param address The MetricAddress of this Histogram.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path to this Histogram's configuration within the `externalConfig`.
+    * @param externalConfig  A Config object which is expected to contain all the necessary fields for creating a Histogram
+    * @param ns
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String, externalConfig : Config)(implicit ns : MetricNamespace) : Histogram = {
+    addToNamespace(address, configPath, Some(externalConfig))
+  }
+
+  private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Histogram = {
     ns.getOrAdd(address){(fullAddress, config) =>
       import scala.collection.JavaConversions._
 
       val addressPath = fullAddress.pieceString.replace('/','.')
-      val params = resolveConfig(config.config, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val c = externalConfig.getOrElse(config.config)
+      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       val percentiles = params.getDoubleList("percentiles").map(_.toDouble)
       val sampleRate = params.getDouble("sample-rate")
       val pruneEmpty = params.getBoolean("prune-empty")

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -108,9 +108,7 @@ object Rate extends CollectorConfigLoader {
 
   private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Rate = {
     ns.getOrAdd(address){(fullAddress, config) =>
-      val addressPath = fullAddress.pieceString.replace('/','.')
-      val c = externalConfig.getOrElse(config.config)
-      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val params = resolveConfig(fullAddress, config.config, externalConfig, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createRate(fullAddress, params.getBoolean("prune-empty"), params.getBoolean("enabled"), config.intervals)
     }
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -1,7 +1,5 @@
 package colossus.metrics
 
-import com.typesafe.config.Config
-
 import scala.concurrent.duration._
 
 /**
@@ -65,9 +63,7 @@ class NopRate private[metrics](val address : MetricAddress, val pruneEmpty : Boo
 
 object Rate extends CollectorConfigLoader {
 
-  import MetricSystem.ConfigRoot
-
-  private val DefaultConfigPath = "collectors-defaults.rate"
+  private val DefaultConfigPath = "system.collectors-defaults.rate"
 
   /**
     * Create a Rate with the following address.  See the documentation for [[colossus.metrics.MetricSystem]] for details on configuration
@@ -81,34 +77,17 @@ object Rate extends CollectorConfigLoader {
   }
   /**
     * Create a Rate with the following address, whose definitions is contained the specified configPath.
+    * See the documentation for [[colossus.metrics.MetricSystem]] for details on configuration
     *
     * @param address    The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
-    * @param configPath The path in the config that this rate's configuration is located.  This is relative to the MetricSystem config
+    * @param configName The path in the config that this rate's configuration is located.  This is relative to the MetricSystem config
     *                   definition.
     * @param ns The namespace to which this Metric is relative.
     * @return
     */
-  def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Rate = {
-    addToNamespace(address, configPath, None)
-  }
-
-  /**
-    * Create a Rate with the following address.  Source the config from the provided Config object,
-    * instead of the MetricNamespace's Config
-    *
-    * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
-    * @param configPath The path to this Rate's configuration within the `externalConfig`.
-    * @param externalConfig  A Config object which is expected to contain all the necessary fields for creating a Rate
-    * @param ns
-    * @return
-    */
-  def apply(address : MetricAddress, configPath : String, externalConfig : Config)(implicit ns : MetricNamespace) : Rate = {
-    addToNamespace(address, configPath, Some(externalConfig))
-  }
-
-  private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Rate = {
+  def apply(address : MetricAddress, configName : String)(implicit ns : MetricNamespace) : Rate = {
     ns.getOrAdd(address){(fullAddress, config) =>
-      val params = resolveConfig(fullAddress, config.config, externalConfig, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val params = resolveConfig(config.config, fullAddress, configName, DefaultConfigPath)
       createRate(fullAddress, params.getBoolean("prune-empty"), params.getBoolean("enabled"), config.intervals)
     }
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -1,5 +1,7 @@
 package colossus.metrics
 
+import com.typesafe.config.Config
+
 import scala.concurrent.duration._
 
 /**
@@ -11,6 +13,7 @@ trait Rate extends Collector{
     * Increment value to this Rate for this specified TagMap
     * A single Rate instance divides values amongst TagMaps, and tracks each one independently
     * When they are collected and reported, all TagMaps will be reported under the same MetricAddress.
+    *
     * @param tags Tags to record with this value
     * @param amount The value to increment the rate
     */
@@ -18,6 +21,7 @@ trait Rate extends Collector{
 
   /**
     * Instruct the collector to not report any values for tag combinations which were previously empty.
+    *
     * @return
     */
   def pruneEmpty : Boolean
@@ -67,6 +71,7 @@ object Rate extends CollectorConfigLoader {
 
   /**
     * Create a Rate with the following address.  See the documentation for [[colossus.metrics.MetricSystem]] for details on configuration
+    *
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param ns The namespace to which this Metric is relative.
     * @return
@@ -76,6 +81,7 @@ object Rate extends CollectorConfigLoader {
   }
   /**
     * Create a Rate with the following address, whose definitions is contained the specified configPath.
+    *
     * @param address    The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param configPath The path in the config that this rate's configuration is located.  This is relative to the MetricSystem config
     *                   definition.
@@ -83,15 +89,35 @@ object Rate extends CollectorConfigLoader {
     * @return
     */
   def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Rate = {
+    addToNamespace(address, configPath, None)
+  }
+
+  /**
+    * Create a Rate with the following address.  Source the config from the provided Config object,
+    * instead of the MetricNamespace's Config
+    *
+    * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
+    * @param configPath The path to this Rate's configuration within the `externalConfig`.
+    * @param externalConfig  A Config object which is expected to contain all the necessary fields for creating a Rate
+    * @param ns
+    * @return
+    */
+  def apply(address : MetricAddress, configPath : String, externalConfig : Config)(implicit ns : MetricNamespace) : Rate = {
+    addToNamespace(address, configPath, Some(externalConfig))
+  }
+
+  private def addToNamespace(address : MetricAddress, configPath : String, externalConfig : Option[Config])(implicit ns : MetricNamespace) : Rate = {
     ns.getOrAdd(address){(fullAddress, config) =>
       val addressPath = fullAddress.pieceString.replace('/','.')
-      val params = resolveConfig(config.config, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
+      val c = externalConfig.getOrElse(config.config)
+      val params = resolveConfig(c, addressPath, s"$ConfigRoot.$configPath", s"$ConfigRoot.$DefaultConfigPath")
       createRate(fullAddress, params.getBoolean("prune-empty"), params.getBoolean("enabled"), config.intervals)
     }
   }
 
   /**
     * Create a new Rate which will be contained by the specified Collection
+    *
     * @param address The MetricAddress of this Rate.  Note, this will be relative to the containing MetricSystem's metricAddress.
     * @param pruneEmpty Instruct the collector to not report any values for tag combinations which were previously empty.
     * @param enabled If this Rate will actually be collected and reported.

--- a/colossus-metrics/src/test/scala/colossus/metrics/CollectionSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CollectionSpec.scala
@@ -7,7 +7,9 @@ class CollectionSpec extends WordSpec with MustMatchers{
 
   "Collection" must {
 
-    implicit val namespace = MetricContext("/", new Collection(CollectorConfig(Seq(1.minute, 1.second))))
+    val collection = Collection.withReferenceConf(Seq(1.minute, 1.second))
+
+    implicit val namespace = MetricContext("/", collection)
 
     "getOrAdd should add a new Collector" in {
       //note, this constructor implicitly adds its constructed object into this collection

--- a/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
@@ -65,7 +65,7 @@ class HistogramSpec extends MetricIntegrationSpec {
 
   "Histogram" must {
     "get tags right" in {
-      implicit val col = MetricContext("/", new Collection(CollectorConfig(List(1.second))))
+      implicit val col = MetricContext("/", Collection.withReferenceConf(Seq(1.second)))
       val addr = MetricAddress.Root / "hist"
       val h = Histogram(addr)
       h.add(10, Map("foo" -> "bar"))
@@ -80,7 +80,7 @@ class HistogramSpec extends MetricIntegrationSpec {
     }
 
     "prune empty values" in {
-      implicit val col = MetricContext("/", new Collection(CollectorConfig(List(1.second))))
+      implicit val col = MetricContext("/", Collection.withReferenceConf(Seq(1.second)))
       val addr = MetricAddress.Root / "hist"
       val h = Histogram(addr, pruneEmpty = true)
       h.add(10, Map("foo" -> "bar"))

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricNamespaceSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricNamespaceSpec.scala
@@ -10,7 +10,7 @@ class MetricNamespaceSpec extends WordSpec with MustMatchers{
 
       import scala.collection.JavaConversions._
       //not using implicits here, just to illustrate the point.
-      val namespace = MetricContext("/", new Collection(CollectorConfig(Seq(1.minute, 1.second))))
+      val namespace = MetricContext("/", Collection.withReferenceConf(Seq(1.minute, 1.second)))
       val subName = namespace / "bar"
 
       //create 2 rates in the parent namespace

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -1,5 +1,6 @@
 package colossus.metrics
 
+import com.typesafe.config.ConfigFactory
 import org.scalatest._
 
 import akka.actor._
@@ -24,12 +25,9 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
 
   "MetricSystem" must {
     "allow multiple systems to start without any conflicts" in {
-      val m1 = MetricSystem(MetricAddress("/sys1"))
-      val m2 = MetricSystem(MetricAddress("/sys2"))
+      val m1 = MetricSystem(MetricAddress("/sys1"), Seq(), false, ConfigFactory.empty())
+      val m2 = MetricSystem(MetricAddress("/sys2"), Seq(), false, ConfigFactory.empty())
       //no exceptions means the test passed
     }
-
-
   }
-
 }

--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -1,7 +1,6 @@
 package colossus
 package testkit
 
-import com.typesafe.config.ConfigFactory
 import core._
 import metrics._
 import service._
@@ -17,7 +16,7 @@ case class FakeWorker(probe: TestProbe, worker: WorkerRef)
 
 object FakeIOSystem {
   def apply()(implicit system: ActorSystem): IOSystem = {
-    new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, ConfigFactory.empty(), (x,y,c) => system.deadLetters)
+    new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, (x,y) => system.deadLetters)
   }
 
   /**
@@ -62,7 +61,7 @@ object FakeIOSystem {
 
   def withManagerProbe()(implicit system: ActorSystem): (IOSystem, TestProbe) = {
     val probe = TestProbe()
-    val sys = new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, ConfigFactory.empty(), (x,y,c) => probe.ref)
+    val sys = new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, (x,y) => probe.ref)
     (sys, probe)
   }
 
@@ -97,7 +96,6 @@ class GenericExecutor extends Actor with CallbackExecution {
     }
   }
 }
-
 
 object CallbackAwait {
 

--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -1,6 +1,7 @@
 package colossus
 package testkit
 
+import com.typesafe.config.ConfigFactory
 import core._
 import metrics._
 import service._
@@ -16,7 +17,7 @@ case class FakeWorker(probe: TestProbe, worker: WorkerRef)
 
 object FakeIOSystem {
   def apply()(implicit system: ActorSystem): IOSystem = {
-    new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, (x,y) => system.deadLetters)
+    new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, ConfigFactory.empty(), (x,y,c) => system.deadLetters)
   }
 
   /**
@@ -61,7 +62,7 @@ object FakeIOSystem {
 
   def withManagerProbe()(implicit system: ActorSystem): (IOSystem, TestProbe) = {
     val probe = TestProbe()
-    val sys = new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, (x,y) => probe.ref)
+    val sys = new IOSystem("FAKE", 0, MetricSystem.deadSystem, system, ConfigFactory.empty(), (x,y,c) => probe.ref)
     (sys, probe)
   }
 

--- a/colossus-tests/src/test/scala/colossus/IOSystemConfigSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/IOSystemConfigSpec.scala
@@ -11,22 +11,22 @@ class IOSystemConfigSpec extends ColossusSpec{
     "load defaults from reference implementation" in {
       val io = IOSystem()
       io.numWorkers mustBe Runtime.getRuntime.availableProcessors()
-      io.name mustBe "io-system"
+      io.name mustBe "iosystem"
       io.metrics.namespace mustBe MetricAddress.Root
-      io.namespace.namespace mustBe MetricAddress("io-system")
+      io.namespace.namespace mustBe MetricAddress("iosystem")
       shutdownIOSystem(io)
     }
 
     "apply user overridden configuration" in {
       val userConfig = """
-                        |colossus.io-system.my-io-system{
+                        |colossus.iosystem{
                         |  num-workers : 2
                         |}
                       """.stripMargin
 
       //to imitate an already loaded configuration
       val c = ConfigFactory.parseString(userConfig).withFallback(ConfigFactory.defaultReference())
-      val io = IOSystem("my-io-system", c)
+      val io = IOSystem("my-io-system", c.getConfig(IOSystem.ConfigRoot))
       io.numWorkers mustBe 2
       io.name mustBe "my-io-system"
       io.namespace.namespace mustBe MetricAddress("/my-io-system")

--- a/colossus-tests/src/test/scala/colossus/IOSystemConfigSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/IOSystemConfigSpec.scala
@@ -7,31 +7,29 @@ import com.typesafe.config.ConfigFactory
 class IOSystemConfigSpec extends ColossusSpec{
 
   "IOSystem creation" must {
+
     "load defaults from reference implementation" in {
       val io = IOSystem()
       io.numWorkers mustBe Runtime.getRuntime.availableProcessors()
-      io.name mustBe "/"
+      io.name mustBe "io-system"
       io.metrics.namespace mustBe MetricAddress.Root
+      io.namespace.namespace mustBe MetricAddress("io-system")
       shutdownIOSystem(io)
     }
 
     "apply user overridden configuration" in {
       val userConfig = """
-                        |my-io-system{
-                        |  name : "/my/path"
-                        |  metrics : {
-                        |    namespace : "/m"
-                        |  }
+                        |colossus.io-system.my-io-system{
+                        |  num-workers : 2
                         |}
                       """.stripMargin
 
       //to imitate an already loaded configuration
       val c = ConfigFactory.parseString(userConfig).withFallback(ConfigFactory.defaultReference())
       val io = IOSystem("my-io-system", c)
-      io.numWorkers mustBe Runtime.getRuntime.availableProcessors()
-      io.metrics.namespace mustBe MetricAddress("/m")
-      io.name mustBe "/my/path"
-      io.namespace.namespace mustBe MetricAddress("/m/my/path")
+      io.numWorkers mustBe 2
+      io.name mustBe "my-io-system"
+      io.namespace.namespace mustBe MetricAddress("/my-io-system")
       shutdownIOSystem(io)
     }
   }

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -56,15 +56,13 @@ class PushPromise {
   def expectSuccess() { assert(isSuccess == true) }
   def expectFailure() {  assert(isFailure == true)}
   def expectCancelled() {  assert(isCancelled == true)}
-
-
 }
 
 trait TestController[I,O] { self: Controller[I,O] with ServerConnectionHandler =>
 
   implicit val namespace = {
     import metrics._
-    MetricContext("/", new Collection(CollectorConfig(List())))
+    MetricContext("/", Collection.withReferenceConf(Seq()))
   }
 
   var _received : Seq[I] = Seq()
@@ -90,10 +88,7 @@ trait TestController[I,O] { self: Controller[I,O] with ServerConnectionHandler =
     p.pushed = push(message)(p.func)
     p
   }
-
 }
-
-
 
 object TestController {
   import RawProtocol.RawCodec

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -1,0 +1,80 @@
+package colossus.core
+
+import colossus.EchoHandler
+import colossus.metrics.MetricAddress
+import colossus.testkit.ColossusSpec
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.duration._
+
+class ServerConfigLoadingSpec  extends ColossusSpec {
+
+  "Server configuration loading" should {
+    "load defaults" in {
+      withIOSystem{ implicit io =>
+        val s = Server.basic()(context => new EchoHandler(context))
+        waitForServer(s)
+        s.name mustBe MetricAddress.Root
+        val settings = s.config.settings
+        settings.bindingAttemptDuration mustBe PollingDuration(200.milliseconds, None)
+        settings.delegatorCreationDuration mustBe PollingDuration(500.milliseconds, None)
+        settings.highWatermarkPercentage mustBe 0.85
+        settings.lowWatermarkPercentage mustBe 0.75
+        settings.maxConnections mustBe 1000
+        settings.maxIdleTime mustBe Duration.Inf
+        settings.port mustBe 9876
+        settings.shutdownTimeout mustBe 100.milliseconds
+        settings.tcpBacklogSize mustBe None
+      }
+    }
+
+    "load user overrides" in {
+      val userOverrides =
+        """{
+          | my-server{
+          |   name = "mine"
+          |    port : 9888
+          |    max-connections : 1000
+          |    max-idle-time : "1 second"
+          |    tcp-backlog-size : 100
+          |    shutdown-timeout : "2 seconds"
+          | }
+          |}
+        """.stripMargin
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      withIOSystem{ implicit io =>
+        val s = Server.basic("my-server", c)(context => new EchoHandler(context))
+        waitForServer(s)
+        s.name mustBe MetricAddress("mine")
+        val settings = s.config.settings
+        settings.bindingAttemptDuration mustBe PollingDuration(200.milliseconds, None)
+        settings.delegatorCreationDuration mustBe PollingDuration(500.milliseconds, None)
+        settings.highWatermarkPercentage mustBe 0.85
+        settings.lowWatermarkPercentage mustBe 0.75
+        settings.maxConnections mustBe 1000
+        settings.maxIdleTime mustBe 1.second
+        settings.port mustBe 9888
+        settings.shutdownTimeout mustBe 2.seconds
+        settings.tcpBacklogSize mustBe Some(100)
+      }
+    }
+
+    "quick config" in {
+      withIOSystem{ implicit io =>
+        val s = Server.basic("quick-server", 8989)(context => new EchoHandler(context))
+        waitForServer(s)
+        s.name mustBe MetricAddress("quick-server")
+        val settings = s.config.settings
+        settings.bindingAttemptDuration mustBe PollingDuration(200.milliseconds, None)
+        settings.delegatorCreationDuration mustBe PollingDuration(500.milliseconds, None)
+        settings.highWatermarkPercentage mustBe 0.85
+        settings.lowWatermarkPercentage mustBe 0.75
+        settings.maxConnections mustBe 1000
+        settings.maxIdleTime mustBe Duration.Inf
+        settings.port mustBe 8989
+        settings.shutdownTimeout mustBe 100.milliseconds
+        settings.tcpBacklogSize mustBe None
+      }
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -76,5 +76,13 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         settings.tcpBacklogSize mustBe None
       }
     }
+    "not explode if there is no 'metrics' configuration" in {
+      withIOSystem{ implicit io =>
+        //this loads the entire config, but the this constructor wants a Config which is pointing at a Server configuration
+        val s = Server.basic("my-server", ServerSettings(8989), ConfigFactory.load())(context => new EchoHandler(context))
+        waitForServer(s)
+        //no explosions, means we are good
+      }
+    }
   }
 }

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -30,7 +30,7 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
 
     "load user overrides" in {
       val userOverrides =
-        """colossus.server.my-server{
+        """colossus.server{
           |    port : 9888
           |    max-connections : 1000
           |    max-idle-time : "1 second"
@@ -40,7 +40,7 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         """.stripMargin
       val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
       withIOSystem{ implicit io =>
-        val s = Server.basic("my-server", c)(context => new EchoHandler(context))
+        val s = Server.basic("my-server", c.getConfig(Server.ConfigRoot))(context => new EchoHandler(context))
         waitForServer(s)
         s.name mustBe MetricAddress("my-server")
         val settings = s.config.settings

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -1,11 +1,8 @@
 colossus{
 
-  io-system {
-    #If num-workers is omitted, it will default to the CPU core count on the host machine
-    #num-workers : 4
-    name : "/"
-    metrics : ${colossus.metrics}
-    metrics : {
+  defaults{
+
+    metrics {
       worker-event-loops : {
         enabled : true
         prune-empty : false
@@ -17,43 +14,46 @@ colossus{
         enabled : true
         prune-empty : false
       }
+      server-connections {
+        enabled : true
+      }
+      server-refused-connections {
+        enabled : true
+        prune-empty : false
+      }
+      server-connects {
+        enabled : true
+        prune-empty : false
+      }
+      server-closed {
+        enabled : true
+        prune-empty : false
+      }
+      server-highwaters {
+        enabled : true
+        prune-empty : false
+      }
     }
-  }
 
-  server {
-    name = "/"
-    port : 9876
-    max-connections : 1000
-    max-idle-time : "Inf"
-    low-watermark-percentage : 0.75
-    high-watermark-percentage : 0.85
-    highwater-max-idle-time : "100 milliseconds"
-    #tcp-backlog-size : 100  #optional
-    binding-attempt-interval : "200 milliseconds"
-    #binding-attempt-max-tries : 3 #optional
-    delegator-creation-interval : "500 milliseconds"
-   # delegator-creation-max-tries: 3 #optional
-    shutdown-timeout : "100 milliseconds"
-    metrics {
-      connections {
-        enabled : true
-      }
-      refused-connections {
-        enabled : true
-        prune-empty : false
-      }
-      connects {
-        enabled : true
-        prune-empty : false
-      }
-      closed {
-        enabled : true
-        prune-empty : false
-      }
-      highwaters {
-        enabled : true
-        prune-empty : false
-      }
+    io-system {
+      #If num-workers is omitted, it will default to the CPU core count on the host machine
+      #num-workers : 4
+    }
+
+    server {
+      name = "/"
+      port : 9876
+      max-connections : 1000
+      max-idle-time : "Inf"
+      low-watermark-percentage : 0.75
+      high-watermark-percentage : 0.85
+      highwater-max-idle-time : "100 milliseconds"
+      #tcp-backlog-size : 100  #optional
+      binding-attempt-interval : "200 milliseconds"
+      #binding-attempt-max-tries : 3 #optional
+      delegator-creation-interval : "500 milliseconds"
+      # delegator-creation-max-tries: 3 #optional
+      shutdown-timeout : "100 milliseconds"
     }
   }
 

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -1,59 +1,56 @@
 colossus{
 
-  defaults{
+  iosystem {
+    #If num-workers is omitted, it will default to the CPU core count on the host machine
+    #num-workers : 4
+  }
 
-    metrics {
-      worker-event-loops : {
-        enabled : true
-        prune-empty : false
-      }
-      worker-connections : {
-        enabled : true
-      }
-      worker-rejected-connections : {
-        enabled : true
-        prune-empty : false
-      }
-      server-connections {
-        enabled : true
-      }
-      server-refused-connections {
-        enabled : true
-        prune-empty : false
-      }
-      server-connects {
-        enabled : true
-        prune-empty : false
-      }
-      server-closed {
-        enabled : true
-        prune-empty : false
-      }
-      server-highwaters {
-        enabled : true
-        prune-empty : false
-      }
+  server {
+    name = "/"
+    port : 9876
+    max-connections : 1000
+    max-idle-time : "Inf"
+    low-watermark-percentage : 0.75
+    high-watermark-percentage : 0.85
+    highwater-max-idle-time : "100 milliseconds"
+    #tcp-backlog-size : 100  #optional
+    binding-attempt-interval : "200 milliseconds"
+    #binding-attempt-max-tries : 3 #optional
+    delegator-creation-interval : "500 milliseconds"
+    # delegator-creation-max-tries: 3 #optional
+    shutdown-timeout : "100 milliseconds"
+  }
+
+  metrics {
+    worker-event-loops : {
+      enabled : true
+      prune-empty : false
     }
-
-    io-system {
-      #If num-workers is omitted, it will default to the CPU core count on the host machine
-      #num-workers : 4
+    worker-connections : {
+      enabled : true
     }
-
-    server {
-      name = "/"
-      port : 9876
-      max-connections : 1000
-      max-idle-time : "Inf"
-      low-watermark-percentage : 0.75
-      high-watermark-percentage : 0.85
-      highwater-max-idle-time : "100 milliseconds"
-      #tcp-backlog-size : 100  #optional
-      binding-attempt-interval : "200 milliseconds"
-      #binding-attempt-max-tries : 3 #optional
-      delegator-creation-interval : "500 milliseconds"
-      # delegator-creation-max-tries: 3 #optional
-      shutdown-timeout : "100 milliseconds"
+    worker-rejected-connections : {
+      enabled : true
+      prune-empty : false
+    }
+    server-connections {
+      enabled : true
+    }
+    server-refused-connections {
+      enabled : true
+      prune-empty : false
+    }
+    server-connects {
+      enabled : true
+      prune-empty : false
+    }
+    server-closed {
+      enabled : true
+      prune-empty : false
+    }
+    server-highwaters {
+      enabled : true
+      prune-empty : false
     }
   }
 

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -5,6 +5,19 @@ colossus{
     #num-workers : 4
     name : "/"
     metrics : ${colossus.metrics}
+    metrics : {
+      worker-event-loops : {
+        enabled : true
+        prune-empty : false
+      }
+      worker-connections : {
+        enabled : true
+      }
+      worker-rejected-connections : {
+        enabled : true
+        prune-empty : false
+      }
+    }
   }
 
   server {

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -8,17 +8,18 @@ colossus{
   }
 
   server {
+    name = "/"
     port : 9876
     max-connections : 1000
-    max-idle-time : "INFINITY"
+    max-idle-time : "Inf"
     low-watermark-percentage : 0.75
     high-watermark-percentage : 0.85
     highwater-max-idle-time : "100 milliseconds"
-    tcp-backlog-size : -1 #placeholder, this is an option
+    #tcp-backlog-size : 100  #optional
     binding-attempt-interval : "200 milliseconds"
-    binding-attempt-max-duration : "INFINITY"
+    #binding-attempt-max-tries : 3 #optional
     delegator-creation-interval : "500 milliseconds"
-    delegator-creation-max-duration : "INFINITY"
+   # delegator-creation-max-tries: 3 #optional
     shutdown-timeout : "100 milliseconds"
     metrics {
       connections {

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -25,7 +25,7 @@ colossus{
       connections {
         enabled : true
       }
-      refused {
+      refused-connections {
         enabled : true
         prune-empty : false
       }

--- a/colossus/src/main/scala/colossus/core/IOSystem.scala
+++ b/colossus/src/main/scala/colossus/core/IOSystem.scala
@@ -17,38 +17,35 @@ import scala.concurrent.{ExecutionContext, Future}
 
 object IOSystem {
 
-  val ConfigRoot = "colossus.defaults.io-system"
+  val ConfigRoot = "colossus.iosystem"
 
   /**
-    * Create a new IOSystem, using only the defaults provided by the corresponding "colossus.defaults.io-system" config path.
+    * Create a new IOSystem, using only the defaults provided by the corresponding `colossus.iosystem` config path.
     * A Config object will be created via {{{ConfigFactory.load()}}}
     *
     * @param sys
     * @return
     */
   def apply()(implicit sys : ActorSystem) : IOSystem = {
-    apply("io-system")
+    apply("iosystem")
   }
 
   /**
     * Create a new IOSystem.
     *
-    * Configuration will look first in `colossus.io-system.$name`, and fallback on `colossus.defaults.io-system`
     * A Config object will be created via {{{ConfigFactory.load()}}}
     *
     * @param name  Name of the IOSystem to create.
-    * @param config The Config source to query, defaults to {{{ConfigFactory.load()}}}
+    * @param ioConfig The Config source in the shape of `colossus.iosystem`
     * @param sys
     * @return
     */
-  def apply(name : String, config : Config = ConfigFactory.load())(implicit sys : ActorSystem) : IOSystem = {
+  def apply(name : String, ioConfig : Config = ConfigFactory.load().getConfig(ConfigRoot))(implicit sys : ActorSystem) : IOSystem = {
 
     import colossus.metrics.ConfigHelpers._
 
-    val ioConfig = config.withFallbacks(s"colossus.io-system.$name", ConfigRoot)
     val workerCount : Option[Int] = ioConfig.getIntOption("num-workers")
-    val msConfig = config.withFallbacks("colossus.defaults.metrics", MetricSystem.ConfigRoot)
-    val ms = MetricSystem(msConfig)
+    val ms = MetricSystem()
     apply(name, workerCount, ms)
   }
 

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -217,8 +217,14 @@ private[colossus] class Server(io: IOSystem, serverConfig: ServerConfig,
   //see if there is local configuration for metrics, if there is, overlay that on the iosystem's metrics config
   //TODO: cache config
   val metricsConfig = if(config.hasPath("metrics")){
-    val serverMetrics = config.getConfig("metrics")
-    serverMetrics.withFallback(io.metrics.config)
+    //TODO : rethink this
+    /*
+    This is a bit tricky.  MetricSystem, when it is created has a modified version of the entire Config object.  The modification
+    being that it overwrites the 'colossus.metrics' path with generated config(userOverrides + MS reference defaults).
+    We want to now overlay the Server'smetrics definitions on top of that, and use that as the Config source
+     */
+    val serverMetrics = config.getObject("metrics").withFallback(io.metrics.config.getConfig(MetricSystem.ConfigRoot))
+    io.metrics.config.withValue(MetricSystem.ConfigRoot, serverMetrics)
   }else{
     log.debug(s"Could not find the 'metrics' path in supplied config, defaulting to the IOSystem's MetricSystem config")
     io.metrics.config

--- a/colossus/src/main/scala/colossus/core/ServerDSL.scala
+++ b/colossus/src/main/scala/colossus/core/ServerDSL.scala
@@ -170,7 +170,7 @@ trait ServerDSL {
     val userPathObject = config.getObject(configPath)
     val serverConfig = userPathObject.withFallback(config.getObject(ConfigRoot)).toConfig
     val name = serverConfig.getString("name")
-    basic(name, ServerSettings.extract(serverConfig), config)(handlerFactory)
+    basic(name, ServerSettings.extract(serverConfig), serverConfig)(handlerFactory)
   }
 
   /**

--- a/colossus/src/main/scala/colossus/core/ServerDSL.scala
+++ b/colossus/src/main/scala/colossus/core/ServerDSL.scala
@@ -5,6 +5,8 @@ object ServerDSL {
   type Receive = PartialFunction[Any, Unit]
 }
 import ServerDSL._
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
 
 /**
  * An instance of this is handed to every new server connection handler
@@ -37,30 +39,165 @@ class DSLDelegator(server : ServerRef, _worker : WorkerRef, initializer: Initial
 //this is mixed in by Server
 trait ServerDSL {
 
+  val ConfigRoot = "colossus.server"
+
+  /**
+    * Create a new Server, using only the defaults provided by the corresponding "colossus.server" config path.
+    * A Config object will be created via {{{ConfigFactory.load()}}}
+    *
+    * @param initializer
+    * @param io
+    * @return
+    */
+  def start()(initializer: WorkerRef => Initializer)(implicit io: IOSystem) : ServerRef = {
+    start(ConfigRoot)(initializer)
+  }
+
+  /**
+    * Create a new Server using the supplied configPath.  This configPath will be overlaid on top of the default "colossus.server"
+    * config path.
+    * A Config object will be created via {{{ConfigFactory.load()}}}
+    *
+    * @param configPath The path to the configuration.
+    * @param initializer
+    * @param io
+    * @return
+    */
+  def start(configPath : String)(initializer: WorkerRef => Initializer)(implicit io: IOSystem) : ServerRef = {
+    start(configPath, ConfigFactory.load())(initializer)
+  }
+
+  /**
+    * Create a new Server by loading its config from the specified configPath.
+    * This configPath will be overlaid on top of the default "colossus.server" config path.
+    *
+    * @param configPath The path to the configuration.
+    * @param config The Config source to query
+    * @param initializer
+    * @param io
+    * @return
+    */
+  def start(configPath : String, config : Config)(initializer: WorkerRef => Initializer)(implicit io: IOSystem) : ServerRef = {
+    val userPathObject = config.getObject(configPath)
+    val serverConfig = userPathObject.withFallback(config.getObject(ConfigRoot)).toConfig
+    val name = serverConfig.getString("name")
+    start(name, ServerSettings.extract(serverConfig))(initializer)
+  }
+
+  /**
+    * Convenience function for starting a server using the specified name and port.  This will be overlaid on top of the default
+    * "colossus.server" configuration path.
+    *
+    * @param name Name of this Server. Name is also the MetricAddress relative to the containing IOSystem's MetricNamespace
+    * @param port Port to run on
+    * @param initializer
+    * @param io
+    * @return
+    */
+  def start(name: String, port: Int)(initializer: WorkerRef => Initializer)(implicit io: IOSystem): ServerRef = {
+
+    val user =
+      s"""
+        |user-settings{
+        |  name : "$name"
+        |  port : $port
+        |}
+      """.stripMargin
+    val userConfig = ConfigFactory.parseString(user)
+
+    start("user-settings",userConfig.withFallback(ConfigFactory.load()))(initializer)
+  }
+
+  /**
+    * Create a new Server.
+    *
+    * @param name Name of this Server. Name is also the MetricAddress relative to the containing IOSystem's MetricNamespace.
+    * @param settings Settings for this Server.
+    * @param initializer
+    * @param io
+    * @return
+    */
   def start(name: String, settings: ServerSettings)(initializer: WorkerRef => Initializer)(implicit io: IOSystem) : ServerRef = {
     val serverConfig = ServerConfig(
       name = name,
-      settings = settings,
-      delegatorFactory = (s,w) => new DSLDelegator(s,w, initializer(w))
+      settings = settings, delegatorFactory = (s,w) => new DSLDelegator(s,w, initializer(w))
     )
     Server(serverConfig)
 
   }
 
-  def start(name: String, port: Int)(initializer: WorkerRef => Initializer)(implicit io: IOSystem): ServerRef = start(name, ServerSettings(port))(initializer)
+  /**
+    * Create a new Server, using only the defaults provided by the corresponding "colossus.server" config path.
+    * A Config object will be created via {{{ConfigFactory.load()}}}
+    *
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
+  def basic()(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem) : ServerRef = {
+    basic(ConfigRoot)(handlerFactory)
+  }
 
+  /**
+    * Create a new Server using the supplied configPath.  This configPath will be overlaid on top of the default "colossus.server"
+    * config path.
+    * A Config object will be created via {{{ConfigFactory.load()}}}
+    *
+    * @param configPath The path to the configuration.
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
+  def basic(configPath : String)(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem) : ServerRef = {
+    basic(configPath, ConfigFactory.load())(handlerFactory)
+  }
 
+  /**
+    * Create a new Server by loading its config from the specified configPath.
+    * This configPath will be overlaid on top of the default "colossus.server" config path.
+    *
+    * @param configPath The path to the configuration.
+    * @param config The Config source to query
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
+  def basic(configPath : String, config : Config)(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem) : ServerRef = {
+    val userPathObject = config.getObject(configPath)
+    val serverConfig = userPathObject.withFallback(config.getObject(ConfigRoot)).toConfig
+    val name = serverConfig.getString("name")
+    basic(name, ServerSettings.extract(serverConfig))(handlerFactory)
+  }
+
+  /**
+    * Convenience function for starting a server using the specified name and port.  This will be overlaid on top of the default
+    * "colossus.server" configuration path.
+    *
+    * @param name Name of this Server. Name is also the MetricAddress relative to the containing IOSystem's MetricNamespace
+    * @param port Port to run on
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
   def basic(name: String, port: Int)(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem): ServerRef = {
     start(name, port){worker => new Initializer(worker){
       def onConnect = handlerFactory
     }}
   }
 
+  /**
+    * Create a new Server.
+    *
+    * @param name Name of this Server. Name is also the MetricAddress relative to the containing IOSystem's MetricNamespace
+    * @param settings Settings for this Server.
+    * @param handlerFactory
+    * @param io
+    * @return
+    */
   def basic(name: String, settings: ServerSettings)(handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem): ServerRef = {
     start(name, settings)(worker => new Initializer(worker) {
       def onConnect = handlerFactory
     })
   }
-
 }
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -3,7 +3,6 @@ package core
 
 import akka.actor._
 import akka.event.LoggingAdapter
-import com.typesafe.config.Config
 import metrics._
 import service.CallbackExecution
 
@@ -25,7 +24,6 @@ import scala.util.control.NonFatal
  */
 case class WorkerConfig(
   io: IOSystem,
-  ioConfig : Config,
   workerId: Int
 )
 
@@ -157,7 +155,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
 
   private val workerIdTag = Map("worker" -> (io.name + "-" + workerId.toString))
 
-  implicit val ns = io.namespace.withConfigOverrides(ioConfig)
+  implicit val ns = io.namespace
   val eventLoops              = Rate("worker/event_loops", "worker-event-loops")
   val numConnections          = Counter("worker/connections", "worker-connections")
   val rejectedConnections     = Rate("worker/rejected_connections", "worker-rejected-connections")

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -3,6 +3,7 @@ package core
 
 import akka.actor._
 import akka.event.LoggingAdapter
+import com.typesafe.config.Config
 import metrics._
 import service.CallbackExecution
 
@@ -24,14 +25,15 @@ import scala.util.control.NonFatal
  */
 case class WorkerConfig(
   io: IOSystem,
+  ioConfig : Config,
   workerId: Int
 )
 
 /**
  * This is a Worker's public interface.  This is what can be used to communicate with a Worker, as it
  * wraps the Worker's ActorRef, as well as providing some additional information which can be made public.
+ *
  * @param id The Worker's id.
- * @param metrics The Metrics associated with this Worker
  * @param worker The ActorRef of the Worker
  * @param system The IOSystem to which this Worker belongs
  */
@@ -140,7 +142,6 @@ class WorkerItemManager(worker: WorkerRef, log: LoggingAdapter) {
 }
 
 
-
 private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLogging with CallbackExecution {
   import Server._
   import Worker._
@@ -156,10 +157,10 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
 
   private val workerIdTag = Map("worker" -> (io.name + "-" + workerId.toString))
 
-  implicit val ns = io.namespace
-  val eventLoops              = Rate("worker/event_loops")
-  val numConnections          = Counter("worker/connections")
-  val rejectedConnections     = Rate("worker/rejected_connections")
+  implicit val ns = io.namespace.withConfigOverrides(ioConfig)
+  val eventLoops              = Rate("worker/event_loops", "worker-event-loops")
+  val numConnections          = Counter("worker/connections", "worker-connections")
+  val rejectedConnections     = Rate("worker/rejected_connections", "worker-rejected-connections")
 
   val selector: Selector = Selector.open()
   val buffer = ByteBuffer.allocateDirect(1024 * 128)
@@ -573,7 +574,8 @@ object Worker {
   case class ConnectionSummary(infos: Seq[ConnectionSnapshot])
 
   /** Sent from Servers
-   * @param sc the underlying socketchannel of the connection
+    *
+    * @param sc the underlying socketchannel of the connection
    * @param attempt used when a worker refuses a connection, which can happen if a worker has just restarted and hasn't yet re-registered servers
    */
   private[core] case class NewConnection(sc: SocketChannel, attempt: Int = 1)

--- a/colossus/src/main/scala/colossus/core/WorkerManager.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerManager.scala
@@ -23,9 +23,8 @@ import scala.util.{Failure, Success}
  *
  * @param workerAgent WorkerRefs that this WorkerManager manages
  * @param ioSystem Containing IOSystem
- * @param ioConfig IOSystem config
  */
-private[colossus] class WorkerManager(workerAgent: Agent[IndexedSeq[WorkerRef]], ioSystem: IOSystem, ioConfig : Config)
+private[colossus] class WorkerManager(workerAgent: Agent[IndexedSeq[WorkerRef]], ioSystem: IOSystem)
 extends Actor with ActorLogging with Stash {
   import WorkerManager._
   import akka.actor.OneForOneStrategy
@@ -48,8 +47,7 @@ extends Actor with ActorLogging with Stash {
   val workers = (1 to numWorkers).map{i =>
     val workerConfig = WorkerConfig(
       workerId = i,
-      io = ioSystem,
-      ioConfig = ioConfig
+      io = ioSystem
     )
     val worker = context.actorOf(Props(classOf[Worker],workerConfig ).withDispatcher("server-dispatcher"), name = s"worker-$i")
     context.watch(worker)

--- a/colossus/src/main/scala/colossus/core/WorkerManager.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerManager.scala
@@ -6,8 +6,7 @@ import akka.agent.Agent
 import akka.pattern.ask
 import akka.routing.RoundRobinGroup
 import akka.util.Timeout
-
-import metrics.MetricSystem
+import com.typesafe.config.Config
 
 import java.net.InetSocketAddress
 
@@ -22,9 +21,11 @@ import scala.util.{Failure, Success}
  * A WorkerManager is just that, an Actor who is responsible for managing all of the Worker Actors in an IOSystem.
  * It is responsible for creating, killing, restarting, relaying messages, etc.
  *
- * @param config configuration parameters
+ * @param workerAgent WorkerRefs that this WorkerManager manages
+ * @param ioSystem Containing IOSystem
+ * @param ioConfig IOSystem config
  */
-private[colossus] class WorkerManager(workerAgent: Agent[IndexedSeq[WorkerRef]], ioSystem: IOSystem) 
+private[colossus] class WorkerManager(workerAgent: Agent[IndexedSeq[WorkerRef]], ioSystem: IOSystem, ioConfig : Config)
 extends Actor with ActorLogging with Stash {
   import WorkerManager._
   import akka.actor.OneForOneStrategy
@@ -47,7 +48,8 @@ extends Actor with ActorLogging with Stash {
   val workers = (1 to numWorkers).map{i =>
     val workerConfig = WorkerConfig(
       workerId = i,
-      io = ioSystem
+      io = ioSystem,
+      ioConfig = ioConfig
     )
     val worker = context.actorOf(Props(classOf[Worker],workerConfig ).withDispatcher("server-dispatcher"), name = s"worker-$i")
     context.watch(worker)

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -57,13 +57,7 @@ package object http extends HttpBodyEncoders {
       implicit val httpClientDefaults = new ClientDefaults
 
     }
-  
-
   }
-
-
-
-
 
   class ReturnCodeTagDecorator[C <: BaseHttp] extends TagDecorator[C#Input, C#Output] {
     override def tagsFor(request: C#Input, response: C#Output): TagMap = {


### PR DESCRIPTION
Take 2.

In this PR:


##  MetricSystem changes
MetricSystem's configuration still comes from `colossus.metrics` however, this definition has been updated so that values that configure how the `MetricSystem` behaves are now moved into `colossus.metrics.system`.  Any value residing within `colossus.metrics` is expected to be a `Metric` definition.

Removed the ability for user overrides to come from a location other than `colossus.metrics`.  This just helps simplify a lot of things.  If a user wants to override behavior, or add definitions to a `MetricSystem`, they will need to just override `colossus.metrics` in their application.conf.  Note, that the `MetricSystem` still has a constructor which takes in a `Config` object, which should allow users to load their Config however they want.

## IOSystem changes
IOSystem configuration defaults now come from `colossus.defaults.io-system`.  Users can apply overrides by putting in their application.conf:
```javascript
colossus.io-system.myIOSystem{
...
}
```
This definition then gets applied on top of the reference defaults.

IOSystem's constructors have also been simplified and reduced a bit.

Worker metrics are now configurable as well.

## Server changes

Servers now too are configurable via typesafe config.  It works exactly like IOSystem, with regards to how and where defaults are stored, and user overrides applied.  The only difference being that defaults are stored in `colossus.defaults.server` and user overrides are expected to be in `colossus.server.$serverName`

## Colossus' Metric definitions.

Colossus components have a lot of metrics, which we'd like to open up and make configurable.  One of the biggest problems we had in the last attempt, was configuring these metrics.  It was tricky as metrics are usually not created at the same time or place of its containing component(ie: IOSystem, Server).  This was causing some pain and hoop jumping in order to bubble down configuration to these call sites.

This PR, scrapped all of that.  Instead, we are now going define ALL metrics that Colossus components collect in `colossus.defaults.metrics`.  The `IOSystem`, at time of its creation, will take this definition, and overlay on on the `colossus.metrics` definition, and use that merged configuration to then create its `MetricSystem`.  This `MetricSystem` is then the system used throughout Colossus to create metrics, and as such, it should contain all of the metrics' definitions.

## Creating / overriding Metric definitions

given the following snippet:
```scala
//for brevity
implicit val ns = MetricNamespace("/prefix")
val rateA = Rate("myrate")
val rateB = Rate("myOtherRate, "pruned")
```
RateA's configuration sources are:
- `colossus.metrics.prefix.myrate`  -
- `colossus.metrics.system.collectors.defaults.rate` - Note overriding this overrides ALL rate defaults.

RateB's configuration sources are:
- `colossus.metrics.prefix.myOtherRate`
- `colossus.metrics.pruned` - This is a metric definition that can be shared amongst different metrics.  Overriding this overrides it for all users of this definition.
- `colossus.metrics.system.collectors.defaults.rate` - Note overriding this overrides ALL rate defaults.

### Overriding Colossus' metrics

There are 2 ways to override Colossus' metrics:

by address:
`colossus.metrics.$iosystem.worker.connections` - where $ioSystem is the name of a created IOSystem.

`colossus.defaults.metrics.worker-connections` - Overriding the default will override it for all metric instances (ie if there are multiple IOSystems)

## /etc   (might change in this PR)

The metric namespace hierarchy that existed between `MetricSystem`, `IOSystem` and `Server` has changed. `MetricSystem` has a global namespace(defaulted to `/` which is applied to ALL metrics created by it(do we still want this?)  However, IOSystem does not stack its name on top of Server metrics anymore.  `MetricNamespace`, while still used, could be removed, but I think it still has a purpose(though we are not using its `/` function to create subspaces anymore).



