### PR TITLE
Refactoring AsyncServiceClient into FutureClient

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
@@ -35,9 +35,9 @@ abstract class ServiceSpec[C <: Protocol](implicit provider: ServiceCodecProvide
     requestTimeout = timeout
   )
 
-  def client(timeout: FiniteDuration = requestTimeout) = AsyncServiceClient[C](clientConfig(timeout))//, clientProvider.clientCodec)
+  def client(timeout: FiniteDuration = requestTimeout) = FutureClient[C](clientConfig(timeout))
 
-  def withClient(f: AsyncServiceClient[Request, Response] => Unit) {
+  def withClient(f: FutureClient[C] => Unit) {
     val c = client()
     f(c)
     c.disconnect()

--- a/colossus-tests/src/it/scala/colossus/BaseRedisITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/BaseRedisITSpec.scala
@@ -5,7 +5,7 @@ import java.net.InetSocketAddress
 import akka.util.ByteString
 import colossus.metrics.MetricSystem
 import colossus.protocols.redis._
-import colossus.service.{AsyncServiceClient, ClientConfig}
+import colossus.service.ClientConfig
 import colossus.testkit.ColossusSpec
 import org.scalatest.concurrent.{ScaledTimeSpans, ScalaFutures}
 import org.scalatest.time.Span

--- a/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala
@@ -7,7 +7,7 @@ import colossus.metrics.MetricSystem
 import colossus.protocols.memcache._
 import colossus.protocols.memcache.MemcacheReply._
 import colossus.protocols.memcache.{MemcacheCommand, MemcacheReply}
-import colossus.service.{AsyncServiceClient, ClientConfig}
+import colossus.service.{FutureClient, ClientConfig}
 import colossus.testkit.ColossusSpec
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
@@ -27,7 +27,7 @@ a Memcached client, which communicates with memcached
  */
 class MemcacheITSpec extends ColossusSpec with ScalaFutures{
 
-  type AsyncMemacheClient = AsyncServiceClient[MemcacheCommand, MemcacheReply]
+  type AsyncMemacheClient = FutureClient[Memcache]
 
   implicit val defaultPatience = PatienceConfig(timeout = Span(2, Seconds), interval = Span(50, Millis))
 

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -5,7 +5,7 @@ import java.net.InetSocketAddress
 import akka.pattern.ask
 import akka.util.{ByteString, Timeout}
 import colossus.core._
-import colossus.service.{AsyncServiceClient, ClientConfig}
+import colossus.service.{FutureClient, ClientConfig, Protocol}
 
 import scala.concurrent.{Await, Future, ExecutionContext}
 import scala.concurrent.duration._
@@ -79,7 +79,7 @@ object TestClient {
     port: Int,
     waitForConnected: Boolean = true,
     connectRetry : RetryPolicy = BackoffPolicy(50.milliseconds, BackoffMultiplier.Exponential(5.seconds))
-  ) : AsyncServiceClient[ByteString, ByteString] = {
+  ) : FutureClient[Raw] = {
     val config = ClientConfig(
       name = "/test",
       requestTimeout = 100.milliseconds,
@@ -88,18 +88,18 @@ object TestClient {
       failFast = true,
       connectRetry = connectRetry
     )
-    val client = AsyncServiceClient[Raw](config)(RawClientCodecProvider, io)
+    val client = FutureClient[Raw](config)(RawClientCodecProvider, io)
     if (waitForConnected) {
       TestClient.waitForConnected(client)
     }
     client
   }
 
-  def waitForConnected[I,O](client: AsyncServiceClient[I,O], maxTries: Int = 10) {
+  def waitForConnected[P <: Protocol](client: FutureClient[P], maxTries: Int = 10) {
     waitForStatus(client, ConnectionStatus.Connected, maxTries)
   }
 
-  def waitForStatus[I,O](client: AsyncServiceClient[I, O], status: ConnectionStatus, maxTries: Int = 5) {
+  def waitForStatus[P <: Protocol](client: FutureClient[P], status: ConnectionStatus, maxTries: Int = 5) {
     var tries = maxTries
     var last = Await.result(client.connectionStatus, 10.seconds)
     while (last != status) {

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -2,7 +2,7 @@ package colossus
 
 import testkit._
 import core._
-import service.{Service, AsyncServiceClient, Callback}
+import service.{Service, Callback}
 import Callback.Implicits._
 
 import akka.actor._

--- a/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
+++ b/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
@@ -73,7 +73,7 @@ class TaskTest extends ColossusSpec {
       }
     }
 
-    "unbind by killing self actor" ignore {
+    "unbind by killing self actor" in {
       withIOSystem{ implicit io =>
         val probe = TestProbe()
         val task = Task.start(new Task(_) {

--- a/colossus-tests/src/test/scala/colossus/service/AsyncServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/AsyncServiceClientSpec.scala
@@ -54,7 +54,7 @@ class AsyncServiceClientSpec extends ColossusSpec {
     }
 
     "shutdown when connection is unbound" in {
-      var client: Option[AsyncServiceClient[ByteString, ByteString]] = None
+      var client: Option[FutureClient[Raw]] = None
       withIOSystem{ implicit io =>
         withServer(makeServer()) {
           client = Some(TestClient(io, TEST_PORT, connectRetry = NoRetry))

--- a/colossus-tests/src/test/scala/colossus/service/AsyncServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/AsyncServiceClientSpec.scala
@@ -15,13 +15,13 @@ import Callback.Implicits._
 import akka.util.ByteString
 import RawProtocol._
 
-class AsyncServiceClientSpec extends ColossusSpec {
+class FutureClientSpec extends ColossusSpec {
 
   def makeServer()(implicit sys: IOSystem): ServerRef = {
-    Service.basic[Raw]("redis-test", TEST_PORT){case x => x}
+    Service.basic[Raw]("future-client-test", TEST_PORT){case x => x}
   }
 
-  "AsyncServiceClient" must {
+  "FutureClient" must {
     "send a command" in {
       withIOSystem{ implicit io =>
         withServer(makeServer()) {
@@ -40,7 +40,7 @@ class AsyncServiceClientSpec extends ColossusSpec {
       }
     }
 
-    "disconnect from server" taggedAs(org.scalatest.Tag("test")) in {
+    "disconnect from server" in {
       withIOSystem{ implicit io =>
         val server = makeServer()
         withServer(server) {
@@ -52,6 +52,45 @@ class AsyncServiceClientSpec extends ColossusSpec {
         }
       }
     }
+
+    "properly fail requests after disconnected" in {
+      withIOSystem{ implicit io =>
+        withServer(makeServer()) {
+          val client = TestClient(io, TEST_PORT)
+          client.disconnect()
+          val toolate = client.send(ByteString("bar"))
+          intercept[ServiceClientException] {
+            Await.result(toolate, 500.milliseconds)
+          }
+        }
+      }
+
+    }
+
+    "allow graceful disconnect" in {
+      withIOSystem{ implicit io =>
+        withServer(makeServer()) {
+          val client = TestClient(io, TEST_PORT)
+          val future = client.send(ByteString("foo"))
+          client.disconnect()
+          val toolate = client.send(ByteString("bar"))
+          Await.result(future, 500.milliseconds) must equal(ByteString("foo"))
+          intercept[ServiceClientException] {
+            Await.result(toolate, 500.milliseconds)
+          }
+        }
+      }
+    }
+
+    "properly buffer messages before workeritem bound" in {
+      withIOSystem{ implicit io =>
+        val client = TestClient(io, TEST_PORT, waitForConnected = false)
+        intercept[NotConnectedException] {
+          Await.result(client.send(ByteString("foo")), 500.milliseconds)
+        }
+      }
+    }
+
 
     "shutdown when connection is unbound" in {
       var client: Option[FutureClient[Raw]] = None

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -351,7 +351,7 @@ class ServiceClientSpec extends ColossusSpec {
             name = "/test",
             requestTimeout = 1.second
           )
-          val client = AsyncServiceClient[Redis](config)//Redis.futureClient(config)
+          val client = FutureClient[Redis](config)
           TestClient.waitForConnected(client)
           TestUtil.expectServerConnections(server, 1)
           Await.result(client.send(Command("bye")), 500.milliseconds) must equal(reply)
@@ -397,7 +397,7 @@ class ServiceClientSpec extends ColossusSpec {
             connectRetry = BackoffPolicy(50.milliseconds, BackoffMultiplier.Exponential(5.seconds), maxTries = Some(2))
           )
 
-          val client = AsyncServiceClient[Raw](config)
+          val client = FutureClient[Raw](config)
           TestUtil.expectServerConnections(server, 0)
           TestClient.waitForStatus(client, ConnectionStatus.NotConnected)
         }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -126,7 +126,7 @@ class ServiceDSLSpec extends ColossusSpec {
         import protocols.http._
         import Http.defaults._
 
-        val s = AsyncServiceClient[Http]("localhost", TEST_PORT, 1.second)
+        val s = FutureClient[Http]("localhost", TEST_PORT, 1.second)
         val t = Http.futureClient(s)
         val q : HttpClient[Future] = t
       }

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -80,13 +80,6 @@ trait ConnectionHandler extends WorkerItem {
    */
   def idleCheck(period: Duration)
 
-  /**
-   * the connection handler should begin its graceful shutdown procedure.  For
-   * both servers and clients this can be triggered either by a call to
-   * gracefulDisconnect or to become.  For ServerConnectionHandlers this can
-   * also occur when the Server begins shutting down.
-   */
-  def shutdownRequest()
 }
 
 /**
@@ -150,7 +143,7 @@ abstract class BasicSyncHandler(context: Context) extends WorkerItem(context) wi
   def receivedMessage(message: Any, sender: ActorRef){}
   def readyForData(out: DataOutBuffer): MoreDataResult = MoreDataResult.Complete
   def idleCheck(period: Duration){}
-  def shutdownRequest (){
+  override def shutdownRequest (){
     endpoint.disconnect()
   }
 

--- a/colossus/src/main/scala/colossus/core/CoreHandler.scala
+++ b/colossus/src/main/scala/colossus/core/CoreHandler.scala
@@ -102,7 +102,7 @@ abstract class CoreHandler(ctx: Context) extends WorkerItem(ctx) with Connection
     }
   }
 
-  final def shutdownRequest() {
+  final override def shutdownRequest() {
     connectionState match {
       case Connected(endpoint) => {
         _connectionState = ShuttingDown(endpoint)

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -105,9 +105,6 @@ class WorkerItemManager(worker: WorkerRef, log: LoggingAdapter) {
       val item = workerItems(id)
       workerItems -= id
       item.setUnbind()
-      if (item.context.proxyExists) {
-        item.context.proxy ! PoisonPill
-      }
     } else {
       log.error(s"Attempted to unbind worker $id that is not bound to this worker")
     }

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -6,117 +6,37 @@ import core._
 import akka.actor._
 import akka.util.{ByteString, Timeout}
 import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 
-sealed trait ConnectionEvent
-sealed trait ClientConnectionEvent extends ConnectionEvent
-object ConnectionEvent {
-  case class ReceivedData(data: ByteString) extends ConnectionEvent
-  case object ReadyForData extends ConnectionEvent
-  //maybe include an id or something
-  case class WriteAck(status: WriteStatus) extends ConnectionEvent
-  case class ConnectionTerminated(cause : DisconnectCause) extends ConnectionEvent
 
-  //for server connections, Connected is send immediately after Bound.  For
-  //clients, the messages are more semantic, Bound is sent immediately while
-  //connected only when the connection is fully established
-  case class Bound(id: Long) extends ConnectionEvent
-
-  case object Connected extends ConnectionEvent
-  //for client connections
-  case object ConnectionFailed extends ClientConnectionEvent
-
-  case object Unbound extends ConnectionEvent
-}
-
-/**
- * This correctly routes messages to the right worker and handler
- */
-class ClientProxy(config: ClientConfig, system: IOSystem, handlerFactory: ActorRef => Context => ClientConnectionHandler) extends Actor with ActorLogging  with Stash {
-  import WorkerCommand._
-  import ConnectionEvent._
-
-  override def preStart() {
-    system.workerManager ! IOCommand.BindWorkerItem(handlerFactory(self))
-    context.become(binding)
-  }
-
-  def receive = binding
-
-  def binding: Receive = {
-    case Bound(id) => {
-      context.become(proxy(id, sender))
-      unstashAll()
-    }
-    case x => stash()
-
-  }
-
-
-  def proxy(connectionId: Long, worker: ActorRef): Receive = {
-    case Bound(wat) => {
-    }
-    case Unbound => context.become(dead)
-    case Connected => {} //we ignore this because there's nothing to do with it.  Maybe add a callback in the future
-    case AsyncServiceClient.Disconnect => {
-      worker ! Disconnect(connectionId)
-      context.become(dying)
-    }
-    case m: Worker.MessageDeliveryFailed => {
-    }
-    case x => worker ! Message(connectionId, x)
-  }
-
-  def dying: Receive = {
-    case Unbound => context.become(dead)
-    case AsyncServiceClient.GetConnectionStatus(promise) => {
-      promise.success(ConnectionStatus.NotConnected)  //we have to fulfill this since it will never reach the handler
-    }
-  }
-
-  def dead: Receive = {
-    case AsyncServiceClient.GetConnectionStatus(promise) => {
-      promise.success(ConnectionStatus.NotConnected)
-    }
-  }
-
-}
-
-trait AsyncServiceClient[I,O] {
+class ProxyWatchdog(proxy: ActorRef, signal: AtomicBoolean) extends Actor {
   
-  def send(request: I): Future[O]
+  override def preStart() {
+    context.watch(proxy)
+  }
 
+  def receive = {
+    case Terminated(ref) => signal.set(true)
+  }
+}
+
+trait FutureClient[C <: Protocol] extends Sender[C, Future] {
   def connectionStatus: Future[ConnectionStatus]
   def disconnect()
-
-  /** Kills the proxy actor and terminates the underlying connection.  
-   * This is different from disconnect because disconnect will not kill the
-   * proxy actor (useful for verifying that a connection has terminated.  Once
-   * this method has been called, any future calls to connectionStatus will
-   * return a Future that never completes
-   *
-   * maybe there's a better way to do this, but AsyncServiceClient isn't used
-   * much outside of tests, so we need some more use cases
-   */
-  def kill()
-
   def clientConfig : ClientConfig
 }
 
-trait FutureClient[C <: Protocol] extends AsyncServiceClient[C#Input, C#Output] with Sender[C, Future]
-
-object AsyncServiceClient {
+object FutureClient {
 
   sealed trait ClientCommand
 
-  case object Disconnect extends ClientCommand
   case class GetConnectionStatus(promise: Promise[ConnectionStatus] = Promise()) extends ClientCommand
 
-  def create[C <: Protocol](config: ClientConfig)(implicit io: IOSystem, provider: ClientCodecProvider[C]): AsyncServiceClient[C#Input, C#Output] with FutureClient[C] = {
+  def create[C <: Protocol](config: ClientConfig)(implicit io: IOSystem, provider: ClientCodecProvider[C]): FutureClient[C] = {
     val gen = new AsyncHandlerGenerator(config, provider.clientCodec())
-    val actor = io.actorSystem.actorOf(Props(classOf[ClientProxy], config, io, gen.handlerFactory))
-    gen.client(actor, config)
+    gen.client
   }
 
   def apply[C <: Protocol] = ClientFactory.futureClientFactory[C]
@@ -129,50 +49,39 @@ object AsyncServiceClient {
  * without using reflection.  We can do that with some nifty path-dependant
  * types
  */
-class AsyncHandlerGenerator[C <: Protocol](config: ClientConfig, codec: Codec[C#Input,C#Output]) {
+class AsyncHandlerGenerator[C <: Protocol](config: ClientConfig, codec: Codec[C#Input,C#Output])(implicit sys: IOSystem) {
 
   type I = C#Input
   type O = C#Output
 
   case class PackagedRequest(request: I, response: Promise[O])
 
-  /**
-   * this is used to communicate with an external actor being used as a service client.
-   */
-  class AsyncHandler(
-    config: ClientConfig,
-    val caller: ActorRef,
-    context: Context
-  ) extends ServiceClient[C](codec, config, context) with WatchedHandler {
-    val watchedActor = caller
+  class ClientWrapper(context: Context) extends WorkerItem(context) with ProxyActor {
 
+    val client = new ServiceClient[C](codec, config, worker)
 
-    override def onBind() {
-      super.onBind()
-      caller.!(ConnectionEvent.Bound(id))(context.worker.worker)
+    def receive = {
+      case PackagedRequest(request, promise) => {
+        client.send(request).execute(promise.complete)
+      }
+      case FutureClient.GetConnectionStatus(promise) => {
+        promise.success(client.connectionStatus)
+      }
+
     }
-
     override def onUnbind() {
       super.onUnbind()
-      caller.!(ConnectionEvent.Unbound)()
-    }
-
-    override def receivedMessage(message: Any, sender: ActorRef) {
-      message match {
-        case PackagedRequest(request, promise) => {
-          send(request).execute(promise.complete)
-        }
-        case AsyncServiceClient.GetConnectionStatus(promise) => {
-          promise.success(connectionStatus)
-        }
-        case other => super.receivedMessage(message, sender)
-      }
+      client.disconnect()
     }
   }
 
   implicit val timeout = Timeout(100.milliseconds)
 
-  def client(proxy: ActorRef, cConfig : ClientConfig) = new AsyncServiceClient[I,O] with FutureClient[C]{
+  protected val proxy = sys.bindWithProxy(new ClientWrapper(_))
+  protected val canary = new AtomicBoolean(false)
+  protected val watchdog = sys.actorSystem.actorOf(Props(classOf[ProxyWatchdog], proxy, canary))
+
+  val client = new FutureClient[C]{
     def send(request: I): Future[O] = {
       val promise = Promise[O]()
       proxy ! PackagedRequest(request, promise)
@@ -180,26 +89,20 @@ class AsyncHandlerGenerator[C <: Protocol](config: ClientConfig, codec: Codec[C#
     }
 
     def disconnect() {
-      proxy ! AsyncServiceClient.Disconnect
-    }
-
-    def kill() {
       proxy ! PoisonPill
     }
 
-    //TODO: when the user manually calls disconnect, this future never
-    //completes.  This isn't terrible but we should think of something more
-    //meaningful
     def connectionStatus: Future[ConnectionStatus] = {
-      import scala.concurrent.ExecutionContext.Implicits.global
-      val s = AsyncServiceClient.GetConnectionStatus()
-      proxy ! s
-      s.promise.future
+      if (canary.get()) {
+        Future.successful(ConnectionStatus.NotConnected)
+      } else {
+        val s = FutureClient.GetConnectionStatus()
+        proxy ! s
+        s.promise.future
+      }
     }
 
-    val clientConfig = cConfig
+    val clientConfig = config
   }
-
-  val handlerFactory: ActorRef => Context =>  ConnectionHandler = caller => context => new AsyncHandler(config, caller, context)
 
 }

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -206,7 +206,7 @@ object ClientFactory {
   implicit def futureClientFactory[C <: Protocol] = new ClientFactory[C, Future, FutureClient[C], IOSystem] {
 
     def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], io: IOSystem) = {
-      AsyncServiceClient.create(config)(io, provider)
+      FutureClient.create(config)(io, provider)
     }
   }
 }

--- a/colossus/src/main/scala/colossus/util/Task.scala
+++ b/colossus/src/main/scala/colossus/util/Task.scala
@@ -15,6 +15,7 @@ import akka.actor._
 abstract class Task(context: Context) extends WorkerItem(context) with ProxyActor {
 
   override def onBind() {  
+    super.onBind()
     run()
   }
 


### PR DESCRIPTION
Fixes #412  and #413 

Farewell `AsyncServiceClient`, long live `FutureClient`.  

* `shutdownRequest` has been moved from `ConnectionHandler` to `WorkerItem`, so all worker items can now have a shutdown procedure
* made several improvements to `ProxyActor` trait including fully handling the linking between itself and the proxy actor
* made improvements to the `WorkerItemProxy`, the actual proxy actor, so it now properly handles shutdown logic and correctly buffers messages before the worker item is bound to the worker.
* `AsyncServiceClient` and it's custom proxy actor are gone.  The new implementation has the exact same public interface, but aside from being considerably simpler it now uses the standard proxy actor.

As a side note, since 0.7.x `AsyncServiceClient` has been hidden by protocol specific future clients, so while this is technically not fully backwards compatible, any code using something like `Http.futureClient` will be unaffected.