### PR TITLE
bind to worker when worker constructor is used

### DIFF
--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -160,9 +160,8 @@ with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
 
   def this(codec: Codec[P#Input,P#Output], config: ClientConfig, worker: WorkerRef) {
     this(codec, config, worker.generateContext())
+    worker.worker ! WorkerCommand.Bind(this)
   }
-
-  context.worker.worker ! WorkerCommand.Bind(this)
 
   import colossus.core.WorkerCommand._
   import config._

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -199,7 +199,7 @@ object ClientFactory {
   implicit def serviceClientFactory[C <: Protocol] = new ClientFactory[C, Callback, ServiceClient[C], WorkerRef] {
 
     def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], worker: WorkerRef): ServiceClient[C] = {
-      new ServiceClient(provider.clientCodec(), config, worker.generateContext())
+      new ServiceClient(provider.clientCodec(), config, worker)
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/tumblr/colossus/issues/373

Bind to worker only if proper constructor is used as notice says

@DanSimon 