### PR TITLE
ServiceConfig now based on server name, caching

### DIFF
--- a/colossus-examples/src/main/resources/application.conf
+++ b/colossus-examples/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+colossus.service.benchmark {
+  request-metrics = false
+}

--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -31,14 +31,12 @@ object BenchmarkService {
       tcpBacklogSize = Some(1024)
     )
 
-    val serviceConfig = ServiceConfig.Default.copy(requestMetrics = false)
-
     Server.start("benchmark", serverConfig) { new Initializer(_) {
 
       val dateHeader = new DateHeader
       val headers = HttpHeaders(serverHeader, dateHeader)
 
-      def onConnect = ctx => new Service[Http](serviceConfig, ctx){
+      def onConnect = new Service[Http](_){
         def handle = {
           //case req => req.ok(plaintext, headers)
           case req if (req.head.url == "/plaintext")  => req.ok(plaintext, headers)

--- a/colossus-tests/src/test/resources/application.conf
+++ b/colossus-tests/src/test/resources/application.conf
@@ -1,4 +1,8 @@
 colossus.service.config-loading-spec {
 
   request-buffer-size = 9876
- }
+}
+
+colossus.service.bad-config {
+  request-buffer-size = "hello"
+}

--- a/colossus-tests/src/test/resources/application.conf
+++ b/colossus-tests/src/test/resources/application.conf
@@ -1,0 +1,4 @@
+colossus.service.config-loading-spec {
+
+  request-buffer-size = 9876
+ }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceConfigLoadingSpec.scala
@@ -23,6 +23,12 @@ class ServiceConfigLoadingSpec extends WordSpec with MustMatchers{
       config.requestMetrics mustBe true
     }
 
+    "throw a ServiceConfigException when something is wrong" in {
+      intercept[ServiceConfigException] {
+        ServiceConfig.load("bad-config")
+      }
+    }
+
 
   }
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceConfigLoadingSpec.scala
@@ -16,6 +16,14 @@ class ServiceConfigLoadingSpec extends WordSpec with MustMatchers{
       config.requestMetrics mustBe true
       config.requestTimeout mustBe Duration.Inf
     }
+
+    "load a config based on path with fallback to defaults" in {
+      val config = ServiceConfig.load("config-loading-spec")
+      config.requestBufferSize mustBe 9876
+      config.requestMetrics mustBe true
+    }
+
+
   }
 
 }

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -35,7 +35,10 @@ colossus{
       }
     }
     shutdown-timeout : "100 milliseconds"
-    connection-handler{
+  }
+
+  service {
+    default {
       request-timeout : "Inf"
       request-buffer-size : 100
       log-errors : true

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -73,7 +73,7 @@ extends ServiceServer[C#Input, C#Output](provider.provideCodec, config, srv) {
 
   implicit val executor   = context.worker.callbackExecutor
 
-  def this(context: ServerContext)(implicit provider: ServiceCodecProvider[C]) = this(ServiceConfig.Default, context)(provider)
+  def this(context: ServerContext)(implicit provider: ServiceCodecProvider[C]) = this(ServiceConfig.load(context.server.config.name.idString), context)(provider)
 
   protected def unhandled: PartialHandler[C] = PartialFunction[C#Input,Callback[C#Output]]{
     case other =>

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -2,15 +2,18 @@ package colossus
 package service
 
 import colossus.parsing.{ParseException, DataSize}
-import com.typesafe.config.{ConfigFactory, Config}
+import com.typesafe.config.{ConfigFactory, Config, ConfigException}
 import core._
 import controller._
-import util.ExceptionFormatter._
 import akka.event.Logging
 import metrics._
 import scala.concurrent.duration._
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
+import util.ConfigCache
+import util.ExceptionFormatter._
 import Codec._
+
+class ServiceConfigException(err: Throwable) extends Exception("Error loading config", err)
 
 /**
  * Configuration class for a Service Server Connection Handler
@@ -33,29 +36,44 @@ case class ServiceConfig(
 
 object ServiceConfig {
 
-  val ConfigRoot = "colossus.server.connection-handler"
+  val CONFIG_ROOT   = "colossus.service"
+  val DEFAULT_NAME  = "default"
 
-  lazy val Default = this.load()
+  lazy val Default = this.load(DEFAULT_NAME)
 
-  import colossus.metrics.ConfigHelpers._
+  private val cache = new ConfigCache[ServiceConfig] {
 
-  /**
-    * Load a ServiceConfig object from a Config source.  The Config object is expected to be in the form of
-    * `colossus.server.connection-handler`.  Please refer to the reference.conf file.
-    *
-    * Note: you will want to avoid calling this every time a ConnectionHandler is created.  If possible, create the appropriate
-    * instancee before your Server starts up, and then use that instance to configure your ConnectionHandlers.  This is to avoid
-    * loading the Config object on every new connection.
-    * @param config
-    * @return
-    */
-  def load(config : Config = ConfigFactory.load().getConfig(ConfigRoot)) : ServiceConfig = {
-    val timeout = config.getScalaDuration("request-timeout")
-    val bufferSize = config.getInt("request-buffer-size")
-    val logErrors = config.getBoolean("log-errors")
-    val requestMetrics = config.getBoolean("request-metrics")
-    val maxRequestSize = DataSize(config.getString("max-request-size"))
-    ServiceConfig(timeout, bufferSize, logErrors, requestMetrics, maxRequestSize)
+    import colossus.metrics.ConfigHelpers._
+    val baseConfig : Config = ConfigFactory.load()
+
+    /**
+      * Load a ServiceConfig object from a Config source.  The Config object is expected to be in the form of
+      * `colossus.server.connection-handler`.  Please refer to the reference.conf file.
+      *
+      * Note: you will want to avoid calling this every time a ConnectionHandler is created.  If possible, create the appropriate
+      * instancee before your Server starts up, and then use that instance to configure your ConnectionHandlers.  This is to avoid
+      * loading the Config object on every new connection.
+      * @param config
+      * @return
+      */
+    def load(name: String) : Try[ServiceConfig] = Try {
+      val config = try {
+        baseConfig.getConfig(CONFIG_ROOT + "." + name).withFallback(baseConfig.getConfig(CONFIG_ROOT + "." + DEFAULT_NAME))
+      } catch {
+        case ex: ConfigException.Missing => baseConfig.getConfig(CONFIG_ROOT + "." + DEFAULT_NAME)
+      }
+      val timeout         = config.getScalaDuration("request-timeout")
+      val bufferSize      = config.getInt("request-buffer-size")
+      val logErrors       = config.getBoolean("log-errors")
+      val requestMetrics  = config.getBoolean("request-metrics")
+      val maxRequestSize  = DataSize(config.getString("max-request-size"))
+      ServiceConfig(timeout, bufferSize, logErrors, requestMetrics, maxRequestSize)
+    }
+  }
+
+  def load(name: String): ServiceConfig = cache.get(name) match {
+    case Success(c) => c
+    case Failure(err) => throw new ServiceConfigException(err)
   }
 }
 

--- a/colossus/src/main/scala/colossus/util/ConfigCache.scala
+++ b/colossus/src/main/scala/colossus/util/ConfigCache.scala
@@ -1,0 +1,24 @@
+package colossus
+package util
+
+import java.util.concurrent.ConcurrentHashMap
+import scala.util.Try
+
+abstract class ConfigCache[T] {
+
+  protected def load(path: String): Try[T]
+
+  private val cache = new ConcurrentHashMap[String, Try[T]]
+
+  def get(path: String): Try[T] = {
+    Option(cache.get(path)) match {
+      case Some(t) => t
+      case None => {
+        val loaded = load(path)
+        cache.putIfAbsent(path, loaded)
+        loaded
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This introduces two changes to how loading config for service server connection handlers works:

1.  Configuration is now path-based, where for a server named `foo`, the config is checked in `colossus.service.foo` falling back to defaults in `colossus.service.default`.  While it is still possible to directly pass a config object to load a service config, by default it will now use the default loaded config and check these paths.  So in practice users should almost never have to create `ServiceConfig` objects.
2.  Since each instantiation of a connection handler attempts to load config, basic caching of `ServiceConfig`based on service name has been added.  Again this is only used when the path-based config is used, so users are still free if (for some odd reason) they want to differently configure different connection handlers for the same server.