### PR TITLE
tag all collecotrs under metric context

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -112,10 +112,11 @@ class Collection(val config: CollectorConfig) {
   def getOrAdd[T <: Collector : ClassTag](address : MetricAddress, tags: TagMap)(f : (MetricAddress, CollectorConfig) => T): T = {
     def cast(retrieved: Collector): T = retrieved match {
       case t : T => t
-      case other =>
+      case other => {
         throw new DuplicateMetricException(
           s"An event collector with address $address of type ${other.getClass.getSimpleName} already exists"
         )
+      }
     }
     if (collectors.containsKey(address)) {
       cast(collectors.get(address).collector)

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -99,7 +99,8 @@ class DuplicateMetricException(message: String) extends Exception(message)
 
 class Collection(val config: CollectorConfig) {
 
-  val collectors : ConcurrentHashMap[MetricAddress, Collector] = new ConcurrentHashMap[MetricAddress, Collector]()
+  import Collection.TaggedCollector
+  val collectors : ConcurrentHashMap[MetricAddress, TaggedCollector] = new ConcurrentHashMap[MetricAddress, TaggedCollector]()
 
   /**
    * Retrieve a collector of a specific type by address, creating a new one if
@@ -108,22 +109,21 @@ class Collection(val config: CollectorConfig) {
    * @param address Address meant to be relative to this MetricNamespace's namespace
    * @param f Function which takes in an absolutely pathed MetricAddress, and a [[CollectorConfig]] and returns an instance of a [[Collector]]
     */
-  def getOrAdd[T <: Collector : ClassTag](address : MetricAddress)(f : (MetricAddress, CollectorConfig) => T): T = {
+  def getOrAdd[T <: Collector : ClassTag](address : MetricAddress, tags: TagMap)(f : (MetricAddress, CollectorConfig) => T): T = {
     def cast(retrieved: Collector): T = retrieved match {
       case t : T => t
-      case other => {
+      case other =>
         throw new DuplicateMetricException(
           s"An event collector with address $address of type ${other.getClass.getSimpleName} already exists"
         )
-      }
     }
     if (collectors.containsKey(address)) {
-      cast(collectors.get(address))
+      cast(collectors.get(address).collector)
     } else {
       val c = f(address, config)
-      collectors.putIfAbsent(address, c) match {
+      collectors.putIfAbsent(address, TaggedCollector(c, tags)) match {
         case null => c
-        case other => cast(other)
+        case other => cast(other.collector)
       }
     }
   }
@@ -134,7 +134,9 @@ class Collection(val config: CollectorConfig) {
     while (keys.hasMoreElements) {
       val key = keys.nextElement
       Option(collectors.get(key)) foreach { c =>
-        build = build ++ c.tick(interval)
+        build = build ++ c.collector.tick(interval).mapValues { valueMap =>
+          valueMap.map { case (t, tValue) => (t ++ c.tagMap, tValue) }
+        }
       }
     }
     build
@@ -148,4 +150,6 @@ object Collection{
   def withReferenceConf(intervals : Seq[FiniteDuration]) : Collection = {
     new Collection(CollectorConfig(intervals, ConfigFactory.defaultReference().getConfig(MetricSystem.ConfigRoot)))
   }
+
+  case class TaggedCollector(collector: Collector, tagMap: TagMap)
 }

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricNamespaceSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricNamespaceSpec.scala
@@ -36,11 +36,19 @@ class MetricNamespaceSpec extends WordSpec with MustMatchers{
       namespace.collection.collectors.keySet().toSet mustBe expected
 
       //paranoid much?
-      namespace.collection.collectors.get(bar) mustBe a[Rate]
-      namespace.collection.collectors.get(baz) mustBe a[Rate]
-      namespace.collection.collectors.get(barBar) mustBe a[Counter]
-      namespace.collection.collectors.get(barBaz) mustBe a[Rate]
+      namespace.collection.collectors.get(bar).collector mustBe a[Rate]
+      namespace.collection.collectors.get(baz).collector mustBe a[Rate]
+      namespace.collection.collectors.get(barBar).collector mustBe a[Counter]
+      namespace.collection.collectors.get(barBaz).collector mustBe a[Rate]
       //yes
+    }
+
+    "add tags" in {
+      val namespace = MetricContext("/", Collection.withReferenceConf(Seq(1.minute, 1.second)))
+      val subnameSpace: MetricContext = namespace / "foo" * ("a" -> "b") / "bar"
+
+      subnameSpace.tags mustBe Map("a" -> "b")
+
     }
   }
 }


### PR DESCRIPTION
@DanSimon 

solves https://github.com/tumblr/colossus/issues/379

Apply tags on metric context to collectors created with it. Metric context inherit tags from their parents, extra tags can be added on contexts using `*` or `withTags`.