### PR TITLE
break out error logging into overridable method

### DIFF
--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -143,12 +143,18 @@ with ServerConnectionHandler {
     val tags = extraTags + ("type" -> error.reason.metricsName)
     errors.hit(tags = tags)
     if (logErrors) {
-      val formattedRequest = error match {
-        case RecoverableError(request, reason) => requestLogFormat.map{_.format(request)}.getOrElse(request.toString)
-        case IrrecoverableError(reason) => "Invalid Request"
+      logError(error).foreach{message =>
+        log.error(error.reason, message )
       }
-      log.error(error.reason, s"Error processing request: $formattedRequest: ${error.reason}")
     }
+  }
+
+  protected def logError(error: ProcessingFailure[I]): Option[String] = {
+    val formattedRequest = error match {
+      case RecoverableError(request, reason) => requestLogFormat.map{_.format(request)}.getOrElse(request.toString)
+      case IrrecoverableError(reason) => "Invalid Request"
+    }
+    Some(s"Error processing request: $formattedRequest: ${error.reason}")
   }
 
   private case class SyncPromise(request: I) {


### PR DESCRIPTION
This simply makes it easier to take more control over how request errors are logged.  Users can override this to, for example, log different types of errors differently, or perhaps not at all.  This does not apply to metrics, so even if log errors are totally suppressed, error metrics will still be ticked.