### PR TITLE
array building cleanup and optimizations

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -25,8 +25,9 @@ object BenchmarkService {
   def start(port: Int)(implicit io: IOSystem) {
 
     HttpServer.basic("benchmark", port) { 
-      case req if (req.head.url == "/plaintext")  => req.ok(plaintext)
-      case req if (req.head.url == "/json")       => req.ok(json)
+      case req   => req.ok(plaintext)
+      //case req if (req.head.url == "/plaintext")  => req.ok(plaintext)
+      //case req if (req.head.url == "/json")       => req.ok(json)
     }
 
   }

--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -25,7 +25,6 @@ object BenchmarkService {
   def start(port: Int)(implicit io: IOSystem) {
 
     HttpServer.basic("benchmark", port) { 
-      //case req   => req.ok(plaintext)
       case req if (req.head.url == "/plaintext")  => req.ok(plaintext)
       case req if (req.head.url == "/json")       => req.ok(json)
     }

--- a/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/BenchmarkExample.scala
@@ -25,9 +25,9 @@ object BenchmarkService {
   def start(port: Int)(implicit io: IOSystem) {
 
     HttpServer.basic("benchmark", port) { 
-      case req   => req.ok(plaintext)
-      //case req if (req.head.url == "/plaintext")  => req.ok(plaintext)
-      //case req if (req.head.url == "/json")       => req.ok(json)
+      //case req   => req.ok(plaintext)
+      case req if (req.head.url == "/plaintext")  => req.ok(plaintext)
+      case req if (req.head.url == "/json")       => req.ok(json)
     }
 
   }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -60,7 +60,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           parser.parse(DataBuffer(ByteString(p1))).toList must equal(Nil)
           parser.parse(DataBuffer(ByteString(p2))).toList must equal(List(expected))
         } catch {
-          case t: Throwable => throw new Exception(s"Failed with splitIndex $splitIndex: '$p1' : '$p2'", t)
+          case t: Throwable => throw new Exception(s"Failed with splitIndex $splitIndex: '$p1' : '$p2' : $t", t)
         }
       }
 

--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -213,6 +213,14 @@ class CombinatorSuite extends WordSpec with MustMatchers{
       buf.remaining must equal(6)
     }
 
+    "line rejects isolated \\r" in {
+      val parser = line(true)
+      val buf = data("hello\ruhoh\r\n")
+      intercept[ParseException] {
+        parser.parse(buf)
+      }
+    }
+
       
 
 

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -770,7 +770,7 @@ object Combinators {
 
     @inline final def write(b: Byte) {
       if (writePos == build.length) {
-      grow()
+        grow()
       }
       build(writePos) = b
       writePos += 1
@@ -823,7 +823,6 @@ object Combinators {
   class LineParser[T](constructor: Array[Byte] => T, includeNewline: Boolean = false, internalBufferBaseSize: Int = 100) extends Parser[T] with FastArrayBuilding {
     private val CR    = '\r'.toByte
     private val LF    = '\n'.toByte
-    //private val empty = Array[Byte]()
 
     def initSize = internalBufferBaseSize
     def shrinkOnComplete = false

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -771,6 +771,9 @@ object Combinators {
     def write(b: Byte) {
       if (writePos == build.length) {
         grow()
+      val nb = new Array[Byte](build.length * 2)
+      System.arraycopy(build, 0, nb, 0, build.length)
+      build = nb
       }
       build(writePos) = b
       writePos += 1

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -762,18 +762,15 @@ object Combinators {
 
     def written = writePos
 
-    private def grow() {
+    @inline final private def grow() {
       val nb = new Array[Byte](build.length * 2)
       System.arraycopy(build, 0, nb, 0, build.length)
       build = nb
     }
 
-    def write(b: Byte) {
+    @inline final def write(b: Byte) {
       if (writePos == build.length) {
-      //grow()
-      val nb = new Array[Byte](build.length * 2)
-      System.arraycopy(build, 0, nb, 0, build.length)
-      build = nb
+      grow()
       }
       build(writePos) = b
       writePos += 1
@@ -854,7 +851,7 @@ object Combinators {
           if (buffer.hasUnreadData) {
             //usually we can skip scanning for the \n
             //do an extra get to read in the \n
-            buffer.data.position(buffer.data.position + 1)
+            buffer.data.get
             res = Some(completeLine())
           } else {
             //this would only happen if the \n is in the next packet/buffer,


### PR DESCRIPTION
**tl;dr** - fixes a small performance regression involving parsing lines, cleans up code

These are some small optimizations that seem to improve overall parsing performance rather significantly.  Overall in benchmarks it improves throughput by about 10%, or rather I should say it fixes a performance regression that decreased throughput by about 10%.  I traced it down to the fact that in `FastArrayBuilder` the code for growing the array was moved into its own function.  Inlining the function fixes the issue.  Not entirely sure why that works, I spent some time looking at generated bytecode and don't see an obvious reason, but if it works, it works.

I also made some other changes that cleaned up the code a bit.  Furthermore, the line parser now correctly verifies that a `\r` is followed by a `\n`where before it just assumed the byte following a `\r`was correct.