### PR TITLE
ClientConfig now can be sourced from typesafe Config

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
@@ -1,19 +1,19 @@
 package colossus.examples
 
-import akka.util.ByteString
-import colossus.IOSystem
-import colossus.core.{ServerContext, DataBuffer, Initializer, Server, ServerRef, WorkerRef}
-import colossus.protocols.http._
-import colossus.protocols.redis._
-import colossus.service.{Callback, Service, ServiceClient, ServiceConfig}
 import java.net.InetSocketAddress
 
-import UrlParsing._
-import HttpMethod._
-import Callback.Implicits._
-import Redis.defaults._
+import akka.util.ByteString
+import colossus.IOSystem
+import colossus.core.{Initializer, Server, ServerContext, ServerRef}
+import colossus.protocols.http.HttpMethod._
+import colossus.protocols.http.UrlParsing._
+import colossus.protocols.http._
+import colossus.protocols.redis.Redis.defaults._
+import colossus.protocols.redis._
+import colossus.service.Callback.Implicits._
+import colossus.service.{Callback, ServiceConfig}
 
-import colossus.controller.IteratorGenerator
+import scala.concurrent.duration._
 
 object HttpExample {
 
@@ -52,7 +52,7 @@ object HttpExample {
   def start(port: Int, redisAddress: InetSocketAddress)(implicit system: IOSystem): ServerRef = {
     Server.start("http-example", port){implicit worker => new Initializer(worker) {
 
-      val redis = Redis.client(redisAddress.getHostName, redisAddress.getPort)
+      val redis: RedisClient[Callback] = Redis.client(redisAddress.getHostName, redisAddress.getPort, 1.second)
 
       def onConnect = context => new HttpExampleService(redis, context)
     }}

--- a/colossus-metrics/src/main/scala/colossus/metrics/ConfigHelper.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/ConfigHelper.scala
@@ -1,7 +1,10 @@
 package colossus.metrics
 
+import java.net.InetSocketAddress
+
 import com.typesafe.config.{Config, ConfigFactory}
 import scala.concurrent.duration._
+import scala.util.Try
 
 //has to be a better way
 object ConfigHelpers {
@@ -49,7 +52,21 @@ object ConfigHelpers {
         }
       }
     }
+
+    def getInetSocketAddress(path : String) : InetSocketAddress = {
+      val raw = config.getString(path)
+      raw.split(":") match {
+        case Array(host, Port(x))=>  new InetSocketAddress(host, x)
+        case _ => throw new InvalidHostAddressException(raw)
+      }
+    }
+
+    private object Port {
+      def unapply(s: String) : Option[Int] = Try(s.toInt).toOption
+    }
   }
 }
 
-private[metrics] class FiniteDurationExpectedException(str : String) extends Exception(str)
+class InvalidHostAddressException(str : String) extends IllegalArgumentException(s"$str was not a valid address, expecting [host]:[port]")
+
+class FiniteDurationExpectedException(str : String) extends Exception(str)

--- a/colossus-tests/src/test/scala/colossus/service/ClientConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ClientConfigLoadingSpec.scala
@@ -1,0 +1,32 @@
+package colossus.service
+
+import java.net.InetSocketAddress
+
+import colossus.metrics.MetricAddress
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{MustMatchers, WordSpec}
+import scala.concurrent.duration._
+
+class ClientConfigLoadingSpec extends WordSpec with MustMatchers{
+
+  "ClientConfig loading" must {
+
+    "load a user defined client using fallbacks" in {
+      val userOverrides =
+        """
+          |colossus.client.my-client {
+          |  address : "127.0.0.1:6379"
+          |  name : "redis"
+          |  pending-buffer-size : 500
+          |}
+        """.stripMargin
+
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val clientConfig = ClientConfig.load("my-client", c)
+
+      val expected = ClientConfig(new InetSocketAddress("127.0.0.1", 6379), requestTimeout = 1.second, name = MetricAddress("redis"), pendingBufferSize = 500)
+
+      clientConfig mustBe expected
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -23,10 +23,7 @@ class ErrorTestDSL(probe: ActorRef) extends ServiceCodecProvider[Raw] {
       probe ! error.reason
       ByteString(s"Error (${error.reason.getClass.getName}): ${error.reason.getMessage}")
     }
-  
 }
-
-
 
 class ServiceDSLSpec extends ColossusSpec {
 
@@ -53,10 +50,10 @@ class ServiceDSLSpec extends ColossusSpec {
     */
 
     "throw UnhandledRequestException on unhandled request" in {
-      val probe = TestProbe() 
+      val probe = TestProbe()
       implicit val provider = new ErrorTestDSL(probe.ref)
-      withIOSystem{ implicit system => 
-        val server = Service.basic[Raw]("test", TEST_PORT) { 
+      withIOSystem{ implicit system =>
+        val server = Service.basic[Raw]("test", TEST_PORT) {
           case any if (false) => ByteString("WAT")
         }
         withServer(server) {
@@ -119,24 +116,21 @@ class ServiceDSLSpec extends ColossusSpec {
         import Http.defaults._
         import Memcache.defaults._
         //this test passes if it compiles
-        val s = Http.futureClient("localhost", TEST_PORT)
-        val t = Memcache.futureClient("localhost", TEST_PORT)
+        val s = Http.futureClient("localhost", TEST_PORT, 1.second)
+        val t = Memcache.futureClient("localhost", TEST_PORT, 1.second)
       }
     }
 
     "be able to lift a sender to a type-specific client" in {
-      withIOSystem{ implicit sys => 
+      withIOSystem{ implicit sys =>
         import protocols.http._
         import Http.defaults._
 
-        val s = AsyncServiceClient[Http]("localhost", TEST_PORT)
+        val s = AsyncServiceClient[Http]("localhost", TEST_PORT, 1.second)
         val t = Http.futureClient(s)
         val q : HttpClient[Future] = t
       }
     }
-
-      
-
   }
 }
 

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -6,7 +6,7 @@ colossus{
   }
 
   server {
-    name = "/"
+    name : "/"
     port : 9876
     max-connections : 1000
     max-idle-time : "Inf"
@@ -14,24 +14,24 @@ colossus{
     high-watermark-percentage : 0.85
     highwater-max-idle-time : "100 milliseconds"
     #tcp-backlog-size : 100  #optional
-    binding-retry = {
-      type = "backoff"
-      multiplier = {
-        type = "exponential"
-        max = "1 second"
+    binding-retry : {
+      type : "backoff"
+      multiplier : {
+        type : "exponential"
+        max : "1 second"
       }
-      base = "100 milliseconds"
-      immediate-first-attempt = false
+      base : "100 milliseconds"
+      immediate-first-attempt : false
     }
-    delegator-creation-policy = {
-      wait-time = "500 milliseconds"
-      retry-policy = {
-        type = "backoff"
-        multiplier = {
-          type = "constant"
+    delegator-creation-policy : {
+      wait-time : "500 milliseconds"
+      retry-policy : {
+        type : "backoff"
+        multiplier : {
+          type : "constant"
         }
-        base = "100 milliseconds"
-        immediate-first-attempt = false
+        base : "100 milliseconds"
+        immediate-first-attempt : false
       }
     }
     shutdown-timeout : "100 milliseconds"
@@ -42,6 +42,34 @@ colossus{
       request-metrics : true
       max-request-size : "1 MB"
     }
+  }
+  
+  client {
+    defaults {
+      #address - 127.0.0.1:333 or myserver.on.the.web:5678 must be provided
+      #name  - must be provided
+      request-timeout : "1 second"
+      pending-buffer-size : 100
+      sent-buffer-size : 100
+      fail-fast : false
+      connect-retry-policy : {
+        type : "backoff"
+        multiplier : {
+          type : "exponential"
+          max : "5 seconds"
+        }
+        base : "50 milliseconds"
+        immediate-first-attempt : true
+      }
+      idle-timeout : "Inf"
+      max-response-size : "1 MB"
+    }
+    #user defined clients go here.
+    #redis-client {
+      #address : 127.0.0.1:6379
+      #name : redis
+      #fail-fast : true
+    #}
   }
 
   metrics {
@@ -97,6 +125,44 @@ colossus{
     }
     connection-handler-concurrent-requests {
       enabled : true
+    }
+    client-requests {
+      enabled : true
+      prune-empty : false
+    }
+    client-errors {
+      enabled : true
+      prune-empty : false
+    }
+    client-dropped-requests {
+      enabled : true
+      prune-empty : false
+    }
+    client-connection-failures{
+      enabled : true
+      prune-empty : false
+    }
+    client-disconnects {
+      enabled : true
+      prune-empty : false
+    }
+    client-latency {
+      enabled : true
+      percentiles : [0.75, 0.99]
+      sample-rate : 0.10
+      prune-empty : false
+    }
+    client-transit-time {
+      enabled : true
+      percentiles : [0.5]
+      sample-rate : 0.02
+      prune-empty : false
+    }
+    client-queue-time {
+      enabled : true
+      percentiles : [0.5]
+      sample-rate : 0.02
+      prune-empty : false
     }
   }
 }

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -126,9 +126,9 @@ object Service {
    * @param port The port to bind the server to
    */
   def basic[T <: Protocol]
-  (name: String, port: Int, requestTimeout: Duration = 100.milliseconds)(userHandler: PartialHandler[T])
+  (name: String, port: Int, config : ServiceConfig = ServiceConfig.Default)(userHandler: PartialHandler[T])
   (implicit system: IOSystem, provider: ServiceCodecProvider[T]): ServerRef = {
-    class BasicService(context: ServerContext) extends Service(ServiceConfig.Default.copy(requestTimeout = requestTimeout), context) {
+    class BasicService(context: ServerContext) extends Service(config, context) {
       def handle = userHandler
     }
     Server.basic(name, port)(context => new BasicService(context))
@@ -151,6 +151,8 @@ trait ClientLifter[C <: Protocol, T[M[_]] <: Sender[C,M]] {
 trait ClientFactory[C <: Protocol, M[_], T <: Sender[C,M], E] {
 
 
+  protected lazy val configDefaults = ConfigFactory.load()
+
   /**
     * Load a ServiceClient definition from a Config.  Looks into `colossus.clients.$clientName` and falls back onto
     * `colossus.client-defaults`
@@ -158,7 +160,7 @@ trait ClientFactory[C <: Protocol, M[_], T <: Sender[C,M], E] {
     * @param config A config object which contains at the least a `colossus.clients.$clientName` and a `colossus.client-defaults`
     * @return
     */
-  def apply(clientName : String, config : Config = ConfigFactory.load())(implicit provider: ClientCodecProvider[C], env: E) : T = {
+  def apply(clientName : String, config : Config = configDefaults)(implicit provider: ClientCodecProvider[C], env: E) : T = {
     apply(ClientConfig.load(clientName, config))
   }
 

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -176,6 +176,10 @@ trait ClientFactory[C <: Protocol, M[_], T <: Sender[C,M], E] {
 
   def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], env: E): T
 
+  def apply(host: String, port : Int)(implicit provider: ClientCodecProvider[C], env: E): T = {
+    apply(host, port, 1.second)
+  }
+
   def apply(host: String, port: Int, requestTimeout: Duration)(implicit provider: ClientCodecProvider[C], env: E): T = {
     apply(new InetSocketAddress(host, port), requestTimeout)
   }

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -1,8 +1,6 @@
 package colossus
 package service
 
-import java.util.concurrent.ConcurrentHashMap
-
 import colossus.parsing.{ParseException, DataSize}
 import com.typesafe.config.{ConfigFactory, Config}
 import core._


### PR DESCRIPTION
First pass of making ClientConfig classes sourceable from Typesafe Config.

The idea was to give ClientConfig `load` functions, similar to `ServiceClient`.  These functions can be invoked directly or indirectly by way of `ClientFactory`

Client definitions are expected to appear in `colossus.client`, and are sourced by name.  Defaults are provided in `colossus.client.defaults`.  The only caveat here, is that, for obvious reasons, the defaults don't have an `address` or `name` field.
