### PR TITLE
Backport pr 433 to 0.8.x

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -60,7 +60,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           parser.parse(DataBuffer(ByteString(p1))).toList must equal(Nil)
           parser.parse(DataBuffer(ByteString(p2))).toList must equal(List(expected))
         } catch {
-          case t: Throwable => throw new Exception(s"Failed with splitIndex $splitIndex: '$p1' : '$p2'", t)
+          case t: Throwable => throw new Exception(s"Failed with splitIndex $splitIndex: '$p1' : '$p2' : $t", t)
         }
       }
 

--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -213,6 +213,14 @@ class CombinatorSuite extends WordSpec with MustMatchers{
       buf.remaining must equal(6)
     }
 
+    "line rejects isolated \\r" in {
+      val parser = line(true)
+      val buf = data("hello\ruhoh\r\n")
+      intercept[ParseException] {
+        parser.parse(buf)
+      }
+    }
+
       
 
 


### PR DESCRIPTION
This was a set of changes to the 0.9.x branch that does a few minor parsing optimizations.  Backporting to 0.8.x since it's a small isolated change and is backwards compatible.  This PR is largely for bookkeeping and I'll be merging immediately since this was already properly PR'ed in #433 .