### PR TITLE
Server slow start

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/ConnectionLimiterSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionLimiterSpec.scala
@@ -1,0 +1,45 @@
+package colossus
+package core
+
+import colossus.metrics.MetricSystem
+import testkit._
+
+import scala.concurrent.duration._
+
+class ConnectionLimiterSpec extends ColossusSpec {
+
+
+  "connection limiter" must {
+    class ManualLimiter(var manualTime: Long, initial: Int, max: Int, duration: FiniteDuration) extends ConnectionLimiter(initial, max, duration) {
+      override def currentTime = manualTime
+    }
+
+    "correctly increase limit to max" in {
+      val l = new ManualLimiter(0, 1, 100, 5.seconds)
+      l.limit mustBe 2
+      l.manualTime = 1000
+      l.limit mustBe 4
+      l.manualTime = 2000
+      l.limit mustBe 8
+      l.manualTime = 2500
+      l.limit mustBe 16
+      l.manualTime = 3000
+      l.limit mustBe 32
+      l.manualTime = 4000
+      l.limit mustBe 64
+      l.manualTime = 5000
+      l.limit mustBe 100
+      l.manualTime = 1000000
+      l.limit mustBe 100
+    }
+
+    "no limiting for nolimiter" in {
+      val l = ConnectionLimiter.noLimiting(50)
+      l.limit mustBe(50)
+    }
+
+  }
+
+}
+
+

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -23,7 +23,8 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         settings.delegatorCreationPolicy mustBe refDelegatorCreationPolicy
         settings.highWatermarkPercentage mustBe 0.85
         settings.lowWatermarkPercentage mustBe 0.75
-        settings.maxConnections mustBe 1000
+        settings.connectionLimiter.max mustBe 1000
+        settings.connectionLimiter.initial mustBe 1000
         settings.maxIdleTime mustBe Duration.Inf
         settings.port mustBe 9876
         settings.shutdownTimeout mustBe 100.milliseconds
@@ -54,7 +55,8 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         settings.delegatorCreationPolicy mustBe refDelegatorCreationPolicy
         settings.highWatermarkPercentage mustBe 0.85
         settings.lowWatermarkPercentage mustBe 0.75
-        settings.maxConnections mustBe 1000
+        settings.connectionLimiter.max mustBe 1000
+        settings.connectionLimiter.initial mustBe 1000
         settings.maxIdleTime mustBe 1.second
         settings.port mustBe 9888
         settings.shutdownTimeout mustBe 2.seconds
@@ -72,7 +74,8 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         settings.delegatorCreationPolicy mustBe refDelegatorCreationPolicy
         settings.highWatermarkPercentage mustBe 0.85
         settings.lowWatermarkPercentage mustBe 0.75
-        settings.maxConnections mustBe 1000
+        settings.connectionLimiter.max mustBe 1000
+        settings.connectionLimiter.initial mustBe 1000
         settings.maxIdleTime mustBe Duration.Inf
         settings.port mustBe 8989
         settings.shutdownTimeout mustBe 100.milliseconds

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -23,8 +23,8 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         settings.delegatorCreationPolicy mustBe refDelegatorCreationPolicy
         settings.highWatermarkPercentage mustBe 0.85
         settings.lowWatermarkPercentage mustBe 0.75
-        settings.connectionLimiter.max mustBe 1000
-        settings.connectionLimiter.initial mustBe 1000
+        settings.maxConnections mustBe 1000
+        settings.slowStart.initial mustBe 20
         settings.maxIdleTime mustBe Duration.Inf
         settings.port mustBe 9876
         settings.shutdownTimeout mustBe 100.milliseconds
@@ -55,8 +55,8 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         settings.delegatorCreationPolicy mustBe refDelegatorCreationPolicy
         settings.highWatermarkPercentage mustBe 0.85
         settings.lowWatermarkPercentage mustBe 0.75
-        settings.connectionLimiter.max mustBe 1000
-        settings.connectionLimiter.initial mustBe 1000
+        settings.maxConnections mustBe 1000
+        settings.slowStart.initial mustBe 20
         settings.maxIdleTime mustBe 1.second
         settings.port mustBe 9888
         settings.shutdownTimeout mustBe 2.seconds
@@ -74,8 +74,8 @@ class ServerConfigLoadingSpec  extends ColossusSpec {
         settings.delegatorCreationPolicy mustBe refDelegatorCreationPolicy
         settings.highWatermarkPercentage mustBe 0.85
         settings.lowWatermarkPercentage mustBe 0.75
-        settings.connectionLimiter.max mustBe 1000
-        settings.connectionLimiter.initial mustBe 1000
+        settings.maxConnections mustBe 1000
+        settings.slowStart.initial mustBe 20
         settings.maxIdleTime mustBe Duration.Inf
         settings.port mustBe 8989
         settings.shutdownTimeout mustBe 100.milliseconds

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -53,8 +53,7 @@ class ServerSpec extends ColossusSpec {
 
     "expose ConnectionSummary data" in {
       val settings = ServerSettings(
-        port = TEST_PORT,
-        maxConnections = 5000
+        port = TEST_PORT
       )
 
       withServer(new EchoHandler(_)) {server => {
@@ -230,7 +229,7 @@ class ServerSpec extends ColossusSpec {
       "reject connection when maxed out" in {
         val settings = ServerSettings(
           port = TEST_PORT,
-          maxConnections = 1
+          connectionLimiter = ConnectionLimiter.noLimiting(1)
         )
         withIOSystem {implicit io =>
           val server = Server.basic("echo", settings)(new EchoHandler(_))
@@ -246,7 +245,7 @@ class ServerSpec extends ColossusSpec {
       "open up spot when connection closes" in {
         val settings = ServerSettings(
           port = TEST_PORT,
-          maxConnections = 1
+          connectionLimiter = ConnectionLimiter.noLimiting(1)
         )
 
         withIOSystem {implicit io =>
@@ -301,7 +300,7 @@ class ServerSpec extends ColossusSpec {
         withIOSystem { implicit io =>
           val settings = ServerSettings(
             port = TEST_PORT,
-            maxConnections = 4,
+            connectionLimiter = ConnectionLimiter.noLimiting(4),
             lowWatermarkPercentage = 0.00,
             highWatermarkPercentage = 0.50,
             highWaterMaxIdleTime = 50.milliseconds,
@@ -375,5 +374,6 @@ class ServerSpec extends ColossusSpec {
       }
     }
   }
+
 
 }

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -229,7 +229,7 @@ class ServerSpec extends ColossusSpec {
       "reject connection when maxed out" in {
         val settings = ServerSettings(
           port = TEST_PORT,
-          connectionLimiter = ConnectionLimiter.noLimiting(1)
+          maxConnections = 1
         )
         withIOSystem {implicit io =>
           val server = Server.basic("echo", settings)(new EchoHandler(_))
@@ -245,7 +245,7 @@ class ServerSpec extends ColossusSpec {
       "open up spot when connection closes" in {
         val settings = ServerSettings(
           port = TEST_PORT,
-          connectionLimiter = ConnectionLimiter.noLimiting(1)
+          maxConnections = 1
         )
 
         withIOSystem {implicit io =>
@@ -300,7 +300,7 @@ class ServerSpec extends ColossusSpec {
         withIOSystem { implicit io =>
           val settings = ServerSettings(
             port = TEST_PORT,
-            connectionLimiter = ConnectionLimiter.noLimiting(4),
+            maxConnections = 4,
             lowWatermarkPercentage = 0.00,
             highWatermarkPercentage = 0.50,
             highWaterMaxIdleTime = 50.milliseconds,

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -9,6 +9,11 @@ colossus{
     name : "/"
     port : 9876
     max-connections : 1000
+    slow-start {
+      enabled = false
+      initial = 20
+      duration = 5 seconds
+    }
     max-idle-time : "Inf"
     low-watermark-percentage : 0.75
     high-watermark-percentage : 0.85

--- a/colossus/src/main/scala/colossus/core/ConnectionLimiter.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionLimiter.scala
@@ -1,0 +1,81 @@
+package colossus
+package core
+
+import com.typesafe.config.Config
+import scala.concurrent.duration._
+
+/**
+ * Used to control slow start of servers, this will exponentially increase its
+ * limit over a period of time until max is reached.  Servers use this to gradually increase the
+ * number of allowable open connections during the first few seconds of startup,
+ * which can help alleviate thundering herd problems due to JVM warmup.
+ *
+ * Initializing a limiter with `initial` equal to `max` will essentially disable any slow ramp
+ */
+class ConnectionLimiter(val initial: Int, val max: Int, val duration: FiniteDuration) {
+
+  private var currentLimit = initial
+  private var startTime = 0L
+  private var complete: Boolean = initial == max
+
+  private var lastCheck: Long = 0
+
+  private val numIncrements: Int = math.max(1, ((math.log(max - initial) / math.log(2)) + 0.5).toInt)
+  private val checkFreq = (duration / numIncrements).toMillis
+
+  def currentTime: Long = System.currentTimeMillis
+
+  def begin() {
+    startTime = currentTime
+  }
+
+  def limit = if (complete) {
+    max
+  } else {
+    currentLimit = math.min(max, math.pow(2, (currentTime - startTime) / checkFreq + 1).toInt)
+    if (currentLimit == max) {
+      complete = true
+    }
+    currentLimit
+  }
+}
+
+object ConnectionLimiter {
+
+  def noLimiting(max: Int) = new ConnectionLimiter(max, max, 1.second)
+
+  def apply(maxConnections: Int, config: ConnectionLimiterConfig) : ConnectionLimiter = {
+    if (config.enabled) {
+      new ConnectionLimiter(config.initial, maxConnections, config.duration)
+    } else {
+      noLimiting(maxConnections)
+    }
+  }
+
+  def fromConfig(maxConnections: Int, config: Config) = apply(maxConnections, ConnectionLimiterConfig.fromConfig(config))
+}
+
+/**
+ * Configuration object for connection limiting, used as part of server
+ * settings.  This does not contain the max value because that is already part
+ * of [[ServerSettings]]
+ */
+case class ConnectionLimiterConfig(enabled: Boolean, initial: Int, duration: FiniteDuration)
+
+object ConnectionLimiterConfig {
+  import colossus.metrics.ConfigHelpers._
+  
+  def fromConfig(config: Config): ConnectionLimiterConfig = {
+    val enabled   = config.getBoolean("enabled")
+    val initial   = config.getInt("initial")
+    val duration  = config.getFiniteDuration("duration")
+    ConnectionLimiterConfig(enabled, initial, duration)
+  }
+
+  /**
+   * Default config to use when not using slow-start.  Notice that since enabled
+   * is set to false, the values of initial and duration are not used
+   */
+  val NoLimiting = ConnectionLimiterConfig(false, 0, 1.second)
+
+}

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -78,11 +78,10 @@ object ServerSettings {
 
     val bindingRetry = RetryPolicy.fromConfig(config.getConfig("binding-retry"))
     val delegatorCreationPolicy = WaitPolicy.fromConfig(config.getConfig("delegator-creation-policy"))
-    val maxConnections = config.getInt("max-connections")
 
     ServerSettings (
       port                    = config.getInt("port"),
-      maxConnections          = maxConnections,
+      maxConnections          = config.getInt("max-connections"),
       slowStart               = ConnectionLimiterConfig.fromConfig(config.getConfig("slow-start")),
       maxIdleTime             = config.getScalaDuration("max-idle-time"),
       lowWatermarkPercentage  = config.getDouble("low-watermark-percentage"),

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -16,6 +16,60 @@ import java.net.ServerSocket
 
 import scala.collection.JavaConversions._
 
+/**
+ * Used to control slow start of servers, this will exponentially increase its
+ * limit over a period of time until max is reached.  Servers use this to gradually increase the
+ * number of allowable open connections during the first few seconds of startup,
+ * which can help alleviate thundering herd problems due to JVM warmup.
+ *
+ * Initializing a limiter with `initial` equal to `max` will essentially disable any slow ramp
+ */
+class ConnectionLimiter(val initial: Int, val max: Int, val rampSpeed: FiniteDuration) {
+
+  private var currentLimit = initial
+  private var startTime = 0L
+  private var complete: Boolean = initial == max
+
+  private var lastCheck: Long = 0
+
+  private val numIncrements: Int = math.max(1, ((math.log(max - initial) / math.log(2)) + 0.5).toInt)
+  private val checkFreq = (rampSpeed / numIncrements).toMillis
+
+  def currentTime: Long = System.currentTimeMillis
+
+  def begin() {
+    startTime = currentTime
+  }
+
+  def limit = if (complete) {
+    max
+  } else {
+    currentLimit = math.min(max, math.pow(2, (currentTime - startTime) / checkFreq + 1).toInt)
+    if (currentLimit == max) {
+      complete = true
+    }
+    currentLimit
+  }
+}
+
+object ConnectionLimiter {
+  def fromConfig(config: Config): ConnectionLimiter = {
+    import colossus.metrics.ConfigHelpers._
+    val maxConnections = config.getInt("max-connections")
+    if (config.getBoolean("slow-start.enabled")) {
+      val initial = config.getInt("slow-start.initial")
+      val duration   = config.getFiniteDuration("slow-start.duration")
+      new ConnectionLimiter(initial, maxConnections, duration)
+    } else {
+      noLimiting(maxConnections)
+    }
+  }
+
+  def noLimiting(max: Int) = new ConnectionLimiter(max, max, 1.second)
+}
+    
+    
+
 /** Contains values for configuring how a Server operates
  *
  * These are all lower-level configuration settings that are for the most part
@@ -55,7 +109,7 @@ import scala.collection.JavaConversions._
  */
 case class ServerSettings(
   port: Int,
-  maxConnections: Int = 1000,
+  connectionLimiter: ConnectionLimiter = ConnectionLimiter.noLimiting(1000),
   maxIdleTime: Duration = Duration.Inf,
   lowWatermarkPercentage: Double = 0.75,
   highWatermarkPercentage: Double = 0.85,
@@ -65,8 +119,8 @@ case class ServerSettings(
   delegatorCreationPolicy : WaitPolicy = WaitPolicy(500.milliseconds, BackoffPolicy(50.milliseconds, BackoffMultiplier.Constant)),
   shutdownTimeout: FiniteDuration = 100.milliseconds
 ) {
-  def lowWatermark = lowWatermarkPercentage * maxConnections
-  def highWatermark = highWatermarkPercentage * maxConnections
+  def lowWatermark = lowWatermarkPercentage * connectionLimiter.max
+  def highWatermark = highWatermarkPercentage * connectionLimiter.max
 }
 
 object ServerSettings {
@@ -77,10 +131,11 @@ object ServerSettings {
 
     val bindingRetry = RetryPolicy.fromConfig(config.getConfig("binding-retry"))
     val delegatorCreationPolicy = WaitPolicy.fromConfig(config.getConfig("delegator-creation-policy"))
+    val connectionLimiter = ConnectionLimiter.fromConfig(config)
 
     ServerSettings (
       port                    = config.getInt("port"),
-      maxConnections          = config.getInt("max-connections"),
+      connectionLimiter       = connectionLimiter,
       maxIdleTime             = config.getScalaDuration("max-idle-time"),
       lowWatermarkPercentage  = config.getDouble("low-watermark-percentage"),
       highWatermarkPercentage = config.getDouble("high-watermark-percentage"),
@@ -291,6 +346,7 @@ private[colossus] class Server(io: IOSystem, serverConfig: ServerConfig,
     case RetryBind(incidentOpt) => {
       if (start()) {
         changeState(accepting(router), Bound)
+        settings.connectionLimiter.begin()
         self ! Select
       } else {
         val incident = incidentOpt.getOrElse(settings.bindingRetry.start())
@@ -383,7 +439,7 @@ private[colossus] class Server(io: IOSystem, serverConfig: ServerConfig,
           val ssc : ServerSocketChannel = key.channel.asInstanceOf[ServerSocketChannel] //oh, java
           val sc: SocketChannel = ssc.accept()
           connects.hit()
-          if (openConnections < settings.maxConnections) {
+          if (openConnections < settings.connectionLimiter.limit) {
             openConnections += 1
             connections.increment()
             sc.configureBlocking(false)


### PR DESCRIPTION
This is a new feature that allows servers to gradually increase the number of allowable connections when first starting.  This is useful to help mitigate the effects of JVM warmup and help stop thundering herd problems when restarting a running service under heavy load.