### PR TITLE
WorkerManager IdleCheck now waits for acks 

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
@@ -1,19 +1,19 @@
 package colossus.examples
 
-import akka.util.ByteString
-import colossus.IOSystem
-import colossus.core.{ServerContext, DataBuffer, Initializer, Server, ServerRef, WorkerRef}
-import colossus.protocols.http._
-import colossus.protocols.redis._
-import colossus.service.{Callback, Service, ServiceClient, ServiceConfig}
 import java.net.InetSocketAddress
 
-import UrlParsing._
-import HttpMethod._
-import Callback.Implicits._
-import Redis.defaults._
+import akka.util.ByteString
+import colossus.IOSystem
+import colossus.core.{Initializer, Server, ServerContext, ServerRef}
+import colossus.protocols.http.HttpMethod._
+import colossus.protocols.http.UrlParsing._
+import colossus.protocols.http._
+import colossus.protocols.redis.Redis.defaults._
+import colossus.protocols.redis._
+import colossus.service.Callback.Implicits._
+import colossus.service.{Callback, ServiceConfig}
 
-import colossus.controller.IteratorGenerator
+import scala.concurrent.duration._
 
 object HttpExample {
 
@@ -52,7 +52,7 @@ object HttpExample {
   def start(port: Int, redisAddress: InetSocketAddress)(implicit system: IOSystem): ServerRef = {
     Server.start("http-example", port){implicit worker => new Initializer(worker) {
 
-      val redis = Redis.client(redisAddress.getHostName, redisAddress.getPort)
+      val redis: RedisClient[Callback] = Redis.client(redisAddress.getHostName, redisAddress.getPort, 1.second)
 
       def onConnect = context => new HttpExampleService(redis, context)
     }}

--- a/colossus-metrics/src/main/scala/colossus/metrics/ConfigHelper.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/ConfigHelper.scala
@@ -1,7 +1,10 @@
 package colossus.metrics
 
+import java.net.InetSocketAddress
+
 import com.typesafe.config.{Config, ConfigFactory}
 import scala.concurrent.duration._
+import scala.util.Try
 
 //has to be a better way
 object ConfigHelpers {
@@ -49,7 +52,21 @@ object ConfigHelpers {
         }
       }
     }
+
+    def getInetSocketAddress(path : String) : InetSocketAddress = {
+      val raw = config.getString(path)
+      raw.split(":") match {
+        case Array(host, Port(x))=>  new InetSocketAddress(host, x)
+        case _ => throw new InvalidHostAddressException(raw)
+      }
+    }
+
+    private object Port {
+      def unapply(s: String) : Option[Int] = Try(s.toInt).toOption
+    }
   }
 }
 
-private[metrics] class FiniteDurationExpectedException(str : String) extends Exception(str)
+class InvalidHostAddressException(str : String) extends IllegalArgumentException(s"$str was not a valid address, expecting [host]:[port]")
+
+class FiniteDurationExpectedException(str : String) extends Exception(str)

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -243,8 +243,7 @@ class ServerSpec extends ColossusSpec {
         }
       }
 
-      //TODO : fix this test
-      "open up spot when connection closes" ignore {
+      "open up spot when connection closes" in {
         val settings = ServerSettings(
           port = TEST_PORT,
           maxConnections = 1
@@ -255,16 +254,9 @@ class ServerSpec extends ColossusSpec {
           withServer(server) {
             val c1 = TestClient(server.system, TEST_PORT)
             expectConnections(server, 1)
-            val c2 = TestClient(server.system, TEST_PORT, waitForConnected = false, connectRetry = NoRetry)
-            //notice, we can't just check if the connection is connected because the
-            //server will accept the connection before closing it
-            intercept[service.ServiceClientException] {
-              Await.result(c2.send(ByteString("hello")), 5000.milliseconds)
-            }
-            TestClient.waitForStatus(c2, ConnectionStatus.NotConnected)
             c1.disconnect()
             TestUtil.expectServerConnections(server, 0)
-            val c3 = TestClient(server.system, TEST_PORT, waitForConnected = true, connectRetry = NoRetry)
+            val c2 = TestClient(server.system, TEST_PORT, waitForConnected = true, connectRetry = NoRetry)
             TestUtil.expectServerConnections(server, 1)
           }
         }

--- a/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
@@ -12,7 +12,7 @@ class WorkerItemSpec extends ColossusSpec {
 
   "A WorkerItem" must {
     "bind to a worker" in {
-      withIOSystem{io => 
+      withIOSystem{io =>
         val probe = TestProbe()
         class MyItem(c: Context) extends WorkerItem(c) {
           override def onBind() {
@@ -38,7 +38,7 @@ class WorkerItemSpec extends ColossusSpec {
         io ! IOCommand.BindWorkerItem(new MyItem(_))
         probe.expectMsg(100.milliseconds, "BOUND")
         probe.expectNoMsg(100.milliseconds)
-      }       
+      }
 
     }
 
@@ -57,7 +57,7 @@ class WorkerItemSpec extends ColossusSpec {
         }
         io ! IOCommand.BindWorkerItem(new MyItem(_))
         probe.expectMsg(100.milliseconds, "PONG")
-      }       
+      }
     }
 
     "not receive messages after unbinding" in {

--- a/colossus-tests/src/test/scala/colossus/core/WorkerManagerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerManagerSpec.scala
@@ -1,0 +1,66 @@
+package colossus.core
+
+import akka.actor.{ActorContext, ActorRef, Props}
+import akka.agent.Agent
+import akka.testkit.TestProbe
+import colossus.IOSystem
+import colossus.testkit.ColossusSpec
+import org.scalatest.concurrent.Eventually
+
+import scala.collection.immutable.IndexedSeq
+import scala.concurrent.duration._
+
+class WorkerManagerSpec extends ColossusSpec with Eventually{
+
+  "WorkerManager" must {
+
+    "send an idle only after all workers ack the previous idle check" in {
+      withIOSystem{ io =>
+        //we need to create a separate manager.
+        implicit val ec = system.dispatcher
+        //need to use the same number of ioSystem workers, since WorkerManager uses this to control the # of workers created
+        val probes: IndexedSeq[TestProbe] = (1 to io.numWorkers).map(_ => TestProbe())
+        val probesIter = probes.iterator
+        var workerRefs : Seq[WorkerRef] = Seq()
+
+        //create a "Worker" which is just a probe.
+        val workerFact = new WorkerFactory {
+          override def createWorker(id: Int, ioSystem: IOSystem, context: ActorContext): ActorRef = {
+            val ref = probesIter.next().ref
+            val worker = WorkerRef(id, ref, ioSystem)
+            workerRefs = workerRefs :+ worker
+            ref
+          }
+        }
+
+        val agent = Agent(Seq[WorkerRef]())
+        val manager: ActorRef = system.actorOf(Props(classOf[WorkerManager], agent, io, workerFact), name = s"idle-check-manager")
+
+        //give the WorkerManager some time to create the Workers
+        eventually{
+          workerRefs must have size io.numWorkers
+        }
+
+        //lets now report Workers as ready, so that the WorkerManager changes its state
+        workerRefs.foreach{x =>
+          manager.tell(WorkerManager.WorkerReady(x), x.worker)
+        }
+
+        //this allows for a bit of timing leeway
+        val window = WorkerManager.IdleCheckFrequency + 50.milliseconds
+
+        //manger should be sending check messages
+        probes.foreach{_.expectMsg(window, Worker.CheckIdleConnections)}
+
+        //no more messages should be sent, until acks are received
+        probes.foreach{_.expectNoMsg(window * 2)}
+
+        //lets now send the acks back
+        probes.foreach{x => manager.tell(WorkerManager.IdleCheckExecuted, x.ref)}
+
+        //now, we should be getting checks again
+        probes.foreach{_.expectMsg(window, Worker.CheckIdleConnections)}
+      }
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/service/ClientConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ClientConfigLoadingSpec.scala
@@ -1,0 +1,32 @@
+package colossus.service
+
+import java.net.InetSocketAddress
+
+import colossus.metrics.MetricAddress
+import com.typesafe.config.ConfigFactory
+import org.scalatest.{MustMatchers, WordSpec}
+import scala.concurrent.duration._
+
+class ClientConfigLoadingSpec extends WordSpec with MustMatchers{
+
+  "ClientConfig loading" must {
+
+    "load a user defined client using fallbacks" in {
+      val userOverrides =
+        """
+          |colossus.client.my-client {
+          |  address : "127.0.0.1:6379"
+          |  name : "redis"
+          |  pending-buffer-size : 500
+          |}
+        """.stripMargin
+
+      val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
+      val clientConfig = ClientConfig.load("my-client", c)
+
+      val expected = ClientConfig(new InetSocketAddress("127.0.0.1", 6379), requestTimeout = 1.second, name = MetricAddress("redis"), pendingBufferSize = 500)
+
+      clientConfig mustBe expected
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -23,10 +23,7 @@ class ErrorTestDSL(probe: ActorRef) extends ServiceCodecProvider[Raw] {
       probe ! error.reason
       ByteString(s"Error (${error.reason.getClass.getName}): ${error.reason.getMessage}")
     }
-  
 }
-
-
 
 class ServiceDSLSpec extends ColossusSpec {
 
@@ -53,10 +50,10 @@ class ServiceDSLSpec extends ColossusSpec {
     */
 
     "throw UnhandledRequestException on unhandled request" in {
-      val probe = TestProbe() 
+      val probe = TestProbe()
       implicit val provider = new ErrorTestDSL(probe.ref)
-      withIOSystem{ implicit system => 
-        val server = Service.basic[Raw]("test", TEST_PORT) { 
+      withIOSystem{ implicit system =>
+        val server = Service.basic[Raw]("test", TEST_PORT) {
           case any if (false) => ByteString("WAT")
         }
         withServer(server) {
@@ -119,24 +116,21 @@ class ServiceDSLSpec extends ColossusSpec {
         import Http.defaults._
         import Memcache.defaults._
         //this test passes if it compiles
-        val s = Http.futureClient("localhost", TEST_PORT)
-        val t = Memcache.futureClient("localhost", TEST_PORT)
+        val s = Http.futureClient("localhost", TEST_PORT, 1.second)
+        val t = Memcache.futureClient("localhost", TEST_PORT, 1.second)
       }
     }
 
     "be able to lift a sender to a type-specific client" in {
-      withIOSystem{ implicit sys => 
+      withIOSystem{ implicit sys =>
         import protocols.http._
         import Http.defaults._
 
-        val s = AsyncServiceClient[Http]("localhost", TEST_PORT)
+        val s = AsyncServiceClient[Http]("localhost", TEST_PORT, 1.second)
         val t = Http.futureClient(s)
         val q : HttpClient[Future] = t
       }
     }
-
-      
-
   }
 }
 

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -6,7 +6,7 @@ colossus{
   }
 
   server {
-    name = "/"
+    name : "/"
     port : 9876
     max-connections : 1000
     max-idle-time : "Inf"
@@ -14,24 +14,24 @@ colossus{
     high-watermark-percentage : 0.85
     highwater-max-idle-time : "100 milliseconds"
     #tcp-backlog-size : 100  #optional
-    binding-retry = {
-      type = "backoff"
-      multiplier = {
-        type = "exponential"
-        max = "1 second"
+    binding-retry : {
+      type : "backoff"
+      multiplier : {
+        type : "exponential"
+        max : "1 second"
       }
-      base = "100 milliseconds"
-      immediate-first-attempt = false
+      base : "100 milliseconds"
+      immediate-first-attempt : false
     }
-    delegator-creation-policy = {
-      wait-time = "500 milliseconds"
-      retry-policy = {
-        type = "backoff"
-        multiplier = {
-          type = "constant"
+    delegator-creation-policy : {
+      wait-time : "500 milliseconds"
+      retry-policy : {
+        type : "backoff"
+        multiplier : {
+          type : "constant"
         }
-        base = "100 milliseconds"
-        immediate-first-attempt = false
+        base : "100 milliseconds"
+        immediate-first-attempt : false
       }
     }
     shutdown-timeout : "100 milliseconds"
@@ -42,6 +42,34 @@ colossus{
       request-metrics : true
       max-request-size : "1 MB"
     }
+  }
+  
+  client {
+    defaults {
+      #address - 127.0.0.1:333 or myserver.on.the.web:5678 must be provided
+      #name  - must be provided
+      request-timeout : "1 second"
+      pending-buffer-size : 100
+      sent-buffer-size : 100
+      fail-fast : false
+      connect-retry-policy : {
+        type : "backoff"
+        multiplier : {
+          type : "exponential"
+          max : "5 seconds"
+        }
+        base : "50 milliseconds"
+        immediate-first-attempt : true
+      }
+      idle-timeout : "Inf"
+      max-response-size : "1 MB"
+    }
+    #user defined clients go here.
+    #redis-client {
+      #address : 127.0.0.1:6379
+      #name : redis
+      #fail-fast : true
+    #}
   }
 
   metrics {
@@ -97,6 +125,44 @@ colossus{
     }
     connection-handler-concurrent-requests {
       enabled : true
+    }
+    client-requests {
+      enabled : true
+      prune-empty : false
+    }
+    client-errors {
+      enabled : true
+      prune-empty : false
+    }
+    client-dropped-requests {
+      enabled : true
+      prune-empty : false
+    }
+    client-connection-failures{
+      enabled : true
+      prune-empty : false
+    }
+    client-disconnects {
+      enabled : true
+      prune-empty : false
+    }
+    client-latency {
+      enabled : true
+      percentiles : [0.75, 0.99]
+      sample-rate : 0.10
+      prune-empty : false
+    }
+    client-transit-time {
+      enabled : true
+      percentiles : [0.5]
+      sample-rate : 0.02
+      prune-empty : false
+    }
+    client-queue-time {
+      enabled : true
+      percentiles : [0.5]
+      sample-rate : 0.02
+      prune-empty : false
     }
   }
 }

--- a/colossus/src/main/scala/colossus/core/IOSystem.scala
+++ b/colossus/src/main/scala/colossus/core/IOSystem.scala
@@ -78,7 +78,8 @@ object IOSystem {
     sys.actorSystem.actorOf(Props(
       classOf[WorkerManager],
       agent,
-      sys
+      sys,
+      DefaultWorkerFactory
     ), name = s"${actorFriendlyName(sys.name)}-manager")
   }
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -207,6 +207,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
       if (timedOut.size > 0) {
         log.debug(s"Terminated ${timedOut.size} idle connections")
       }
+      sender() ! IdleCheckExecuted
     }
     case WorkerManager.RegisterServer(server) => if (!delegators.contains(server.server)){
       try{

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -1,11 +1,12 @@
 package colossus
 package service
 
+import com.typesafe.config.{Config, ConfigFactory}
 import core._
 
 import akka.actor.ActorRef
 import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.language.higherKinds
 
 import java.net.InetSocketAddress
@@ -13,8 +14,6 @@ import metrics.MetricAddress
 
 import Codec._
 
-
-//TODO : Rename to Protocol
 trait Protocol {self =>
   type Input
   type Output
@@ -36,11 +35,13 @@ import Protocol._
 
 /**
  * Provide a Codec as well as some convenience functions for usage within in a Service.
- * @tparam C the type of codec this provider will supply
+  *
+  * @tparam C the type of codec this provider will supply
  */
 trait CodecProvider[C <: Protocol] {
   /**
     * The Codec which will be used.
+    *
     * @return
     */
   def provideCodec: ServerCodec[C#Input, C#Output]
@@ -49,7 +50,8 @@ trait CodecProvider[C <: Protocol] {
 trait ServiceCodecProvider[C <: Protocol] extends CodecProvider[C] {
   /**
    * Basic error response
-   * @param error Request that caused the error
+    *
+    * @param error Request that caused the error
    * @return A response which represents the failure encoded with the Codec
    */
   def errorResponse(error: ProcessingFailure[C#Input]): C#Output
@@ -60,8 +62,6 @@ trait ClientCodecProvider[C <: Protocol] {
   def name: String
   def clientCodec(): ClientCodec[C#Input, C#Output]
 }
-
-
 
 
 class UnhandledRequestException(message: String) extends Exception(message)
@@ -119,40 +119,6 @@ extends ServiceServer[C#Input, C#Output](provider.provideCodec, config, srv) {
 
 
 object Service {
-  /*
-  /** Start a service with worker and connection initialization
-   *
-   * The basic structure of a service using this method is:{{{
-   Service.serve[Http]{ workerContext =>
-     //worker initialization
-     workerContext.handle { connectionContext =>
-       //connection initialization
-       connection.become {
-         case ...
-       }
-     }
-   }
-   }}}
-   *
-   * @param serverSettings Settings to provide the underlying server
-   * @param serviceConfig Config for the service
-   * @param handler The worker initializer to use for the service
-   * @tparam T The codec to use, eg Http, Redis
-   * @return A [[ServerRef]] for the server.
-   */
-
-  def serve[T <: Protocol]
-  (serverSettings: ServerSettings, serviceConfig: ServiceConfig[T#Input, T#Output])
-  (handler: Initializer[T])
-  (implicit system: IOSystem, provider: CodecProvider[T]): ServerRef = {
-    val serverConfig = ServerConfig(
-      name = serviceConfig.name,
-      settings = serverSettings,
-      delegatorFactory = (s,w) => provider.provideDelegator(handler, s, w, provider, serviceConfig)
-    )
-    Server(serverConfig)
-  }
-  */
 
   /** Quick-start a service, using default settings
    *
@@ -160,9 +126,9 @@ object Service {
    * @param port The port to bind the server to
    */
   def basic[T <: Protocol]
-  (name: String, port: Int, requestTimeout: Duration = 100.milliseconds)(userHandler: PartialHandler[T])
+  (name: String, port: Int, config : ServiceConfig = ServiceConfig.Default)(userHandler: PartialHandler[T])
   (implicit system: IOSystem, provider: ServiceCodecProvider[T]): ServerRef = {
-    class BasicService(context: ServerContext) extends Service(ServiceConfig.Default.copy(requestTimeout = requestTimeout), context) {
+    class BasicService(context: ServerContext) extends Service(config, context) {
       def handle = userHandler
     }
     Server.basic(name, port)(context => new BasicService(context))
@@ -185,9 +151,36 @@ trait ClientLifter[C <: Protocol, T[M[_]] <: Sender[C,M]] {
 trait ClientFactory[C <: Protocol, M[_], T <: Sender[C,M], E] {
 
 
+  protected lazy val configDefaults = ConfigFactory.load()
+
+  /**
+    * Load a ServiceClient definition from a Config.  Looks into `colossus.clients.$clientName` and falls back onto
+    * `colossus.client-defaults`
+    * @param clientName The name of the client definition to load
+    * @param config A config object which contains at the least a `colossus.clients.$clientName` and a `colossus.client-defaults`
+    * @return
+    */
+  def apply(clientName : String, config : Config = configDefaults)(implicit provider: ClientCodecProvider[C], env: E) : T = {
+    apply(ClientConfig.load(clientName, config))
+  }
+
+  /**
+    * Create a Client from a config source.
+    *
+    * @param config A Config object in the shape of `colossus.client-defaults`.  It is also expected to have the `address` and `name` fields.
+    * @return
+    */
+  def apply(config : Config)(implicit provider: ClientCodecProvider[C], env: E) : T = {
+    apply(ClientConfig.load(config))
+  }
+
   def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], env: E): T
 
-  def apply(host: String, port: Int, requestTimeout: Duration = 1.second)(implicit provider: ClientCodecProvider[C], env: E): T = {
+  def apply(host: String, port : Int)(implicit provider: ClientCodecProvider[C], env: E): T = {
+    apply(host, port, 1.second)
+  }
+
+  def apply(host: String, port: Int, requestTimeout: Duration)(implicit provider: ClientCodecProvider[C], env: E): T = {
     apply(new InetSocketAddress(host, port), requestTimeout)
   }
 
@@ -199,20 +192,15 @@ trait ClientFactory[C <: Protocol, M[_], T <: Sender[C,M], E] {
     )
     apply(config)
   }
-
-
 }
 
-
 object ClientFactory {
-
 
   implicit def serviceClientFactory[C <: Protocol] = new ClientFactory[C, Callback, ServiceClient[C], WorkerRef] {
 
     def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], worker: WorkerRef): ServiceClient[C] = {
       new ServiceClient(provider.clientCodec(), config, worker.generateContext())
     }
-
   }
 
   implicit def futureClientFactory[C <: Protocol] = new ClientFactory[C, Future, FutureClient[C], IOSystem] {
@@ -220,9 +208,7 @@ object ClientFactory {
     def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], io: IOSystem) = {
       AsyncServiceClient.create(config)(io, provider)
     }
-
   }
-
 }
 
 class CodecClientFactory[C <: Protocol, M[_], B <: Sender[C, M], T[M[_]] <: Sender[C,M], E]

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -1,8 +1,6 @@
 package colossus
 package service
 
-import java.util.concurrent.ConcurrentHashMap
-
 import colossus.parsing.{ParseException, DataSize}
 import com.typesafe.config.{ConfigFactory, Config}
 import core._


### PR DESCRIPTION
This is to fix #265 .  

WorkerManager now doesn't use `context.schedule` it uses `context.scheduleOnce`.  After Workers process the `CheckIdleConnections`, they respond with a 'IdleCheckExecuted`.  Once the WorkerManager receives those acks from all Workers, it will only then schedule another idle check.

Note, this is branched off of the service_client_config branch.  So, I can merge this directly into that, or wait until that branch is approved and merged into develop, then rebase this off of develop.  Either or.