### PR TITLE
Websocket server improvements

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
@@ -1,18 +1,13 @@
 package colossus.examples
 
-
 import colossus._
 import colossus.core._
-import colossus.service._
-import colossus.protocols.http._
 import colossus.protocols.websocket._
+import subprotocols.rawstring._
 
 import akka.actor._
-import akka.util.ByteString
 
 import scala.concurrent.duration._
-
-import Http.defaults._
 
 class PrimeGenerator extends Actor {
 
@@ -52,51 +47,51 @@ object WebsocketExample {
     
     val generator = io.actorSystem.actorOf(Props[PrimeGenerator])
 
-    Server.basic("websocket", port){ ctx => new Service[Http](ctx) {
-      def handle = {
-        case UpgradeRequest(resp) => {
-          become(() => new WebsocketServerHandler(ctx) with ProxyActor {
+    WebsocketServer.start("websocket", port){worker => new WebsocketInitializer(worker) {
+      
+      def onConnect = ctx => new WebsocketServerHandler[RawString](ctx) with ProxyActor {
+        private var sending = false
 
-            private var sending = false
-
-            override def preStart() {
-              send(ByteString("HELLO THERE!"))
-            }
-
-            override def shutdown() {
-              send(ByteString("goodbye!"))
-              super.shutdown()
-            }
-
-            def handle = {
-              case bytes => bytes.utf8String.toUpperCase match {
-                case "START" => {
-                  sending = true
-                  generator ! Next
-                }
-                case "STOP" => {
-                  sending = false
-                }
-                case "EXIT" => {
-                  disconnect()
-                }
-              }
-            }
-
-            def receive = {
-              case prime: Integer => {
-                send(ByteString(s"PRIME: $prime"))
-                if(sending) {
-                  import io.actorSystem.dispatcher
-                  io.actorSystem.scheduler.scheduleOnce(100.milliseconds, generator , Next)
-                }
-              }
-            }
-
-          })
-          Callback.successful(resp)
+        override def preStart() {
+          sendMessage("HELLO THERE!")
         }
+
+        override def shutdown() {
+          sendMessage("goodbye!")
+          super.shutdown()
+        }
+
+        def handle = {
+          case "START" => {
+            sending = true
+            generator ! Next
+          }
+          case "STOP" => {
+            sending = false
+          }
+          case "EXIT" => {
+            disconnect()
+          }
+          case other => {
+            sendMessage(s"unknown command: $other")
+          }
+        }
+
+        def handleError(reason: Throwable){}
+
+        def receive = {
+          case prime: Integer => {
+            sendMessage(s"PRIME: $prime")
+            if(sending) {
+              import io.actorSystem.dispatcher
+              io.actorSystem.scheduler.scheduleOnce(100.milliseconds, generator , Next)
+            }
+          }
+        }
+
       }
+
     }}
+
   }
 }

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockConnection.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockConnection.scala
@@ -5,6 +5,7 @@ import core._
 
 import akka.actor._
 import akka.testkit.TestProbe
+import scala.concurrent.duration._
 
 trait MockConnection extends Connection with MockChannelActions {
   
@@ -54,6 +55,14 @@ trait MockConnection extends Connection with MockChannelActions {
 
   def workerProbe: TestProbe
   def serverProbe: Option[TestProbe]
+
+  /**
+   * checks to see if the connection handler has attempted to close the
+   * connection.  
+   */
+  def expectDisconnectAttempt() {
+    workerProbe.expectMsg(100.milliseconds, WorkerCommand.Disconnect(id))
+  }
 
 
 }

--- a/colossus-tests/src/test/scala/colossus/core/DataBlockSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/DataBlockSpec.scala
@@ -1,0 +1,31 @@
+package colossus
+package core
+
+import testkit._
+import akka.util.{ByteString, ByteStringBuilder}
+
+class DataBlockSpec extends ColossusSpec {
+
+  "DataBlock" must {
+    
+    "respect equality" in {
+      DataBlock("123456") == DataBlock("123456") must equal(true)
+    }
+
+    "generate same hashcode for same data" in {
+      DataBlock("123456abcdef").hashCode must equal(DataBlock("123456abcdef").hashCode)
+    }
+
+    "take" in {
+      DataBlock("12345").take(3) must equal(DataBlock("123"))
+    }
+
+    "drop" in {
+      DataBlock("12345").drop(3) must equal(DataBlock("45"))
+    }
+
+  }
+}
+
+    
+

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -142,6 +142,14 @@ class WebsocketSpec extends ColossusSpec {
       sendReceive(frame, expectedFrame)
     }
 
+    "close" in {
+      val con = MockConnection.server(new MyHandler(_))
+      val send = Frame(Header(OpCodes.Close, true), DataBlock(""))
+      con.typedHandler.connected(con)
+      con.typedHandler.receivedData(send.encode(random))
+      con.expectDisconnectAttempt()
+    }
+
       
     
   }

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -34,7 +34,7 @@ class WebsocketSpec extends WordSpec with MustMatchers{
     }
 
     "accept a properly crafted upgrade request" in {
-      UpgradeRequest.unapply(valid).isEmpty must equal(false)
+      UpgradeRequest.validate(valid).isEmpty must equal(false)
     }
 
     "produce a correctly formatted response" in {
@@ -50,7 +50,7 @@ class WebsocketSpec extends WordSpec with MustMatchers{
         ),
         HttpBody.NoBody
       )
-      UpgradeRequest.unapply(valid).get must equal(expected)
+      UpgradeRequest.validate(valid).get must equal(expected)
 
     }
   }

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -11,7 +11,6 @@ import org.scalatest._
 import akka.util.ByteString
 
 import scala.util.Success
-import DataBlock._
 
 class WebsocketSpec extends WordSpec with MustMatchers{
 
@@ -59,7 +58,7 @@ class WebsocketSpec extends WordSpec with MustMatchers{
   "frame parsing" must {
 
     "unmask data" in {
-      val masked = DataBlock("abcd") +:+ ByteString(41, 7, 15, 8, 14, 66, 52, 11, 19, 14, 7, 69).toArray
+      val masked = DataBlock("abcd") ++ DataBlock(ByteString(41, 7, 15, 8, 14, 66, 52, 11, 19, 14, 7, 69).toArray)
       FrameParser.unmask(true, masked).byteString must equal(ByteString("Hello World!"))
     }
     

--- a/colossus/src/main/scala/colossus/core/DataBlock.scala
+++ b/colossus/src/main/scala/colossus/core/DataBlock.scala
@@ -1,0 +1,65 @@
+package colossus
+package core
+
+import akka.util.ByteString
+
+/**
+ * A low-overhead abstraction over a byte array.  This offers much of the same
+ * functionally offered by Akka's ByteString, but without any additional
+ * overhead.  While this makes DataBlock a bit less powerful and flexible, it
+ * also makes it considerably faster.
+ *
+ * TODO: This is possibly a contender for using in all places where Array[Byte]
+ * is used, but thorough benchmarking is needed.  It is also possible that the
+ * performance of ByteString has improved in later versions of Akka, so that
+ * should also be tested before expanding on this any more.
+ *
+ */
+
+case class DataBlock(data: Array[Byte]) {
+  
+  def size = data.length
+  def length = data.length
+
+  def byteString: ByteString = ByteString(data)
+  def utf8String = byteString.utf8String
+
+  /**
+   * Create a new DataBlock containing the data from `block` appended to the
+   * data in this block
+   */
+  def ++(block: DataBlock): DataBlock = {
+    val concat = new Array[Byte](data.length + block.length)
+    System.arraycopy(data, 0, concat, 0, data.length)
+    System.arraycopy(block.data, 0, concat, data.length, block.length)
+    DataBlock(concat)
+  }
+
+  def take(bytes: Int): DataBlock = {
+    val copy = new Array[Byte](math.min(bytes, size))
+    System.arraycopy(data, 0, copy, 0, copy.length)
+    DataBlock(copy)
+  }
+
+  def drop(bytes: Int): DataBlock = {
+    val copy = new Array[Byte](math.max(0, size - bytes))
+    System.arraycopy(data, size - copy.length, copy, 0, copy.length)
+    DataBlock(copy)
+  }
+
+
+  def apply(index: Int) = data(index)
+
+  override def toString = "DataBlock(" + data.mkString(",") + ")"
+  override def equals(that: Any) = that match {
+    case DataBlock(dta) => java.util.Arrays.equals(data, dta)
+    case _ => false
+  }
+  override def hashCode = toString.hashCode
+
+}
+
+object DataBlock {
+
+  def apply(str: String): DataBlock = DataBlock(ByteString(str).toArray)
+}

--- a/colossus/src/main/scala/colossus/core/DataBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/DataBuffer.scala
@@ -6,66 +6,6 @@ import java.nio.ByteBuffer
 import java.nio.channels.SocketChannel
 
 
-/**
- * A low-overhead abstraction over a byte array.  This offers much of the same
- * functionally offered by Akka's ByteString, but without any additional
- * overhead.  While this makes DataBlock a bit less powerful and flexible, it
- * also makes it considerably faster.
- *
- * TODO: This is possibly a contender for using in all places where Array[Byte]
- * is used, but thorough benchmarking is needed.  It is also possible that the
- * performance of ByteString has improved in later versions of Akka, so that
- * should also be tested before expanding on this any more.
- *
- */
-
-case class DataBlock(data: Array[Byte]) {
-  
-  def size = data.length
-  def length = data.length
-
-  def byteString: ByteString = ByteString(data)
-  def utf8String = byteString.utf8String
-
-  /**
-   * Create a new DataBlock containing the data from `block` appended to the
-   * data in this block
-   */
-  def ++(block: DataBlock): DataBlock = {
-    val concat = new Array[Byte](data.length + block.length)
-    System.arraycopy(data, 0, concat, 0, data.length)
-    System.arraycopy(block.data, 0, concat, data.length, block.length)
-    DataBlock(concat)
-  }
-
-  def take(bytes: Int): DataBlock = {
-    val copy = new Array[Byte](math.min(bytes, size))
-    System.arraycopy(data, 0, copy, 0, copy.length)
-    DataBlock(copy)
-  }
-
-  def drop(bytes: Int): DataBlock = {
-    val copy = new Array[Byte](math.max(0, size - bytes))
-    System.arraycopy(data, size - copy.length, copy, 0, copy.length)
-    DataBlock(copy)
-  }
-
-
-  def apply(index: Int) = data(index)
-
-  override def toString = "DataBlock(" + data.mkString(",") + ")"
-  override def equals(that: Any) = that match {
-    case DataBlock(dta) => java.util.Arrays.equals(data, dta)
-    case _ => false
-  }
-  override def hashCode = toString.hashCode
-
-}
-
-object DataBlock {
-
-  def apply(str: String): DataBlock = DataBlock(ByteString(str).toArray)
-}
 
 
 /**

--- a/colossus/src/main/scala/colossus/core/DataBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/DataBuffer.scala
@@ -7,40 +7,64 @@ import java.nio.channels.SocketChannel
 
 
 /**
- * A zero-overhead abstraction over a byte array.  This offers much of the same
+ * A low-overhead abstraction over a byte array.  This offers much of the same
  * functionally offered by Akka's ByteString, but without any additional
  * overhead.  While this makes DataBlock a bit less powerful and flexible, it
  * also makes it considerably faster.
  *
- * Note - unfortunately implementing `take` and `drop` here conflicted with the
- * methods in arrayOps that is imported by default.  It's possible to "unimport"
- * things defined in predef, but that seems like too much of a hassle for anyone
- * who wants to use this.
+ * TODO: This is possibly a contender for using in all places where Array[Byte]
+ * is used, but thorough benchmarking is needed.  It is also possible that the
+ * performance of ByteString has improved in later versions of Akka, so that
+ * should also be tested before expanding on this any more.
+ *
  */
-object DataBlock {
-  type DataBlock = Array[Byte]
 
-  implicit class DataBlockOps(val data: DataBlock) extends AnyVal {
-    
-    //def size = data.length
-    def byteString: ByteString = ByteString(data)
-    def utf8String = byteString.utf8String
+case class DataBlock(data: Array[Byte]) {
+  
+  def size = data.length
+  def length = data.length
 
-    /**
-     * Create a new DataBlock containing the data from `block` appended to the
-     * data in this block
-     */
-    def +:+(block: DataBlock): DataBlock = {
-      val concat = DataBlock(data.length + block.length)
-      System.arraycopy(data, 0, concat, 0, data.length)
-      System.arraycopy(block, 0, concat, data.length, block.length)
-      concat
-    }
+  def byteString: ByteString = ByteString(data)
+  def utf8String = byteString.utf8String
 
+  /**
+   * Create a new DataBlock containing the data from `block` appended to the
+   * data in this block
+   */
+  def ++(block: DataBlock): DataBlock = {
+    val concat = new Array[Byte](data.length + block.length)
+    System.arraycopy(data, 0, concat, 0, data.length)
+    System.arraycopy(block.data, 0, concat, data.length, block.length)
+    DataBlock(concat)
   }
 
-  def apply(size: Int): DataBlock = new Array[Byte](size)
-  def apply(str: String): DataBlock = ByteString(str).toArray
+  def take(bytes: Int): DataBlock = {
+    val copy = new Array[Byte](math.min(bytes, size))
+    System.arraycopy(data, 0, copy, 0, copy.length)
+    DataBlock(copy)
+  }
+
+  def drop(bytes: Int): DataBlock = {
+    val copy = new Array[Byte](math.max(0, size - bytes))
+    System.arraycopy(data, size - copy.length, copy, 0, copy.length)
+    DataBlock(copy)
+  }
+
+
+  def apply(index: Int) = data(index)
+
+  override def toString = "DataBlock(" + data.mkString(",") + ")"
+  override def equals(that: Any) = that match {
+    case DataBlock(dta) => java.util.Arrays.equals(data, dta)
+    case _ => false
+  }
+  override def hashCode = toString.hashCode
+
+}
+
+object DataBlock {
+
+  def apply(str: String): DataBlock = DataBlock(ByteString(str).toArray)
 }
 
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/SubProtocol.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/SubProtocol.scala
@@ -1,0 +1,41 @@
+package colossus
+package protocols.websocket
+
+import service._
+
+import scala.util.{Try, Success, Failure}
+
+import core.DataBlock._
+
+
+trait FrameCodec[P <: Protocol] {
+
+  def decode(data: DataBlock): Try[P#Input]
+  def encode(output: P#Output): DataBlock
+}
+
+object subprotocols {
+
+  object rawstring {
+    
+    trait RawString extends Protocol {
+      type Input = String
+      type Output = String
+    }
+
+    class RawStringCodec extends FrameCodec[RawString] {
+      def encode(str: String): DataBlock = str.getBytes("UTF-8")
+      def decode(block: DataBlock): Try[String] = Try{ block.utf8String }
+    }
+
+    implicit object StringCodecProvider extends FrameCodecProvider[RawString] {
+      def provideCodec() = new RawStringCodec
+    }
+  }
+}
+
+trait FrameCodecProvider[P <: Protocol] {
+  
+  def provideCodec(): FrameCodec[P]
+
+}

--- a/colossus/src/main/scala/colossus/protocols/websocket/SubProtocol.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/SubProtocol.scala
@@ -3,9 +3,9 @@ package protocols.websocket
 
 import service._
 
-import scala.util.{Try, Success, Failure}
+import scala.util.Try
 
-import core.DataBlock._
+import core.DataBlock
 
 
 trait FrameCodec[P <: Protocol] {
@@ -24,7 +24,7 @@ object subprotocols {
     }
 
     class RawStringCodec extends FrameCodec[RawString] {
-      def encode(str: String): DataBlock = str.getBytes("UTF-8")
+      def encode(str: String): DataBlock = DataBlock(str)
       def decode(block: DataBlock): Try[String] = Try{ block.utf8String }
     }
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -226,8 +226,8 @@ abstract class WebsocketHandler[P <: Protocol](context: Context)(implicit provid
 }
 
  
-abstract class WebsocketServerHandler[P <: Protocol : FrameCodecProvider](serverContext: ServerContext)
-extends WebsocketHandler(serverContext.context) with ServerConnectionHandler {
+abstract class WebsocketServerHandler[P <: Protocol](serverContext: ServerContext)(implicit provider: FrameCodecProvider[P])
+extends WebsocketHandler[P](serverContext.context)(provider) with ServerConnectionHandler {
 
   implicit val namespace = serverContext.server.namespace
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/package.scala
@@ -6,6 +6,24 @@ import service._
 import akka.util.{ByteString, ByteStringBuilder}
 import java.util.Random
 
+/**
+ * **This package is experimental and subject to breaking changes between
+ * versions**.  We currently don't support the complete Websocket spec but there
+ * is enough support for basic servers
+ *
+ * The Websocket protocol defines an asynchronous application protocol.  Since
+ * unlike HTTP or other similar protocols there are no requests or responses,
+ * writing a Websocket server is slightly different from other service-protocol
+ * servers.  In particular, you should use the [[WebsocketServer]] to start a
+ * server and the [[WebsocketServerHandler]] to define a connection handler.
+ *
+ * The [[subprotocols]] package contains some basic sub-protocols, but these
+ * tend to be application specific so support is limited.
+ *
+ * Websocket connection handlers are designed to behave like actors, and mixing
+ * in the `ProxyActor` trait can make Websocket connections behave like and
+ * interact with Akka actors.
+ */
 package object websocket {
 
   class WebsocketCodec extends Codec[Frame, Frame]{


### PR DESCRIPTION
This makes some notable improvements to the API for starting and using a Websocket server.

* new sub-protocols package for defining websocket sub-protocols.  These work similarly to regular codecs, but are designed to parse the contents of Websocket frames, so no streaming support is needed.
* New API for starting a Websocket server.  The `WebsocketServer` properly encapsulates starting a HTTP server and handling the Websocket upgrade request.
* The Websocket server handler now properly handles the Ping and Close opcodes.  Support for the Continue code is still needed.
* Created a new `DataBlock` class that wraps a byte array.  This is similar to Akka's `ByteString`, but at least from previous benchmarking ByteString has some serious performance problems.  This is an attempt to get something with similar functionality without the overhead, though I haven't done much benchmarking on it yet.

This is still not a complete solution and I think there's probably more ways to improve this.  But we can take this incrementally and figure out what works and what doesn't.