### PR TITLE
WorkerManager IdleCheck now waits for acks 

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
@@ -12,7 +12,7 @@ class WorkerItemSpec extends ColossusSpec {
 
   "A WorkerItem" must {
     "bind to a worker" in {
-      withIOSystem{io => 
+      withIOSystem{io =>
         val probe = TestProbe()
         class MyItem(c: Context) extends WorkerItem(c) {
           override def onBind() {
@@ -38,7 +38,7 @@ class WorkerItemSpec extends ColossusSpec {
         io ! IOCommand.BindWorkerItem(new MyItem(_))
         probe.expectMsg(100.milliseconds, "BOUND")
         probe.expectNoMsg(100.milliseconds)
-      }       
+      }
 
     }
 
@@ -57,7 +57,7 @@ class WorkerItemSpec extends ColossusSpec {
         }
         io ! IOCommand.BindWorkerItem(new MyItem(_))
         probe.expectMsg(100.milliseconds, "PONG")
-      }       
+      }
     }
 
     "not receive messages after unbinding" in {

--- a/colossus-tests/src/test/scala/colossus/core/WorkerManagerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerManagerSpec.scala
@@ -1,0 +1,66 @@
+package colossus.core
+
+import akka.actor.{ActorContext, ActorRef, Props}
+import akka.agent.Agent
+import akka.testkit.TestProbe
+import colossus.IOSystem
+import colossus.testkit.ColossusSpec
+import org.scalatest.concurrent.Eventually
+
+import scala.collection.immutable.IndexedSeq
+import scala.concurrent.duration._
+
+class WorkerManagerSpec extends ColossusSpec with Eventually{
+
+  "WorkerManager" must {
+
+    "send an idle only after all workers ack the previous idle check" in {
+      withIOSystem{ io =>
+        //we need to create a separate manager.
+        implicit val ec = system.dispatcher
+        //need to use the same number of ioSystem workers, since WorkerManager uses this to control the # of workers created
+        val probes: IndexedSeq[TestProbe] = (1 to io.numWorkers).map(_ => TestProbe())
+        val probesIter = probes.iterator
+        var workerRefs : Seq[WorkerRef] = Seq()
+
+        //create a "Worker" which is just a probe.
+        val workerFact = new WorkerFactory {
+          override def createWorker(id: Int, ioSystem: IOSystem, context: ActorContext): ActorRef = {
+            val ref = probesIter.next().ref
+            val worker = WorkerRef(id, ref, ioSystem)
+            workerRefs = workerRefs :+ worker
+            ref
+          }
+        }
+
+        val agent = Agent(Seq[WorkerRef]())
+        val manager: ActorRef = system.actorOf(Props(classOf[WorkerManager], agent, io, workerFact), name = s"idle-check-manager")
+
+        //give the WorkerManager some time to create the Workers
+        eventually{
+          workerRefs must have size io.numWorkers
+        }
+
+        //lets now report Workers as ready, so that the WorkerManager changes its state
+        workerRefs.foreach{x =>
+          manager.tell(WorkerManager.WorkerReady(x), x.worker)
+        }
+
+        //this allows for a bit of timing leeway
+        val window = WorkerManager.IdleCheckFrequency + 50.milliseconds
+
+        //manger should be sending check messages
+        probes.foreach{_.expectMsg(window, Worker.CheckIdleConnections)}
+
+        //no more messages should be sent, until acks are received
+        probes.foreach{_.expectNoMsg(window * 2)}
+
+        //lets now send the acks back
+        probes.foreach{x => manager.tell(WorkerManager.IdleCheckExecuted, x.ref)}
+
+        //now, we should be getting checks again
+        probes.foreach{_.expectMsg(window, Worker.CheckIdleConnections)}
+      }
+    }
+  }
+}

--- a/colossus/src/main/scala/colossus/core/IOSystem.scala
+++ b/colossus/src/main/scala/colossus/core/IOSystem.scala
@@ -78,7 +78,8 @@ object IOSystem {
     sys.actorSystem.actorOf(Props(
       classOf[WorkerManager],
       agent,
-      sys
+      sys,
+      DefaultWorkerFactory
     ), name = s"${actorFriendlyName(sys.name)}-manager")
   }
 

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -207,6 +207,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
       if (timedOut.size > 0) {
         log.debug(s"Terminated ${timedOut.size} idle connections")
       }
+      sender() ! IdleCheckExecuted
     }
     case WorkerManager.RegisterServer(server) => if (!delegators.contains(server.server)){
       try{


### PR DESCRIPTION
This is to fix #265 .  

WorkerManager now doesn't use `context.schedule` it uses `context.scheduleOnce`.  After Workers process the `CheckIdleConnections`, they respond with a 'IdleCheckExecuted`.  Once the WorkerManager receives those acks from all Workers, it will only then schedule another idle check.

Note, this is branched off of the service_client_config branch.  So, I can merge this directly into that, or wait until that branch is approved and merged into develop, then rebase this off of develop.  Either or.