### PR TITLE
server settings is now path-based with defaults

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -43,7 +43,7 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         """.stripMargin
       val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
       withIOSystem{ implicit io =>
-        val s = Server.basic("my-server", c.getConfig(Server.ConfigRoot))(context => new EchoHandler(context))
+        val s = Server.basic("my-server", c)(context => new EchoHandler(context))
         waitForServer(s)
         s.name mustBe MetricAddress("my-server")
         val settings = s.config.settings

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -33,12 +33,15 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
 
     "load user overrides" in {
       val userOverrides =
-        """colossus.server{
+        """colossus.server.my-server{
           |    port : 9888
           |    max-connections : 1000
           |    max-idle-time : "1 second"
-          |    tcp-backlog-size : 100
           |    shutdown-timeout : "2 seconds"
+          |}
+          |colossus.server {
+          |   shutdown-timeout : "3 seconds"
+          |    tcp-backlog-size : 100
           |}
         """.stripMargin
       val c = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -5,7 +5,7 @@ import akka.actor._
 import java.net.InetSocketAddress
 
 import akka.agent.Agent
-import com.typesafe.config.Config
+import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.concurrent.duration._
 
@@ -70,6 +70,8 @@ case class ServerSettings(
 }
 
 object ServerSettings {
+  val ConfigRoot = "colossus.server"
+
   def extract(config : Config) : ServerSettings = {
     import colossus.metrics.ConfigHelpers._
 
@@ -88,6 +90,17 @@ object ServerSettings {
       delegatorCreationPolicy = delegatorCreationPolicy,
       shutdownTimeout         = config.getFiniteDuration("shutdown-timeout")
     )
+  }
+
+  def load(name: String, config: Config = ConfigFactory.load()): ServerSettings = {
+    val nameRoot = ConfigRoot + "." + name
+    val resolved = if (config.hasPath(nameRoot)) {
+      config.getConfig(nameRoot).withFallback(config.getConfig(ConfigRoot))
+    } else {
+      config.getConfig(ConfigRoot)
+    }
+    extract(resolved)
+
   }
 }
 

--- a/colossus/src/main/scala/colossus/core/ServerDSL.scala
+++ b/colossus/src/main/scala/colossus/core/ServerDSL.scala
@@ -5,8 +5,7 @@ object ServerDSL {
   type Receive = PartialFunction[Any, Unit]
 }
 import ServerDSL._
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 
 /**
  * An instance of this is handed to every new server connection handler
@@ -39,7 +38,6 @@ class DSLDelegator(server : ServerRef, _worker : WorkerRef, initializer: Initial
 //this is mixed in by Server
 trait ServerDSL {
 
-  val ConfigRoot = "colossus.server"
 
   /**
     * Create a new Server
@@ -52,9 +50,9 @@ trait ServerDSL {
     * @param io
     * @return
     */
-  def start(name: String, serverConfig: Config = loadConfig)(initializer: WorkerRef => Initializer)(implicit io: IOSystem): ServerRef = {
+  def start(name: String, serverConfig: Config = ConfigFactory.load())(initializer: WorkerRef => Initializer)(implicit io: IOSystem): ServerRef = {
 
-    start(name, ServerSettings.extract(serverConfig))(initializer)
+    start(name, ServerSettings.load(name, serverConfig))(initializer)
   }
 
   /**
@@ -68,9 +66,8 @@ trait ServerDSL {
     * @return
     */
   def start(name: String, port: Int)(initializer: WorkerRef => Initializer)(implicit io: IOSystem): ServerRef = {
-    val serverConfig = loadConfig
-    val serverSettings = ServerSettings.extract(serverConfig)
-    start(name, serverSettings.copy(port = port))(initializer)
+    val serverSettings = ServerSettings.load(name).copy(port = port)
+    start(name, serverSettings)(initializer)
   }
 
   /**
@@ -102,10 +99,10 @@ trait ServerDSL {
     * @param io
     * @return
     */
-  def basic(name: String, serverConfig: Config = loadConfig)
+  def basic(name: String, serverConfig: Config = ConfigFactory.load())
            (handlerFactory: ServerContext => ServerConnectionHandler)(implicit io: IOSystem): ServerRef = {
 
-    basic(name, ServerSettings.extract(serverConfig))(handlerFactory)
+    basic(name, ServerSettings.load(name, serverConfig))(handlerFactory)
   }
 
   /**
@@ -140,5 +137,4 @@ trait ServerDSL {
     })
   }
 
-  private def loadConfig = ConfigFactory.load().getConfig(ConfigRoot)
 }


### PR DESCRIPTION
Similar to everything else, configuring server's now first looks for the configuration at the path `colossus.server.<name>`, falling back to just `colossus.server` defined in the reference.conf