### PR TITLE
Metrics getters

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -43,7 +43,7 @@ trait Counter extends Collector {
 }
 
 //Working implementation of a Counter
-class DefaultCounter private[metrics](val address: MetricAddress) extends Counter {
+private[metrics] class DefaultCounter private[metrics](val address: MetricAddress) extends Counter {
 
   private val counters = new CollectionMap[TagMap]
 
@@ -64,7 +64,7 @@ class DefaultCounter private[metrics](val address: MetricAddress) extends Counte
 }
 
 //Dummy implementation of a counter, used when "enabled=false" is specified at creation
-class NopCounter private[metrics](val address : MetricAddress) extends Counter {
+private[metrics] class NopCounter private[metrics](val address : MetricAddress) extends Counter {
   val empty : MetricMap = Map()
   override def tick(interval: FiniteDuration): MetricMap = empty
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -55,7 +55,7 @@ private[metrics] class DefaultRate private[metrics](val address: MetricAddress, 
   private val minInterval = if (intervals.size > 0) intervals.min else Duration.Inf
 
   def hit(tags: TagMap = TagMap.Empty, amount: Long = 1) {
-    maps.foreach{ case (_, map) => map.increment(tags) }
+    maps.foreach{ case (_, map) => map.increment(tags, amount) }
   }
 
   def tick(interval: FiniteDuration): MetricMap  = {

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -15,6 +15,14 @@ class RateSpec extends MetricIntegrationSpec {
       r.tick(1.minute)("/foo")(Map()) must equal(2)
     }
 
+    "increment by amount" in {
+      val r = rate()
+      r.hit(amount = 23)
+      r.value(1.second) mustBe 23
+      r.tick(1.second)("/foo")(Map()) must equal(23)
+    }
+
+
     "tick resets value for interval" in {
       val r = rate()
       r.hit()

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -31,6 +31,24 @@ class RateSpec extends MetricIntegrationSpec {
       val r = rate()
       r.hit()
       r.hit()
+      r.count() mustBe 2
+      r.tick(1.second)
+      r.count() mustBe 2
+    }
+
+    "get the current value for an interval" in {
+      val r = rate()
+      r.hit()
+      r.hit()
+      r.value(1.second) mustBe 2
+      r.tick(1.second)
+      r.value(1.second) mustBe 0
+    }
+
+    "count in metrics" in {
+      val r = rate()
+      r.hit()
+      r.hit()
       r.tick(1.second)("/foo/count")(Map()) must equal(2)
 
       r.hit()


### PR DESCRIPTION
This adds some methods to `Rate` and `Histogram` to make it easier to retrieve values as they're being collected.  In particular  they should help make it easier in tests to verify that metrics are properly being collected with the right values.

Also did a little refactoring in `Histogram` to get rid of the obsolete `Snapshot`.