### PR TITLE
Several changes to metrics

### DIFF
--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -1,9 +1,17 @@
 colossus {
   metrics {
     system {
-      collect-system-metrics: true
+      # name is only used when naming internal actors or logging, generally this
+      # only needs to be changed in the rare event multiple metric systems are
+      # required.  Name is not used at all in metric namespaces or addresses
+      name = "metrics"
+
+      #system metrics include stats like GC time and memory usage
+      system-metrics{
+        enabled = true
+        namespace = "/"
+      }
       collection-intervals: ["1 second", "1 minute"]
-      namespace: "/"
       enabled: true
       collectors-defaults {
         rate {

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -149,7 +149,7 @@ class Collection(val config: CollectorConfig) {
 //this project is the lowest common denominator for both.
 object Collection{
   def withReferenceConf(intervals : Seq[FiniteDuration]) : Collection = {
-    new Collection(CollectorConfig(intervals, ConfigFactory.defaultReference().getConfig(MetricSystem.ConfigRoot)))
+    new Collection(CollectorConfig(intervals, ConfigFactory.defaultReference().getConfig(MetricSystemConfig.ConfigRoot)))
   }
 
   case class TaggedCollector(collector: Collector, tagMap: TagMap)

--- a/colossus-metrics/src/main/scala/colossus/metrics/StatReporter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/StatReporter.scala
@@ -24,7 +24,7 @@ case class MetricReporterConfig(
   includeHostInGlobalTags: Boolean = true
 )
 
-class MetricReporter(intervalAggregator : ActorRef, config: MetricReporterConfig, namespace: MetricAddress) extends Actor with ActorLogging{
+class MetricReporter(intervalAggregator : ActorRef, config: MetricReporterConfig, metricSystemName: String) extends Actor with ActorLogging{
   import MetricReporter._
   import config._
 
@@ -35,9 +35,7 @@ class MetricReporter(intervalAggregator : ActorRef, config: MetricReporterConfig
     case _: Exception                => Restart
   }
 
-  private val strippedAddress = namespace.toString.replace("/", "")
-
-  private def createSender(sender : MetricSender) = context.actorOf(sender.props, name = s"$strippedAddress-${sender.name}-sender")
+  private def createSender(sender : MetricSender) = context.actorOf(sender.props, name = s"$metricSystemName-${sender.name}-sender")
 
   private var reporters = Seq[ActorRef]()
 
@@ -81,8 +79,8 @@ class MetricReporter(intervalAggregator : ActorRef, config: MetricReporterConfig
 object MetricReporter {
   case object ResetSender
 
-  def apply(config: MetricReporterConfig, intervalAggregator : ActorRef, namespace: MetricAddress)(implicit fact: ActorRefFactory): ActorRef = {
-    fact.actorOf(Props(classOf[MetricReporter], intervalAggregator, config, namespace))
+  def apply(config: MetricReporterConfig, intervalAggregator : ActorRef, name: String)(implicit fact: ActorRefFactory): ActorRef = {
+    fact.actorOf(Props(classOf[MetricReporter], intervalAggregator, config, name))
   }
 
 }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -103,7 +103,7 @@ object Counter extends CollectorConfigLoader{
   def apply(address : MetricAddress, configPath : String)(implicit ns : MetricNamespace) : Counter = {
     ns.getOrAdd(address){ (fullAddress, config) =>
       val params = resolveConfig(config.config, fullAddress, configPath, DefaultConfigPath)
-      createCounter(address, params.getBoolean("enabled"))
+      createCounter(fullAddress, params.getBoolean("enabled"))
     }
   }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -112,7 +112,7 @@ object Histogram extends CollectorConfigLoader{
       val sampleRate = params.getDouble("sample-rate")
       val pruneEmpty = params.getBoolean("prune-empty")
       val enabled = params.getBoolean("enabled")
-      createHistogram(address, percentiles, sampleRate, pruneEmpty, enabled, config.intervals)
+      createHistogram(fullAddress, percentiles, sampleRate, pruneEmpty, enabled, config.intervals)
     }
   }
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/package.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/package.scala
@@ -42,6 +42,10 @@ package object metrics {
     }.toSeq
     def fragments: Seq[MetricFragment] = fragments(TagMap.Empty)
 
+    def withTags(newtags: TagMap): MetricMap = underlying.map{ case (address, values) =>
+      address -> values.map{case (tags, value) => (tags ++ newtags, value)}
+    }
+
   }
 
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/CollectionSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CollectionSpec.scala
@@ -1,6 +1,5 @@
 package colossus.metrics
 
-import colossus.metrics.MetricAddress
 import org.scalatest.{MustMatchers, WordSpec}
 import scala.concurrent.duration._
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
@@ -42,6 +42,13 @@ class CounterSpec extends MetricIntegrationSpec {
       counter.tick(1.second) must equal(Map())
     }
 
+    "have correct address" in {
+      implicit val ns = MetricContext("/foo", Collection.withReferenceConf(Seq(1.second))) / "bar"
+      val c = Counter("/baz")
+      c.address must equal(MetricAddress("/foo/bar/baz"))
+
+    }
+
     
   }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
@@ -64,6 +64,13 @@ class HistogramSpec extends MetricIntegrationSpec {
   }
 
   "Histogram" must {
+
+    "correctly generate address based on namespace" in {
+      implicit val ns = MetricContext("/foo", Collection.withReferenceConf(Seq(1.second))) / "bar"
+      val h = Histogram("baz")
+      h.address must equal(MetricAddress("/foo/bar/baz"))
+    }
+
     "get tags right" in {
       implicit val col = MetricContext("/", Collection.withReferenceConf(Seq(1.second)))
       val addr = MetricAddress.Root / "hist"

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricReportFilterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricReportFilterSpec.scala
@@ -68,7 +68,7 @@ class MetricReportFilterSpec(_system : ActorSystem) extends MetricIntegrationSpe
 
     val config = MetricReporterConfig(Seq(EchoSender(probe.ref)), None, filter, false)
 
-    val reporter = sys.actorOf(Props(classOf[MetricReporter], mockAggregator.ref, config, Root / "sys1"))
+    val reporter = MetricReporter(config, mockAggregator.ref, "sys1")
 
     mockAggregator.send(reporter, ReportMetrics(metricMap))
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -32,4 +32,21 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
       //no exceptions means the test passed
     }
   }
+
+  "SystemMetricsCollector" must {
+    "generate system metrics" in {
+      implicit val ns = TestNamespace() / "foo" * ("a" -> "b")
+      val s = new SystemMetricsCollector(ns)
+      val m = s.metrics
+
+      m contains "/foo/system/gc/msec" mustBe true
+      m contains "/foo/system/gc/cycles" mustBe true
+      m contains "/foo/system/fd_count" mustBe true
+      m contains "/foo/system/memory" mustBe true
+
+      //verify the namespace's tags are being added
+      m("/foo/system/fd_count") contains (Map("a" -> "b")) mustBe true
+    }
+
+  }
 }

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -25,8 +25,10 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
 
   "MetricSystem" must {
     "allow multiple systems to start without any conflicts" in {
-      val m1 = MetricSystem(MetricAddress("/sys1"), Seq(), false, ConfigFactory.empty())
-      val m2 = MetricSystem(MetricAddress("/sys2"), Seq(), false, ConfigFactory.empty())
+      val config = MetricSystemConfig.load()
+      
+      val m1 = MetricSystem(config)
+      val m2 = MetricSystem(config.copy(name = "different-name"))
       //no exceptions means the test passed
     }
   }

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -64,6 +64,13 @@ class RateSpec extends MetricIntegrationSpec {
       //s2("foo/count").size must equal(1)
       s2("foo")(Map("a" -> "b")) must equal(1)
     }
+
+    "have the right address" in {
+      implicit val ns = MetricContext("/foo", Collection.withReferenceConf(Seq(1.second))) / "bar"
+      val r = Rate("/baz")
+      r.address must equal(MetricAddress("/foo/bar/baz"))
+      
+    }
   }
 }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/Util.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/Util.scala
@@ -53,3 +53,9 @@ trait EventuallyEquals {
 object EventuallyEquals extends EventuallyEquals
 
 
+object TestNamespace {
+
+  def apply(): MetricNamespace = MetricContext("/", Collection.withReferenceConf(Seq(1.second)), Map())
+
+}
+

--- a/colossus-tests/src/test/scala/colossus/IOSystemConfigSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/IOSystemConfigSpec.scala
@@ -13,7 +13,6 @@ class IOSystemConfigSpec extends ColossusSpec{
       io.numWorkers mustBe Runtime.getRuntime.availableProcessors()
       io.name mustBe "iosystem"
       io.metrics.namespace mustBe MetricAddress.Root
-      io.namespace.namespace mustBe MetricAddress("iosystem")
       shutdownIOSystem(io)
     }
 
@@ -29,7 +28,6 @@ class IOSystemConfigSpec extends ColossusSpec{
       val io = IOSystem("my-io-system", c.getConfig(IOSystem.ConfigRoot))
       io.numWorkers mustBe 2
       io.name mustBe "my-io-system"
-      io.namespace.namespace mustBe MetricAddress("/my-io-system")
       shutdownIOSystem(io)
     }
   }

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -20,7 +20,8 @@ case class ControllerConfig(
   outputBufferSize: Int,
   sendTimeout: Duration,
   inputMaxSize: DataSize = 1.MB,
-  flushBufferOnClose: Boolean = true
+  flushBufferOnClose: Boolean = true,
+  metricsEnabled: Boolean = true
 )
 
 //used to terminate input streams when a connection is closing

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -59,8 +59,12 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
   
   
   //this has to be lazy to avoid initialization-order NPE
-  lazy val inputSizeHistogram = Histogram("input_size", sampleRate = 0.10, percentiles = List(0.75,0.99))
-  lazy val inputSizeTracker = new ParserSizeTracker(Some(controllerConfig.inputMaxSize), Some(inputSizeHistogram))
+  lazy val inputSizeHistogram = if (controllerConfig.metricsEnabled) {
+    Some(Histogram("input_size", sampleRate = 0.10, percentiles = List(0.75,0.99)))
+  } else {
+    None
+  }
+  lazy val inputSizeTracker = new ParserSizeTracker(Some(controllerConfig.inputMaxSize), inputSizeHistogram)
 
   private[controller] def inputOnClosed() {
     inputState match {

--- a/colossus/src/main/scala/colossus/core/IOSystem.scala
+++ b/colossus/src/main/scala/colossus/core/IOSystem.scala
@@ -134,7 +134,7 @@ class IOSystem private[colossus](
   /**
    * The namespace of this IOSystem, used by metrics
    */
-  val namespace = MetricContext(MetricAddress(name), metrics.collection)
+  val namespace = metrics / name
 
   //ENSURE THIS IS THE LAST THING INITIALIZED!!!
   private[colossus] val workerManager : ActorRef = managerFactory(workers, this)

--- a/colossus/src/main/scala/colossus/core/IOSystem.scala
+++ b/colossus/src/main/scala/colossus/core/IOSystem.scala
@@ -30,6 +30,8 @@ object IOSystem {
     apply("iosystem")
   }
 
+
+
   /**
     * Create a new IOSystem.
     *
@@ -40,12 +42,17 @@ object IOSystem {
     * @param sys
     * @return
     */
-  def apply(name : String, ioConfig : Config = ConfigFactory.load().getConfig(ConfigRoot))(implicit sys : ActorSystem) : IOSystem = {
+  def apply(
+    name : String,
+    ioConfig : Config = ConfigFactory.load().getConfig(ConfigRoot),
+    metrics: Option[MetricSystem] = None
+  )(implicit sys : ActorSystem) : IOSystem = {
 
     import colossus.metrics.ConfigHelpers._
 
+    val ms: MetricSystem = metrics.getOrElse(MetricSystem())
+
     val workerCount : Option[Int] = ioConfig.getIntOption("num-workers")
-    val ms = MetricSystem()
     apply(name, workerCount, ms)
   }
 
@@ -134,7 +141,7 @@ class IOSystem private[colossus](
   /**
    * The namespace of this IOSystem, used by metrics
    */
-  val namespace = metrics / name
+  val namespace: MetricNamespace = metrics
 
   //ENSURE THIS IS THE LAST THING INITIALIZED!!!
   private[colossus] val workerManager : ActorRef = managerFactory(workers, this)

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -123,7 +123,7 @@ case class ServerRef private[colossus] (config: ServerConfig, server: ActorRef, 
 
   def serverState = serverStateAgent.get()
 
-  val namespace : MetricNamespace = MetricContext(name, system.namespace.collection)
+  val namespace : MetricNamespace = system.namespace / name
 
   def maxIdleTime = {
     if(serverStateAgent().connectionVolumeState == ConnectionVolumeState.HighWater) {

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -155,7 +155,7 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
 
   private val workerIdTag = Map("worker" -> (io.name + "-" + workerId.toString))
 
-  implicit val ns = io.namespace
+  implicit val ns = io.namespace / io.name
   val eventLoops              = Rate("worker/event_loops", "worker-event-loops")
   val numConnections          = Counter("worker/connections", "worker-connections")
   val rejectedConnections     = Rate("worker/rejected_connections", "worker-rejected-connections")

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -113,7 +113,7 @@ class DroppedReplyException extends ServiceServerException("Dropped Reply")
 abstract class ServiceServer[I,O]
   (codec: ServerCodec[I,O], config: ServiceConfig, serverContext: ServerContext)
 extends Controller[I,O](codec,
-  ControllerConfig(config.requestBufferSize, Duration.Inf, config.maxRequestSize),
+  ControllerConfig(config.requestBufferSize, Duration.Inf, config.maxRequestSize,true, config.requestMetrics),
   serverContext.context)
 with ServerConnectionHandler {
   import ServiceServer._


### PR DESCRIPTION
This PR makes a whole bunch of necessary changes to get metrics properly working:

* `MetricSystem` no longer has a configurable root, it's namespace is always `/`.  Now that we have proper metric namespaces there's no need to have a preset root.
* `MetricSystem` now has a `name`, however this is only used for naming actors so in most cases it can stay as the default
* A new `SystemMetricsConfig` is used to configure the system metrics.  
* `IOSystem` also no longer has a configurable root.  Its name is not used in its metrics namespace
* Servers now create their own namespace using the server's name.  Workers use the IOSystem's name.
* Created a new `MetricSystemConfig` that loads config settings for metric systems.  This simplified the constructors a bit
* `IOSystem` now has a constructor that can take in an `IOSystemConfig` and a `MetricSystem`
* Fixed a bug where histograms and counters were not being created with the full address
* Fixed a bug where system metrics did not have the hostname tag
* `ControllerConfig`now has a new `metricsEnabled` parameter, which `ServiceServer` propagates based on its own `requestMetrics` config value.  This is used for the `input_size` metric.
* Changed `MetricInterval` to `CollectionInterval` to keep naming consistent

