### PR TITLE
adding config-less constructors for HttpService

### DIFF
--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -79,10 +79,16 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
   }
 
   abstract class HttpService(config: ServiceConfig, context: ServerContext)
-    extends BaseHttpServiceHandler[Http](config, Http.defaults.httpServerDefaults, context)
+  extends BaseHttpServiceHandler[Http](config, Http.defaults.httpServerDefaults, context) {
+      
+    def this(context: ServerContext) = this(ServiceConfig.load(context.server.name.idString), context)
+  }
 
   abstract class StreamingHttpService(config: ServiceConfig, context: ServerContext)
-    extends BaseHttpServiceHandler[StreamingHttp](config, StreamingHttpProvider, context)
+  extends BaseHttpServiceHandler[StreamingHttp](config, StreamingHttpProvider, context) {
+
+    def this(context: ServerContext) = this(ServiceConfig.load(context.server.name.idString), context)
+  }
 
   implicit object StreamingHttpProvider extends ServiceCodecProvider[StreamingHttp] {
     def provideCodec = new StreamingHttpServerCodec


### PR DESCRIPTION
This adds extra constructors to `HttpService` and `StreamingHttpService` that use new path-based config loading.