### PR TITLE
Make clients compatible with Scalamock

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -44,7 +44,7 @@ object RawProtocol {
 
   implicit object RawClientLifter extends ClientLifter[Raw, RawClient] {
     
-    def lift[M[_]](client: Sender[Raw,M])(implicit async: Async[M]) = new LiftedClient(client) with RawClient[M]
+    def lift[M[_]](client: Sender[Raw,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with RawClient[M]
   }
 
   object Raw extends ClientFactories[Raw, RawClient]{

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -472,10 +472,12 @@ class ServiceClientSpec extends ColossusSpec with MockFactory {
 
       val c = stub[HttpClient[Callback]]
 
-      (c.send _) when(HttpRequest.get("/foo")) returns(Callback.successful(HttpResponse.ok("hello")))
+      val resp = HttpRequest.get("/foo").ok("hello")
+
+      (c.send _) when(HttpRequest.get("/foo")) returns(Callback.successful(resp))
 
       implicit val executor = FakeIOSystem.testExecutor
-      CallbackAwait.result(c.send(HttpRequest.get("/foo")), 1.second) mustBe HttpResponse.ok("hello")
+      CallbackAwait.result(c.send(HttpRequest.get("/foo")), 1.second) mustBe resp
 
     }
       

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -20,8 +20,9 @@ import UnifiedProtocol._
 import scala.concurrent.Await
 
 import RawProtocol._
+import org.scalamock.scalatest.MockFactory
 
-class ServiceClientSpec extends ColossusSpec {
+class ServiceClientSpec extends ColossusSpec with MockFactory {
 
   //TODO: we no longer need to return a triple, just the connection, as the others are members
   def newClient(
@@ -465,9 +466,20 @@ class ServiceClientSpec extends ColossusSpec {
         }
       }
     }
+
+    "work with mocking" in {
+      import protocols.http._
+
+      val c = stub[HttpClient[Callback]]
+
+      (c.send _) when(HttpRequest.get("/foo")) returns(Callback.successful(HttpResponse.ok("hello")))
+
+      implicit val executor = FakeIOSystem.testExecutor
+      CallbackAwait.result(c.send(HttpRequest.get("/foo")), 1.second) mustBe HttpResponse.ok("hello")
+
+    }
       
 
   }
 }
-
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -5,7 +5,7 @@ import scala.language.higherKinds
 import service._
 import scala.concurrent.{ExecutionContext, Future}
 
-trait HttpClient[M[_]] extends LiftedClient[Http, M] with HttpRequestBuilder[M[HttpResponse]]{
+trait HttpClient[M[_]]  extends LiftedClient[Http, M] with HttpRequestBuilder[M[HttpResponse]]{ //self: LiftedClient[Http, M] => 
 
   protected def build(req: HttpRequest) = client.send(req)
 
@@ -20,7 +20,7 @@ object HttpClient {
 
   implicit object HttpClientLifter extends ClientLifter[Http, HttpClient] {
     
-    def lift[M[_]](client: Sender[Http,M])(implicit async: Async[M]) = new LiftedClient(client) with HttpClient[M]
+    def lift[M[_]](client: Sender[Http,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with HttpClient[M]
   }
 
 }

--- a/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
@@ -118,7 +118,7 @@ import scala.language.higherKinds
   
     implicit object MemcacheClientLifter extends ClientLifter[Memcache, MemcacheClient] {
       
-      def lift[M[_]](client: Sender[Memcache,M])(implicit async: Async[M]) = new LiftedClient(client) with MemcacheClient[M]
+      def lift[M[_]](client: Sender[Memcache,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with MemcacheClient[M]
     }
 
   }

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
@@ -499,7 +499,7 @@ object RedisClient {
 
   implicit object RedisClientLifter extends ClientLifter[Redis, RedisClient] {
     
-    def lift[M[_]](client: Sender[Redis,M])(implicit async: Async[M]) = new LiftedClient(client) with RedisClient[M]
+    def lift[M[_]](client: Sender[Redis,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with RedisClient[M]
   }
 
 }

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -234,7 +234,10 @@ class ClientFactories[C <: Protocol, T[M[_]] <: Sender[C, M]](implicit lifter: C
 
 }
 
-class LiftedClient[C <: Protocol, M[_] ](val client: Sender[C,M])(implicit val async: Async[M]) extends Sender[C,M] {
+trait LiftedClient[C <: Protocol, M[_] ] extends Sender[C,M] {
+
+  def client: Sender[C,M]
+  implicit val async: Async[M]
 
   def send(input: C#Input): M[C#Output] = client.send(input)
 
@@ -243,4 +246,9 @@ class LiftedClient[C <: Protocol, M[_] ](val client: Sender[C,M])(implicit val a
   def disconnect() {
     client.disconnect()
   }
+
+}
+
+class BasicLiftedClient[C <: Protocol, M[_] ](val client: Sender[C,M])(implicit val async: Async[M]) extends LiftedClient[C,M] {
+
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -37,6 +37,7 @@ object ColossusBuild extends Build {
       "com.typesafe.akka" %% "akka-agent"   % AKKA_VERSION,
       "com.typesafe.akka" %% "akka-testkit" % AKKA_VERSION,
       "org.scalatest"     %% "scalatest" % SCALATEST_VERSION % "test, it",
+      "org.scalamock" %% "scalamock-scalatest-support" % "3.2.2" % "test",
       "org.mockito" % "mockito-all" % "1.9.5" % "test",
       "com.github.nscala-time" %% "nscala-time" % "1.2.0"
     ),


### PR DESCRIPTION
So right now mocking service clients doesn't really work.  Mockito just doesn't like the higher-kinded type parameter and scalamock doesn't seem to like that we have a trait extending a class without a default constructor.

This solves the issue with scalamock.  `LiftedClient`, which was previously a class, is now a trait, and the new `BasicLiftedClient` is a class extending it.  this way, for example, `HttpClient` can still extends `LiftedClient` but also work with scalamock.