### PR TITLE
Server cleanup

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -119,7 +119,7 @@ object TestUtil {
   def expectServerConnections(server: ServerRef, connections: Int, maxTries: Int = 10) {
     var tries = maxTries
     implicit val timeout = Timeout(100.milliseconds)
-    while (Await.result((server.server ? Server.GetInfo), 100.milliseconds) != Server.ServerInfo(connections, ServerStatus.Bound)) {
+    while (Await.result(server.info(), 100.milliseconds) != Server.ServerInfo(connections, ServerStatus.Bound)) {
       Thread.sleep(100)
       tries -= 1
       if (tries == 0) {

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -2,19 +2,20 @@ package colossus
 package core
 
 import akka.actor._
-import java.net.InetSocketAddress
-
 import akka.agent.Agent
+import akka.pattern.ask
+import akka.util.Timeout
 import com.typesafe.config.{Config, ConfigFactory}
-
-import scala.concurrent.duration._
-
-import metrics._
-
+import java.net.{InetSocketAddress, ServerSocket}
 import java.nio.channels.{SelectionKey, Selector, ServerSocketChannel, SocketChannel}
-import java.net.ServerSocket
-
+import metrics._
 import scala.collection.JavaConversions._
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+
+
+
 
 /** Contains values for configuring how a Server operates
  *
@@ -145,6 +146,11 @@ case class ServerRef private[colossus] (config: ServerConfig, server: ActorRef, 
     } else {
       config.settings.maxIdleTime
     }
+  }
+
+  def info(): Future[Server.ServerInfo] = {
+    implicit val timeout = Timeout(1.second)
+    (server ? Server.GetInfo).mapTo[Server.ServerInfo]
   }
 
   /**


### PR DESCRIPTION
* Adding a proper `onShutdown()` hook for `Initializer`
* Made a bunch of internal classes and objects private
* `ServerRef` now has a `info()` method instead of users sending the underlying actor a message
* fixed up a bunch of scaladocs for Server-related stuff,