### PR TITLE
Connection handler config

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -31,17 +31,15 @@ object BenchmarkService {
       tcpBacklogSize = Some(1024)
     )
 
-    val serviceConfig = ServiceConfig(
-      requestMetrics = false
-    )
+    val serviceConfig = ServiceConfig.Default.copy(requestMetrics = false)
 
     Server.start("benchmark", serverConfig) { new Initializer(_) {
 
       val dateHeader = new DateHeader
       val headers = HttpHeaders(serverHeader, dateHeader)
 
-      def onConnect = ctx => new Service[Http](serviceConfig, ctx){ 
-        def handle = { 
+      def onConnect = ctx => new Service[Http](serviceConfig, ctx){
+        def handle = {
           //case req => req.ok(plaintext, headers)
           case req if (req.head.url == "/plaintext")  => req.ok(plaintext, headers)
           //case req if (req.head.url == "/json")       => req.ok(json, headers)

--- a/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
@@ -17,9 +17,9 @@ import colossus.controller.IteratorGenerator
 
 object HttpExample {
 
-  class HttpExampleService(redis: RedisClient[Callback], context: ServerContext) extends HttpService(ServiceConfig(), context){
+  class HttpExampleService(redis: RedisClient[Callback], context: ServerContext) extends HttpService(ServiceConfig.Default, context){
     
-    def invalidReply(reply: Reply) = s"Invalid reply from redis $reply"    
+    def invalidReply(reply: Reply) = s"Invalid reply from redis $reply"
 
     def handle = {
       case req @ Get on Root => req.ok("Hello World!")

--- a/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
@@ -2,12 +2,12 @@ package colossus
 package controller
 
 import akka.util.ByteString
-import colossus.parsing.ParseException
+import colossus.core._
+import colossus.parsing.DataSize._
 import colossus.testkit._
-import core._
 
-import scala.util.{Try, Failure, Success}
 import scala.concurrent.duration._
+import scala.util.Success
 
 class InputControllerSpec extends ColossusSpec with CallbackMatchers{
   
@@ -65,7 +65,7 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers{
     
     "reject data above the size limit" in {
       val input = ByteString("hello")
-      val config = ControllerConfig(4, 50.milliseconds, 2L)
+      val config = ControllerConfig(4, 50.milliseconds, 2.bytes)
       val con = static(config)
       con.typedHandler.receivedData(DataBuffer(input))
       con.typedHandler.received.isEmpty must equal(true)

--- a/colossus-tests/src/test/scala/colossus/core/DataSizeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/DataSizeSpec.scala
@@ -1,0 +1,39 @@
+package colossus.core
+
+import colossus.parsing.{InvalidDataSizeException, DataSize}
+import org.scalatest.{MustMatchers, WordSpec}
+
+class DataSizeSpec extends WordSpec with MustMatchers{
+
+  "Datasize" must {
+    "be created from a string" in {
+
+      val sizes : Map[String, DataSize] = Map(
+          "1 B"->DataSize(1),
+          "1 KB"-> DataSize(1024),
+          "1 MB" -> DataSize(1024*1024),
+          "2 b" -> DataSize(2),
+          "2 Kb" -> DataSize(2 * 1024),
+          "2 mB" -> DataSize(1024*1024*2))
+
+      sizes.foreach{ case (k, v) => DataSize(k) mustBe v }
+
+
+    }
+    "throw an InvalidDataSize Exception if the creation string is invalid" in {
+      val badSizes = Seq("-1 B", "1", "KB")
+      badSizes foreach { x =>
+        intercept[InvalidDataSizeException]{
+          DataSize(x)
+        }
+      }
+    }
+
+    "implicits should work" in {
+      import colossus.parsing.DataSize._
+      1.MB mustBe DataSize("1 MB")
+      1.KB mustBe DataSize("1 KB")
+      1.B mustBe DataSize("1 B")
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/core/DataSizeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/DataSizeSpec.scala
@@ -31,9 +31,8 @@ class DataSizeSpec extends WordSpec with MustMatchers{
 
     "implicits should work" in {
       import colossus.parsing.DataSize._
-      1.MB mustBe DataSize("1 MB")
-      1.KB mustBe DataSize("1 KB")
-      1.B mustBe DataSize("1 B")
+      1L.MB mustBe DataSize("1 MB")
+      1L.KB mustBe DataSize("1 KB")
     }
   }
 }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceConfigLoadingSpec.scala
@@ -1,0 +1,21 @@
+package colossus.service
+
+import colossus.parsing.DataSize._
+import org.scalatest.{WordSpec, MustMatchers}
+
+import scala.concurrent.duration.Duration
+
+class ServiceConfigLoadingSpec extends WordSpec with MustMatchers{
+
+  "Service configuration loading" should {
+    "load defaults" in {
+      val config = ServiceConfig.Default
+      config.logErrors mustBe true
+      config.maxRequestSize mustBe 1.MB
+      config.requestBufferSize mustBe 100
+      config.requestMetrics mustBe true
+      config.requestTimeout mustBe Duration.Inf
+    }
+  }
+
+}

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -95,7 +95,7 @@ colossus{
       sample-rate : 0.50
       prune-empty : false
     }
-    connection-concurrent_requests {
+    connection-handler-concurrent-requests {
       enabled : true
     }
   }

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -35,6 +35,13 @@ colossus{
       }
     }
     shutdown-timeout : "100 milliseconds"
+    connection-handler{
+      request-timeout : "Inf"
+      request-buffer-size : 100
+      log-errors : true
+      request-metrics : true
+      max-request-size : "1 MB"
+    }
   }
 
   metrics {
@@ -68,38 +75,28 @@ colossus{
       enabled : true
       prune-empty : false
     }
-  }
-
-  service-server {
-    request-timeout : "INFINITY"
-    request-buffer-size : 100
-    log-errors : true
-    request-metrics : true
-    metrics : {
-      requests {
-        enabled : true
-        prune-empty : false
-
-      }
-      latency {
-        enabled : true
-        percentiles : [0.75, 0.9, 0.99, 0.999, 0.9999]
-        sample-rate : 0.25
-        prune-empty : false
-      }
-      errors{
-        enabled : true
-        prune-empty : false
-      }
-      requests_per_connection{
-        enabled : true
-        percentiles: [0.5, 0.75, 0.99]
-        sample-rate : 0.50
-        prune-empty : false
-      }
-      concurrent_requests {
-        enabled : true
-      }
+    connection-handler-requests {
+      enabled : true
+      prune-empty : false
+    }
+    connection-handler-latency{
+      enabled : true
+      percentiles : [0.75, 0.9, 0.99, 0.999, 0.9999]
+      sample-rate : 0.25
+      prune-empty : false
+    }
+    connection-handler-errors{
+      enabled : true
+      prune-empty : false
+    }
+    connection-handler-requests-per-connection{
+      enabled : true
+      percentiles: [0.5, 0.75, 0.99]
+      sample-rate : 0.50
+      prune-empty : false
+    }
+    connection-concurrent_requests {
+      enabled : true
     }
   }
 }

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -1,7 +1,6 @@
 package colossus
 package controller
 
-import colossus.metrics.MetricAddress
 import colossus.parsing.DataSize
 import colossus.parsing.DataSize._
 import core._
@@ -14,13 +13,13 @@ import scala.concurrent.duration.Duration
  *
  * @param outputBufferSize the maximum number of outbound messages that can be queued for sending at once
  * @param sendTimeout if a queued outbound message becomes older than this it will be cancelled
- * @param name The MetricAddress associated with this controller
  * @param inputMaxSize maximum allowed input size (in bytes)
+ * @param flushBufferOnClose
  */
 case class ControllerConfig(
   outputBufferSize: Int,
   sendTimeout: Duration,
-  inputMaxSize: DataSize = 1L.MB,
+  inputMaxSize: DataSize = 1.MB,
   flushBufferOnClose: Boolean = true
 )
 

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -43,8 +43,8 @@ import scala.collection.JavaConversions._
  *
  * @param delegatorCreationPolicy A [[colossus.core.WaitPolicy]] describing how
  * to handle delegator startup.  Since a Server waits for a signal from the
- * [[colossus.core.IOSystem]] that every worker has properly initialized a
- * [[colossus.core.delegator]], this determines how long to wait before the
+ * [[colossus.IOSystem]] that every worker has properly initialized a
+ * [[colossus.core.Delegator]], this determines how long to wait before the
  * initialization is considered a failure and whether to retry the
  * initialization.
  *

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -25,8 +25,7 @@ import scala.util.{Failure, Success, Try}
  * @param pendingBufferSize Size of the pending buffer
  * @param sentBufferSize Size of the sent buffer
  * @param failFast  When a failure is detected, immediately fail all pending requests.
- * @param connectionAttempts Polling configuration to govern retry behavior for both initial connect attempts
- *                           and for connection lost events.
+ * @param connectRetry Retry policy for connections.
  * @param idleTimeout How long the connection can remain idle (both sending and
  *        receiving data) before it is closed.  This should be significantly higher
  *        than requestTimeout.
@@ -41,7 +40,7 @@ case class ClientConfig(
   failFast: Boolean = false,
   connectRetry : RetryPolicy = BackoffPolicy(50.milliseconds, BackoffMultiplier.Exponential(5.seconds)),
   idleTimeout: Duration = Duration.Inf,
-  maxResponseSize: DataSize = 1L.MB
+  maxResponseSize: DataSize = 1.MB
 )
 
 class ServiceClientException(message: String) extends Exception(message)

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -75,7 +75,7 @@ extends ServiceServer[C#Input, C#Output](codec, config, srv) {
 
   def this(config: ServiceConfig, context: ServerContext)(implicit provider: ServiceCodecProvider[C]) = this(provider.provideCodec, config, context)
 
-  def this(context: ServerContext)(implicit provider: ServiceCodecProvider[C]) = this(ServiceConfig(), context)(provider)
+  def this(context: ServerContext)(implicit provider: ServiceCodecProvider[C]) = this(ServiceConfig.Default, context)(provider)
 
   protected def unhandled: PartialHandler[C] = PartialFunction[C#Input,Callback[C#Output]]{
     case other =>
@@ -164,7 +164,7 @@ object Service {
   def basic[T <: Protocol]
   (name: String, port: Int, requestTimeout: Duration = 100.milliseconds)(userHandler: PartialHandler[T])
   (implicit system: IOSystem, provider: ServiceCodecProvider[T]): ServerRef = {
-    class BasicService(context: ServerContext) extends Service(ServiceConfig(requestTimeout = requestTimeout), context) {
+    class BasicService(context: ServerContext) extends Service(ServiceConfig.Default.copy(requestTimeout = requestTimeout), context) {
       def handle = userHandler
     }
     Server.basic(name, port)(context => new BasicService(context))

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -14,28 +14,16 @@ case object Complete extends ParseStatus
 
 class ParseException(message: String) extends Exception(message)
 
-case class DataSize(value: Long) extends AnyVal {
-  def MB: DataSize = DataSize(value * 1024 * 1024)
-  def KB: DataSize = DataSize(value * 1024)
-  def bytes = value
+case class DataSize(bytes: Long) extends AnyVal {
+  def megabytes = MB
+  def MB: DataSize = DataSize(bytes * 1024 * 1024)
+  def kilobytes = KB
+  def KB: DataSize = DataSize(bytes * 1024)
 }
 
 object DataSize {
-  //implicit def longToDataSize(l: Long): DataSize = DataSize(l)
 
-  implicit class IntToSize(val amount : Int) extends DataSizeConversions[Int]
-  implicit class LongToSize(val amount : Long) extends DataSizeConversions[Long]
-
-  trait DataSizeConversions[T] {
-    def amount : T
-
-    def bytes = B
-    def B = DataSize(s"$amount B")
-    def MB = DataSize(s"$amount MB")
-    def megabytes = MB
-    def KB = DataSize(s"$amount KB")
-    def kilobytes = KB
-  }
+  implicit def longToDataSize(l: Long): DataSize = DataSize(l)
 
   val StrFormat = "(\\d+) (B|KB|MB)".r
 

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -14,16 +14,18 @@ case object Complete extends ParseStatus
 
 class ParseException(message: String) extends Exception(message)
 
-case class DataSize(bytes: Long) extends AnyVal {
+case class DataSize(value: Long) extends AnyVal {
   def megabytes = MB
-  def MB: DataSize = DataSize(bytes * 1024 * 1024)
+  def MB: DataSize = DataSize(value * 1024 * 1024)
   def kilobytes = KB
-  def KB: DataSize = DataSize(bytes * 1024)
+  def KB: DataSize = DataSize(value * 1024)
+  def bytes = this
 }
 
 object DataSize {
 
   implicit def longToDataSize(l: Long): DataSize = DataSize(l)
+  implicit def intToDataSize(l: Int): DataSize = DataSize(l)
 
   val StrFormat = "(\\d+) (B|KB|MB)".r
 
@@ -58,7 +60,7 @@ class ParserSizeTracker(maxSize: Option[DataSize], histogramOpt: Option[Histogra
   //data buffer into smaller chunks, but that would probably have a performance
   //cost.
 
-  val max = maxSize.map{_.bytes}.getOrElse(Long.MaxValue)
+  val max = maxSize.map{_.value}.getOrElse(Long.MaxValue)
 
   private var used = 0L
 


### PR DESCRIPTION
A few things here:

- ServiceConfig can now be loaded from configuration sources.  It's values are nested in `colossus.server.connection-handler`.
- Service metrics are added to `colossus.metrics`, so that they can be loaded at runtime.
- `DataSize` got a bit of love:
  - Added the ability to create one from a String(needed for config loading)
  - Added an unapply for pattern matching
  - Added some implicit objects to make it smell a bit like Durations ie: `1.KB`.  This was there before, but each invocation would create multiple instances.  This can be backed out if there is any strong resistance.  (Mainly b/c after I did this, I realized that it already existed by way of the existing implicit and instance functions 🙈  )

Note:  There is now naming ambiguity in this branch. ConnectionHandlers are called, well, ConnectionHandlers and/or Service.  This PR doesn't help this at all.  We should make a full name change on this pretty quickly to clean up this ambiguity.  I'm fine with doing in this branch, or saving it for another.