### PR TITLE
Rename things

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -50,7 +50,7 @@ class EchoHandler(c: ServerContext) extends NoopHandler(c){
 
 object RawProtocol {
   import colossus.service._
-  import controller.StaticCodec
+  import controller.Codec
 
   trait BaseRawCodec  {
     def decode(data: DataBuffer) = if (data.hasUnreadData) Some(ByteString(data.takeAll)) else None
@@ -59,8 +59,8 @@ object RawProtocol {
     def endOfStream() = None
   }
 
-  object RawServerCodec extends BaseRawCodec with StaticCodec.Server[Raw]
-  object RawClientCodec extends BaseRawCodec with StaticCodec.Client[Raw]
+  object RawServerCodec extends BaseRawCodec with Codec.Server[Raw]
+  object RawClientCodec extends BaseRawCodec with Codec.Client[Raw]
 
   trait Raw extends Protocol {
     type Request = ByteString

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -28,7 +28,7 @@ class PushPromise {
   def expectCancelled() {  assert(isCancelled == true)}
 }
 
-trait TestController[E <: Encoding] extends ControllerIface[E] { self: StaticController[E] with ServerConnectionHandler =>
+trait TestController[E <: Encoding] extends ControllerIface[E] { self: Controller[E] with ServerConnectionHandler =>
 
   implicit val namespace = {
     import metrics._
@@ -65,12 +65,12 @@ object TestController {
 
   val defaultConfig = ControllerConfig(4, 50.milliseconds)
 
-  type T[E <: Encoding] = StaticController[E] with TestController[E] with ServerConnectionHandler
+  type T[E <: Encoding] = Controller[E] with TestController[E] with ServerConnectionHandler
 
   def controller[E <: Encoding](codec: Codec[E], config: ControllerConfig)(implicit sys: ActorSystem): TypedMockConnection[T[E]] = {
     val con =MockConnection.server(
       c => {
-        val t: T[E] = new BasicController[E](codec, config, c.context) with StaticController[E] with TestController[E] with ServerConnectionHandler
+        val t: T[E] = new BasicController[E](codec, config, c.context) with Controller[E] with TestController[E] with ServerConnectionHandler
         t
       },
       500

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -67,7 +67,7 @@ object TestController {
 
   type T[E <: Encoding] = StaticController[E] with TestController[E] with ServerConnectionHandler
 
-  def controller[E <: Encoding](codec: StaticCodec[E], config: ControllerConfig)(implicit sys: ActorSystem): TypedMockConnection[T[E]] = {
+  def controller[E <: Encoding](codec: Codec[E], config: ControllerConfig)(implicit sys: ActorSystem): TypedMockConnection[T[E]] = {
     val con =MockConnection.server(
       c => {
         val t: T[E] = new BasicController[E](codec, config, c.context) with StaticController[E] with TestController[E] with ServerConnectionHandler

--- a/colossus-tests/src/test/scala/colossus/service/CodecSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/CodecSpec.scala
@@ -2,7 +2,7 @@ package colossus
 package service
 
 import core.{DataBuffer, DataOutBuffer}
-import controller.{Encoding, StaticCodec}
+import controller.{Encoding, Codec}
 
 import org.scalatest.{WordSpec, MustMatchers}
 
@@ -17,7 +17,7 @@ class CodecSpec extends WordSpec with MustMatchers {
 
   "Codec" must {
     "decode all stops when databuffer is empty" in {
-      val c = new StaticCodec[MyE] {
+      val c = new Codec[MyE] {
         def decode(d: DataBuffer) = Some(ByteString(d.takeAll).utf8String)
         def encode(i: String, buffer: DataOutBuffer) { buffer write DataBuffer(ByteString(i.toString)) }
         def reset(){}

--- a/colossus/src/main/scala/colossus/controller/Codec.scala
+++ b/colossus/src/main/scala/colossus/controller/Codec.scala
@@ -3,7 +3,7 @@ package controller
 
 import core.{DataBuffer, DataOutBuffer}
 
-trait StaticCodec[E <: Encoding] {
+trait Codec[E <: Encoding] {
   def decode(data: DataBuffer): Option[E#Input]
   def encode(message: E#Output, buffer: DataOutBuffer)
 
@@ -21,12 +21,12 @@ trait StaticCodec[E <: Encoding] {
 }
 
 
-object StaticCodec {
+object Codec {
 
   import service.Protocol
 
-  type Server[P <: Protocol] = StaticCodec[P#ServerEncoding]
-  type Client[P <: Protocol] = StaticCodec[P#ClientEncoding]
+  type Server[P <: Protocol] = Codec[P#ServerEncoding]
+  type Client[P <: Protocol] = Codec[P#ClientEncoding]
 
 }
 

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -51,14 +51,14 @@ trait ControllerImpl[E <: Encoding] {
 /**
  * methods that both input and output need but shouldn't be exposed in the above traits
  */
-trait BaseStaticController[E <: Encoding] extends CoreHandler with ControllerImpl[E]{this: ControllerIface[E] =>
+trait BaseController[E <: Encoding] extends CoreHandler with ControllerImpl[E]{this: ControllerIface[E] =>
   def fatalError(reason: Throwable) {
     onFatalError(reason).foreach{o => push(o){_ => ()}}
     disconnect()
   }
 }
 
-trait StaticController[E <: Encoding] extends StaticInputController[E] with StaticOutputController[E]{this: ControllerIface[E] => }
+trait Controller[E <: Encoding] extends StaticInputController[E] with StaticOutputController[E]{this: ControllerIface[E] => }
 
 /**
  * This can be used to build connection handlers directly on top of the
@@ -68,6 +68,6 @@ abstract class BasicController[E <: Encoding](
   val codec: Codec[E],
   val controllerConfig: ControllerConfig,
   val context: Context
-) extends StaticController[E] { self: ControllerIface[E] => }
+) extends Controller[E] { self: ControllerIface[E] => }
 
 

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -27,7 +27,7 @@ case class ControllerConfig(
 //these are the methods that the controller layer requires to be implemented
 trait ControllerIface[E <: Encoding] {
   protected def connectionState: ConnectionState
-  protected def codec: StaticCodec[E]
+  protected def codec: Codec[E]
   protected def processMessage(input: E#Input)
   protected def controllerConfig: ControllerConfig
   implicit val namespace: MetricNamespace
@@ -65,7 +65,7 @@ trait StaticController[E <: Encoding] extends StaticInputController[E] with Stat
  * controller layer
  */
 abstract class BasicController[E <: Encoding](
-  val codec: StaticCodec[E],
+  val codec: Codec[E],
   val controllerConfig: ControllerConfig,
   val context: Context
 ) extends StaticController[E] { self: ControllerIface[E] => }

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -6,7 +6,7 @@ import colossus.parsing.ParserSizeTracker
 import core._
 import colossus.service.NotConnectedException
 
-trait StaticInputController[E <: Encoding] extends BaseStaticController[E] {this: ControllerIface[E] =>
+trait StaticInputController[E <: Encoding] extends BaseController[E] {this: ControllerIface[E] =>
   private var _readsEnabled = true
   def readsEnabled = _readsEnabled
 

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -64,7 +64,7 @@ object StaticOutState {
   case object Terminated extends StaticOutState(false)
 }
 
-trait StaticOutputController[E <: Encoding] extends BaseStaticController[E]{this: ControllerIface[E] =>
+trait StaticOutputController[E <: Encoding] extends BaseController[E]{this: ControllerIface[E] =>
 
 
   private var state: StaticOutState = StaticOutState.Suspended

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
@@ -6,9 +6,9 @@ import colossus.service._
 import parsing._
 import Combinators.Parser
 
-import controller.StaticCodec
+import controller.Codec
 
-class StaticHttpClientCodec extends StaticCodec[Http#ClientEncoding] {
+class StaticHttpClientCodec extends Codec[Http#ClientEncoding] {
 
   private var parser : Parser[HttpResponse] = HttpResponseParser.static()
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpServerCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpServerCodec.scala
@@ -4,9 +4,9 @@ package protocols.http
 
 import core._
 import service._
-import controller.StaticCodec
+import controller.Codec
 
-class StaticHttpServerCodec(headers: HttpHeaders) extends StaticCodec[Http#ServerEncoding] {
+class StaticHttpServerCodec(headers: HttpHeaders) extends Codec[Http#ServerEncoding] {
   private var parser = HttpRequestParser()
 
   def encode(response: HttpResponse, buffer: DataOutBuffer){ response.encode(buffer, headers) }

--- a/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
@@ -1,7 +1,7 @@
 package colossus
 package protocols.memcache
 
-import controller.StaticCodec
+import controller.Codec
 import core._
 import service._
 
@@ -362,7 +362,7 @@ class ZCompressor(bufferKB: Int = 10) extends Compressor {
 
 }
 
-class MemcacheClientCodec() extends StaticCodec.Client[Memcache] {
+class MemcacheClientCodec() extends Codec.Client[Memcache] {
   private var parser = new MemcacheReplyParser()
 
   def encode(cmd: MemcacheCommand, buffer: DataOutBuffer) {

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisClientCodec.scala
@@ -1,11 +1,11 @@
 package colossus
 package protocols.redis
 
-import controller.StaticCodec
+import controller.Codec
 import core._
 import service._
 
-class RedisClientCodec() extends StaticCodec.Client[Redis] {
+class RedisClientCodec() extends Codec.Client[Redis] {
   private var replyParser = RedisReplyParser()
 
   def reset(){

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisServerCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisServerCodec.scala
@@ -1,11 +1,11 @@
 package colossus
 package protocols.redis
 
-import controller.StaticCodec
+import controller.Codec
 import core._
 import service._
 
-class RedisServerCodec extends StaticCodec.Server[Redis] {
+class RedisServerCodec extends Codec.Server[Redis] {
   private var commandParser = RedisCommandParser.command
   def reset() {
     commandParser = RedisCommandParser.command

--- a/colossus/src/main/scala/colossus/protocols/telnet/Telnet.scala
+++ b/colossus/src/main/scala/colossus/protocols/telnet/Telnet.scala
@@ -1,7 +1,7 @@
 package colossus
 package protocols
 
-import controller.StaticCodec
+import controller.Codec
 import core._
 import service._
 
@@ -106,7 +106,7 @@ package object telnet {
   }
 
   //there's a compiler bug that prevents us from doing "extends Telnet[ServerCodec]" :(
-  implicit object TelnetServerCodec extends StaticCodec.Server[Telnet] {
+  implicit object TelnetServerCodec extends Codec.Server[Telnet] {
     val parser = new TelnetCommandParser
 
     def decode(data: DataBuffer): Option[TelnetCommand] = parser.parse(data)

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -174,7 +174,7 @@ abstract class BaseWebsocketHandler(val context: Context) extends {
   val codec = new WebsocketCodec
   val controllerConfig = ControllerConfig(50, scala.concurrent.duration.Duration.Inf)
 
-} with StaticController[Websocket#ServerEncoding] with ControllerIface[Websocket#ServerEncoding] {
+} with Controller[Websocket#ServerEncoding] with ControllerIface[Websocket#ServerEncoding] {
 
 
   def send(bytes: DataBlock) {

--- a/colossus/src/main/scala/colossus/protocols/websocket/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/package.scala
@@ -5,7 +5,7 @@ import core._
 import service._
 import akka.util.{ByteString, ByteStringBuilder}
 import java.util.Random
-import controller.StaticCodec
+import controller.Codec
 
 /**
  * **This package is experimental and subject to breaking changes between
@@ -27,7 +27,7 @@ import controller.StaticCodec
  */
 package object websocket {
 
-  class WebsocketCodec extends StaticCodec[Websocket#ServerEncoding]{
+  class WebsocketCodec extends Codec[Websocket#ServerEncoding]{
     
     private val random = new Random
     private val parser = FrameParser.frame

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -148,7 +148,7 @@ object ClientState {
  * TODO: make underlying output controller data size configurable
  */
 class ServiceClient[P <: Protocol](
-  val codec: StaticCodec.Client[P],
+  val codec: Codec.Client[P],
   val config: ClientConfig,
   val context: Context
 )(implicit tagDecorator: TagDecorator[P#Input,P#Output] = TagDecorator.default[P#Input,P#Output])
@@ -159,7 +159,7 @@ extends {
 with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
 
 
-  def this(codec: StaticCodec.Client[P], config: ClientConfig, worker: WorkerRef) {
+  def this(codec: Codec.Client[P], config: ClientConfig, worker: WorkerRef) {
     this(codec, config, worker.generateContext())
     worker.worker ! WorkerCommand.Bind(this)
   }

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -155,7 +155,7 @@ class ServiceClient[P <: Protocol](
 extends {
   //needed to deal with initialization order
   val controllerConfig = ControllerConfig(config.pendingBufferSize, config.requestTimeout, config.maxResponseSize)
-} with StaticController[P#ClientEncoding] with ControllerIface[P#ClientEncoding]
+} with Controller[P#ClientEncoding] with ControllerIface[P#ClientEncoding]
 with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
 
 

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -11,7 +11,7 @@ import scala.language.higherKinds
 
 import java.net.InetSocketAddress
 import metrics.MetricAddress
-import controller.{Encoding, StaticCodec}
+import controller.{Encoding, Codec}
 
 trait Protocol {self =>
   type Request
@@ -180,7 +180,7 @@ trait ServiceDSL[P <: Protocol, R <: GenRequestHandler[P], I <: ServiceInitializ
  */
 trait BasicServiceDSL[P <: Protocol] {
 
-  protected def provideCodec(): StaticCodec.Server[P]
+  protected def provideCodec(): Codec.Server[P]
 
   protected def errorMessage(reason: ProcessingFailure[P#Request]): P#Response
 
@@ -285,7 +285,7 @@ trait ServiceClientFactory[P <: Protocol] extends ClientFactory[P, Callback, Ser
 
 object ServiceClientFactory {
   
-  def staticClient[P <: Protocol](name: String, codecProvider: () => StaticCodec.Client[P]) = new ServiceClientFactory[P] {
+  def staticClient[P <: Protocol](name: String, codecProvider: () => Codec.Client[P]) = new ServiceClientFactory[P] {
 
     def defaultName = name
 

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -109,7 +109,7 @@ class DroppedReplyException extends ServiceServerException("Dropped Reply")
  * in the order that they are received.
  *
  */
-trait ServiceServer[P <: Protocol] extends StaticController[P#ServerEncoding] with ControllerIface[P#ServerEncoding] with ServerConnectionHandler {
+trait ServiceServer[P <: Protocol] extends Controller[P#ServerEncoding] with ControllerIface[P#ServerEncoding] with ServerConnectionHandler {
   import ServiceServer._
 
   type I = P#ServerEncoding#Input


### PR DESCRIPTION
This was going to be a larger PR, but I think we'll take it in smaller steps.  Since we've now removed all the streaming code, there's not need to have things prefixed with "Static", so just rename `StaticCodec` and `StaticController`