### PR TITLE
moving idleCheck to WorkerItem mixin trait

### DIFF
--- a/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
@@ -110,7 +110,7 @@ class OutputControllerSpec extends ColossusSpec {
       val endpoint = static()
       val p = endpoint.typedHandler.pPush(ByteString("wat"))
       Thread.sleep(300)
-      endpoint.handler.idleCheck(1.millisecond)
+      endpoint.typedHandler.idleCheck(1.millisecond)
       p.expectCancelled()
     }
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -445,6 +445,28 @@ class ServiceClientSpec extends ColossusSpec {
       failed must equal(true)
     }
 
+    "timeout requests while waiting to reconnect" taggedAs(org.scalatest.Tag("test")) in {
+      withIOSystem{ implicit io => 
+        val config = ClientConfig(
+          name = "/test",
+          requestTimeout = 100.milliseconds,
+          address = new InetSocketAddress("localhost", TEST_PORT),
+          failFast = false,
+          connectRetry = BackoffPolicy(10.seconds, BackoffMultiplier.Constant)
+        )
+        val client = Raw.futureClient(config)
+        import io.actorSystem.dispatcher
+        val f = client.send(ByteString("blah"))
+        Thread.sleep(350)
+        //beware, a java TimeoutException is NOT what we want, that is simply
+        //the future timing out, which it shouldn't here
+        intercept[RequestTimeoutException] {
+          Await.result(f, 100.milliseconds)
+        }
+      }
+    }
+      
+
   }
 }
 

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -36,7 +36,7 @@ class DisconnectingException(message: String) extends Exception(message)
  * ultimately implemented by Controller.  This merely contains methods needed
  * by both input and output controller
  */
-trait MasterController[Input, Output] extends ConnectionHandler {
+trait MasterController[Input, Output] extends ConnectionHandler with IdleCheck {
   protected def connectionState: ConnectionState
   protected def codec: Codec[Output, Input]
   protected def controllerConfig: ControllerConfig

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -4,7 +4,7 @@ package controller
 import core._
 import java.util.LinkedList
 import scala.annotation.tailrec
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
 import scala.util.{Success, Failure}
 
 import service.{NotConnectedException, RequestTimeoutException}
@@ -351,7 +351,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
     }
   }
         
-  def idleCheck(period: Duration): Unit = {
+  def idleCheck(period: FiniteDuration): Unit = {
     val time = System.currentTimeMillis
     while (!msgq.isEmpty && msgq.head.isTimedOut(time, controllerConfig.sendTimeout)) {
       val expired = msgq.dequeue

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -69,18 +69,10 @@ trait ConnectionHandler extends WorkerItem {
    */
   def connected(endpoint: WriteEndpoint)
 
-  /**
-   * Called periodically on every attached connection handler, this can be used
-   * for checking if an ongoing operation has timed out.
-   *
-   * Be aware that this is totally independant of a connection's idle timeout,
-   * which is only based on the last time there was any I/O.
-   *
-   * @param period the frequency at which this method is called.  Currently this is hardcoded to `WorkerManager.IdleCheckFrequency`, but may become application dependent in the future.
-   */
-  def idleCheck(period: Duration)
 
 }
+
+
 
 /**
  * Mixin containing events just for server connection handlers

--- a/colossus/src/main/scala/colossus/core/WorkerItem.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerItem.scala
@@ -7,6 +7,7 @@ import akka.event.LoggingAdapter
 import java.net.InetSocketAddress
 import java.nio.ByteBuffer
 import java.nio.channels.{SelectionKey, Selector, SocketChannel}
+import scala.concurrent.duration.FiniteDuration
 
 class WorkerItemException(message: String) extends Exception(message)
 
@@ -123,6 +124,27 @@ abstract class WorkerItem(val context: Context) {
     unbind()
   }
 
+
+}
+
+/**
+ * A mixin trait for worker items that defines a method which is periodically
+ * called by the worker.  This can be used to do periodic checks
+ */
+trait IdleCheck extends WorkerItem {
+
+  /**
+   * Called periodically on every attached connection handler, this can be used
+   * for checking if an ongoing operation has timed out.
+   *
+   * Be aware that this is totally independant of a connection's idle timeout,
+   * which is only based on the last time there was any I/O.
+   *
+   * @param period the frequency at which this method is called.  Currently this
+   * is hardcoded to `WorkerManager.IdleCheckFrequency`, but may become
+   * application dependent in the future.
+   */
+  def idleCheck(period: FiniteDuration)
 
 }
 

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -364,7 +364,7 @@ with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
   }
 
 
-  override def idleCheck(period: Duration) {
+  override def idleCheck(period: FiniteDuration) {
     super.idleCheck(period)
 
     if (sentBuffer.size > 0 && sentBuffer.front.isTimedOut(System.currentTimeMillis)) {

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -178,7 +178,7 @@ with ServerConnectionHandler {
   def currentRequestBufferSize = requestBuffer.size
   private var numRequests = 0
 
-  override def idleCheck(period: Duration) {
+  override def idleCheck(period: FiniteDuration) {
     super.idleCheck(period)
 
     val time = System.currentTimeMillis


### PR DESCRIPTION
Fixes #432 

The `idleCheck` method has been moved out of `ConnectionHandler` and into a separate mixin trait for `WorkerItem`.  The main reason we're doing this is so that the idle check on `ServiceClient` can occur even when the client is waiting to reconnect and is not recognized as a connection handler.  

I also changed the parameter passed into `idleCheck` from `Duration` to `FiniteDuration`, since there's no reason for it to ever be infinite.