### PR TITLE
adding back AsyncServiceClient object for backwards compatability

### DIFF
--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -31,7 +31,7 @@ trait FutureClient[C <: Protocol] extends Sender[C, Future] {
   def clientConfig : ClientConfig
 }
 
-object FutureClient {
+trait FutureClientOps {
 
   sealed trait ClientCommand
 
@@ -44,6 +44,11 @@ object FutureClient {
 
   def apply[C <: Protocol] = ClientFactory.futureClientFactory[C]
 }
+object FutureClient extends FutureClientOps
+
+//TODO: remove in 0.9.x
+@deprecated("Use FutureClient Instead", "0.8.1")
+object AsyncServiceClient extends FutureClientOps
 
 /**
  * So we need to take a type-parameterized request object, package it into a


### PR DESCRIPTION
This is purely to ensure backwards compatibility with 0.8.0.  In a previous PR we totally removed `AsyncServiceClient` and moved the relevant functionality in `FutureClient`.  This brings back `AsyncServiceClient` as an alias for `FutureClient`and includes a deprecation warning.