### PR TITLE
making error and errorHander lazy vals to avoid init NPE's

### DIFF
--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -96,8 +96,8 @@ extends ServiceServer[C#Input, C#Output](codec, config, srv) {
     throw new ReceiveException("No sender")
   }
   
-  private val handler: PartialHandler[C] = handle orElse unhandled
-  private val errorHandler: ErrorHandler[C] = onError orElse unhandledError
+  private lazy val handler: PartialHandler[C] = handle orElse unhandled
+  private lazy val errorHandler: ErrorHandler[C] = onError orElse unhandledError
 
   def receivedMessage(message: Any, sender: ActorRef) {
     currentSender = Some(sender)


### PR DESCRIPTION
Fixes #378 . This will solve any silly initialization errors that can arise when extending this class and using vals for/in handlers or error handlers. I did some benchmarking and there was no difference in performance whatsoever.