### PR TITLE
Resurrect Pipes

### DIFF
--- a/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
@@ -1,0 +1,226 @@
+package colossus
+package controller
+
+import colossus.testkit.{FakeIOSystem, ColossusSpec, CallbackMatchers}
+import org.scalatest._
+
+import akka.util.ByteString
+import core.DataBuffer
+import scala.util.{Success, Failure}
+
+import scala.concurrent.duration._
+
+import PushResult._
+
+class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
+
+  implicit val cbe = FakeIOSystem.testExecutor
+
+  implicit val duration = 1.second
+
+  "InfinitePipe" must {
+
+    "push an item after pull request" in {
+      val pipe = new InfinitePipe[Int]
+      var v = 0
+      pipe.pull{x => v = x.get.get}
+      pipe.push(2) mustBe an[Filled]
+      v must equal(2)
+    }
+
+    "push an item after pull request with another request during execution" in {
+      val pipe = new InfinitePipe[Int]
+      var v = 0
+      def pl() {
+        pipe.pull{x => v = x.get.get;pl()}
+      }
+      pl()
+      pipe.push(2) must equal(Ok)
+      v must equal(2)
+    }
+
+    "receive Complete result when puller completes pipe during execution" in {
+      val pipe = new InfinitePipe[Int]
+      pipe.pull{x => pipe.complete()}
+      pipe.push(2) must equal(Complete)
+    }
+
+
+    "fail to push when pipe is full" in {
+      val pipe = new InfinitePipe[Int]
+      pipe.push(1) mustBe an[Full]
+    }
+
+    "received Close if pipe is closed outside pull execution" in {
+      val pipe = new InfinitePipe[Int]
+      pipe.complete()
+      pipe.push(1) must equal(Closed)
+    }
+
+    "fail to push when pipe has been terminated" in {
+      val pipe = new InfinitePipe[Int]
+      pipe.terminate(new Exception("sadfsadf"))
+      pipe.push(1) mustBe an[Error]
+    }
+
+    "full trigger fired when pipe opens up" in {
+      val pipe = new InfinitePipe[Int]
+      val f = pipe.push(1) match {
+        case Full(trig) => trig
+        case other => fail(s"didn't get trigger, got $other")
+      }
+      var triggered = false
+      f.fill{() => triggered = true}
+      triggered must equal(false)
+      pipe.pull{_ => ()}
+      triggered must equal(true)
+    }
+
+    "immediately fail pulls when terminated" in {
+      val pipe = new InfinitePipe[Int]
+      pipe.terminate(new Exception("asdf"))
+      var pulled = false
+      pipe.pull{r => pulled = true; r mustBe an[Failure[_]]}
+      pulled mustBe true
+    }
+
+    /*
+    "get a callback from pullCB" in {
+      val pipe = new InfinitePipe[Int]
+      pipe.push(1) must equal(Success(PushResult.Ok))
+      pipe.push(2) must equal(Success(PushResult.Ok))
+      var ok = false
+      val cb = pipe.pullCB().map{
+        case Some(1) => ok = true
+        case _ => throw new Exception("failed!!")
+      }
+      ok must equal(false)
+      cb.execute()
+      ok must equal(true)
+    }
+    */
+
+    "fold" in {
+      val pipe = new InfinitePipe[Int]
+      var executed = false
+      pipe.fold(0){case (a, b) => a + b}.execute{
+        case Success(6) => {executed = true}
+        case other => {
+          println("FAIL")
+          throw new Exception(s"bad end value $other")
+        }
+
+      }
+      executed must equal(false)
+      pipe.push(1) must equal(Ok)
+      pipe.push(2) must equal(Ok)
+      executed must equal(false)
+      pipe.push(3) must equal(Ok)
+      pipe.complete()
+      executed must equal(true)
+    }
+
+    "foldWhile folds before terminal condition is met" in {
+      val pipe = new InfinitePipe[Int]
+      var executed = false
+      pipe.foldWhile(0){(a, b) => a + b}{_ != 10}.execute{
+        case Success(x) if x < 10 => {executed = true}
+        case other => {
+          throw new Exception(s"bad end value $other")
+        }
+
+      }
+      //the first 4 pushes should bring our total to 8
+      (1 to 4).foreach { i =>
+        executed must equal(false)
+        pipe.push(2) must equal(Ok)
+      }
+
+      pipe.complete()
+      executed must equal(true)
+    }
+
+    "foldWhile stops folding after terminal condition" in {
+      val pipe = new InfinitePipe[Int]
+      var executed = false
+      pipe.foldWhile(0){(a, b) => a + b}{_ != 10}.execute{
+        case Success(10) => {executed = true}
+         case other => {
+          throw new Exception(s"bad end value $other")
+         }
+      }
+       //the first 4 pushes should bring our total to 8
+       (1 to 4).foreach { i =>
+         executed must equal(false)
+         pipe.push(2)
+       }
+        (1 to 4).foreach { i =>
+          pipe.push(2)
+        }
+        pipe.complete()
+        executed must equal(true)
+    }
+  }
+
+  "FiniteBytePipe" must {
+    "close after correct number of bytes have been pushed" in {
+      val pipe = new FiniteBytePipe(7)
+      val data = DataBuffer(ByteString("1234567890"))
+      pipe.fold(ByteString){(a, b) => b}.execute()
+      pipe.push(data) must equal(Complete)
+      data.remaining must equal(3)
+    }
+
+    "not allow negatively sized pipes" in {
+      intercept[IllegalArgumentException] {
+        new FiniteBytePipe(-1)
+      }
+    }
+
+    "immediately close 0 sized pipes" in {
+      val pipe = new FiniteBytePipe(0)
+      val data = DataBuffer(ByteString("1234567890"))
+      pipe.push(data) must equal(Closed)
+      data.remaining must equal(10)
+      //this works..because the CB will never fire if the pipe is not closed
+      pipe.pullCB() must evaluateTo { x : Option[DataBuffer]=>
+        x must be (None)
+      }
+
+    }
+
+    "properly calculates bytes remaining" taggedAs(org.scalatest.Tag("test")) in {
+      //arose from a bug where the pipe was using the buffer's total length
+      //instead of how many bytes were readable
+      val pipe = new FiniteBytePipe(4)
+      val data = DataBuffer(ByteString("1234567"))
+      var res = ByteString()
+      data.take(5)
+      pipe.fold(ByteString()){(buf, build) => build ++ ByteString(buf.takeAll)}.execute{
+        case Success(bstr) => res = bstr
+        case Failure(err) => throw err
+      }
+      pipe.push(data) must equal(Ok)
+      val data2 = DataBuffer(ByteString("abcdefg"))
+      pipe.push(data2) must equal(Complete)
+      res must equal(ByteString("67ab"))
+    }
+
+  }
+
+  /*
+  "DualPipe" must {
+    "combine two pipes" in {
+      val p1 = new FiniteBytePipe(10, 5)
+      val p2 = new FiniteBytePipe(10, 5)
+      val p3 = p1 ++ p2
+      p1.push(DataBuffer(ByteString("12345")))
+      p1.push(DataBuffer(ByteString("67890")))
+      p2.push(DataBuffer(ByteString("abcde")))
+      var res: String = ""
+      def drain
+      */
+
+
+}
+

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -296,7 +296,6 @@ class BufferedPipe[T](size: Int, lowWatermarkP: Double = 0.8, highWatermarkP: Do
   case object Idle extends PushableState
   case class Dead(reason: Throwable) extends State
 
-  //Full is the default state because we can only push once we've received a callback from pull
   private var state: State = Idle
   private val buffer = new LinkedList[T]
   private val lowWatermark = size * lowWatermarkP

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -1,0 +1,400 @@
+package colossus
+package controller
+
+import core.DataBuffer
+import akka.util.ByteString
+import scala.util.{Try, Success, Failure}
+
+import service.{Callback, UnmappedCallback}
+
+trait Transport {
+  //can be triggered by either a source or sink, this will immediately cause
+  //all subsequent pull and pushes to return an Error
+  def terminate(reason: Throwable)
+
+  def terminated : Boolean
+
+  def isClosed: Boolean
+}
+
+/**
+ * A Sink is the write side of a pipe.  It allows you to push items to it,
+ * and will return whether or not it can accept more data.  In the case where
+ * the pipe is full, the Sink will return a mutable Trigger and you can
+ * attach a callback to for when the pipe can receive more items
+ */
+trait Sink[T] extends Transport {
+  def push(item: T): PushResult
+
+  def isFull: Boolean
+
+  //after this is called, data can no longer be written, but can still be read until EOS
+  def complete()
+
+  def feed(from: Source[T], linkState: Boolean) {
+    def tryPush(item: T): Unit = push(item) match {
+      case PushResult.Ok            => feed(from, linkState)
+      case PushResult.Closed        => from.terminate(new Exception("This is probably not what we want to do"))
+      case PushResult.Complete      => from.terminate(new Exception("This is probably not what we want to do"))
+      case PushResult.Full(trig)    => trig.fill(() => tryPush(item))
+      case PushResult.Filled(trig)  => trig.fill(() => tryPush(item))
+      case PushResult.Error(reason) => from.terminate(reason)
+    }
+    from.pull{
+      case Success(Some(item)) => tryPush(item)
+      case Success(None)       => if (linkState) complete()
+      case Failure(err)        => if (linkState) terminate(err)
+    }
+  }
+
+}
+
+/**
+ * A Source is the read side of a pipe.  You provide a handler for when an item
+ * is ready and the Source will call it.  Note that if the underlying pipe has
+ * multiple items ready, onReady will only be called once.  This is so that the
+ * consumer of the sink can implicitly apply backpressure by only pulling when
+ * it is able to
+ */
+trait Source[T] extends Transport {
+  def pull(onReady: Try[Option[T]] => Unit)
+
+  def pullCB(): Callback[Option[T]] = UnmappedCallback(pull)
+
+  def fold[U](init: U)(cb: (T, U) => U): Callback[U] = {
+    pullCB().flatMap{
+      case Some(i) => fold(cb(i, init))(cb)
+      case None => Callback.successful(init)
+    }
+  }
+
+  def foldWhile[U](init: U)(cb:  (T, U) => U)(f : U => Boolean) : Callback[U] = {
+    pullCB().flatMap {
+      case Some(i) => {
+        val aggr = cb(i, init)
+        if(f(aggr)){
+              foldWhile(aggr)(cb)(f)
+            }else{
+              Callback.successful(aggr)
+            }
+        }
+      case None => Callback.successful(init)
+      }
+  }
+    
+
+  def ++(next: Source[T]): Source[T] = new DualSource(this, next)
+
+}
+
+abstract class Generator[T] extends Source[T] {
+  
+  private var _terminated: Option[Throwable] = None
+  private var _closed = false
+
+  def terminated = _terminated.isDefined
+  def isClosed = _closed
+
+  def terminate(reason: Throwable) {
+    _terminated = Some(reason)
+  }
+
+  def generate(): Option[T]
+
+  def pull(f: Try[Option[T]] => Unit) {
+    _terminated.map{t => f(Failure(new PipeTerminatedException(t)))}.getOrElse {
+      val r = generate()
+      if (r.isEmpty) _closed = true
+      f(Success(r))
+    }
+  }
+}
+
+class IteratorGenerator[T](iterator: Iterator[T]) extends Generator[T] {
+  def generate() = if (iterator.hasNext) Some(iterator.next) else None
+}
+
+object Source {
+  def one[T](data: T) = new Source[T] {
+    var item: Try[Option[T]] = Success(Some(data))
+    def pull(onReady: Try[Option[T]] => Unit) {
+      val t = item
+      if (item.isSuccess) {
+        item = Success(None)
+      }
+      onReady(t)
+    }
+    def terminate(reason: Throwable) {
+      item = Failure(reason)
+    }
+
+    def terminated = item.isFailure
+    def isClosed = item.filter{_.isEmpty}.isSuccess
+  }
+}
+
+
+/**
+ * A Pipe is a callback-based data transport abstraction meant for handling
+ * streams.  It provides backpressure feedback for both the write and read
+ * ends.
+ */
+trait Pipe[T, U] extends Sink[T] with Source[U] {
+
+  def join[V, W](pipe : Pipe[V, W])(f : U => Seq[V]) : Pipe[T, W] = PipeCombinator.join(this, pipe)(f)
+
+  def ->>[V, W](pipe : Pipe[V, W])(f : U => Seq[V]) : Pipe[T, W] = join(pipe)(f)
+}
+
+
+/**
+ * When a user attempts to push a value into a pipe, and the pipe either fills
+ * or was already full, a Trigger is returned in the PushResult.  This is
+ * essentially just a fillable callback function that is called when the pipe
+ * either becomes empty or is closed or terminated
+ *
+ * Notice that when the trigger is executed we don't include any information
+ * about the state of the pipe.  The handler can just try pushing again to
+ * determine if the pipe is dead or not.
+ */
+class Trigger {
+
+  private var callback: Option[() => Unit] = None
+  def fill(cb: () => Unit) {
+    callback = Some(cb)
+  }
+
+  def trigger() {
+    callback.foreach{f => f()}
+  }
+
+  /**
+   * Cancels execution of the trigger.  The pusher should only do this when they're about to terminate the stream.
+   *
+   * TODO: might be a better way to handle this, but it would probably imply we'd need to know who terminated the stream
+   */
+  def cancel() {
+    callback = None
+  }
+
+}
+
+sealed trait PushResult
+object PushResult {
+  sealed trait Pushed extends PushResult
+  sealed trait NotPushed extends PushResult
+
+  //the item was successfully pushed and is ready for more data
+  case object Ok extends Pushed
+
+  //the item was successfully pushed but the pipe is not yet ready for more data, trigger is called when it's ready
+  case class Filled(trigger: Trigger) extends Pushed
+
+  //the item was successfully pushed but that's the last one, future pushes will return Closed
+  case object Complete extends Pushed
+
+  //the item was not pushed because the pipe is already full
+  case class Full(trigger: Trigger) extends NotPushed
+
+  //The pipe has been manually closed (without error) and is not accepting any more items
+  case object Closed extends NotPushed
+
+  //The pipe has been terminated or some other error has occurred
+  case class Error(reason: Throwable) extends NotPushed
+}
+
+/** A pipe designed to accept a fixed number of bytes
+ * 
+ * BE AWARE: when pushing buffers into this pipe, if the pipe completes, the
+ * buffer may still contain unread data meant for another consumer
+ */
+class FiniteBytePipe(totalBytes: Long) extends InfinitePipe[DataBuffer] {
+  require(totalBytes >= 0, "A FiniteBytePipe must accept 0 or more bytes")
+
+  private var taken = 0L
+  def remaining = totalBytes - taken
+
+  if(totalBytes == 0){
+    complete()
+  }
+
+  override def push(data: DataBuffer): PushResult = {
+    //notice we're only dong these checks to avoid the databuffer copying,
+    //won't need this when we get slices
+    if (!terminated && !isFull && !isClosed) {
+      if (taken == totalBytes) {
+        throw new Exception("All bytes have been read but pipe is not closed!") //this should never happen
+      } else {
+        val partial = if (remaining >= data.remaining) {
+          data
+        } else {
+          //TODO: need databuffer slices to avoid copying here
+          DataBuffer(ByteString(data.take(remaining.toInt)))
+        }
+        //need to get this value here, since remaining might be 0 after call
+        val toAdd = partial.remaining
+        val res = super.push(partial) 
+        if (res.isInstanceOf[PushResult.Pushed]) {
+          taken += toAdd
+          if (taken == totalBytes) {
+            complete()
+            PushResult.Complete
+          } else {
+            res
+          }
+        } else {
+          res
+        }
+      }
+    } else {
+      //lazy but effective, just push an empty buffer since it will be rejected anyway with the correct response
+      super.push(DataBuffer(ByteString()))
+    }
+  }
+
+}
+
+/**
+ * Wraps 2 sinks and will automatically begin reading from the second only when
+ * the first is empty.  The `None` from the first sink is never exposed.  The
+ * first error reported from either sink is propagated.
+ */
+class DualSource[T](a: Source[T], b: Source[T]) extends Source[T] {
+  private var a_empty = false
+  def pull(cb: Try[Option[T]] => Unit) {
+    if (a_empty) {
+      b.pull(cb)
+    } else {
+      a.pull{
+        case Success(None) => {
+          a_empty = true
+          pull(cb)
+        }
+        case other => cb(other)
+      }
+    }
+  }
+
+  def terminate(reason: Throwable) {
+    a.terminate(reason)
+    b.terminate(reason)
+  }
+
+  override def terminated: Boolean = a.terminated && b.terminated
+
+  def isClosed = a.isClosed && b.isClosed
+}
+
+
+
+sealed trait PipeException extends Throwable
+class PipeTerminatedException(reason: Throwable) extends Exception("Pipe Terminated", reason) with PipeException
+class PipeStateException(message: String) extends Exception(message) with PipeException
+
+/**
+ * This is a special exception that Input/Output controllers look for when
+ * error handling pipes.  In most cases they will log the error that terminated
+ * the pipe, but for this one exception, the failure will be silent.  This is
+ * basically for situations where a certain amount of data is expected but for
+ * some reason the receiver decides to cancel for some business-logic reason.
+ */
+class PipeCancelledException extends Exception("Pipe Cancelled") with PipeException
+
+class InfinitePipe[T] extends Pipe[T, T] {
+
+  sealed trait State
+  case class Full(trigger: Trigger) extends State
+  case class Pulling(callback: Try[Option[T]] => Unit) extends State
+  case object Closed extends State
+  case class Dead(reason: Throwable) extends State
+
+  //Full is the default state because we can only push once we've received a callback from pull
+  private var state: State = Full(new Trigger)
+
+  def terminated  = state.isInstanceOf[Dead]
+  def isFull      = state.isInstanceOf[Full]
+  def isClosed    = state == Closed
+
+  def isPushable  = state.isInstanceOf[Pulling]
+
+  /** Attempt to push a value into the pipe.
+   *
+   * The value will only be successfully pushed only if there has already a
+   * been a request for data on the pulling side.  In other words, the pipe
+   * will never interally queue a value.
+   * 
+   * @return the result of the push
+   * @throws PipeException when pushing to a full pipe
+   */
+  def push(item: T): PushResult = state match {
+    case Full(trig)   => PushResult.Full(trig)
+    case Dead(reason) => PushResult.Error(reason)
+    case Closed       => PushResult.Closed
+    case Pulling(cb)  => {
+      state = Full(new Trigger) //maybe create a new state here might be some weirdness if the puller pushes to the pipe
+      cb(Success(Some(item)))
+      //notice that the callback may (and probably will) call "pull" in its
+      //execution.  Thus we can expect the state to have changed here
+      state match {
+        case Full(trig)   => PushResult.Filled(trig)    //cb didn't call "pull"
+        case Dead(reason) => PushResult.Error(reason)   //cb terminated the pipe
+        case Closed       => PushResult.Complete        //cb closed the pipe
+        case Pulling(_)   => PushResult.Ok              //cb called pull
+      }
+    }
+  }
+
+  //this is useful for inherited pipes that need to do some processing on a value before it is pushed
+  protected def whenPushable(f: => PushResult): PushResult = if (isPushable) f else state match {
+    case Full(trig)   => PushResult.Full(trig)
+    case Dead(reason) => PushResult.Error(reason)
+    case Closed       => PushResult.Closed
+    case Pulling(cb)  => throw new PipeStateException("This should never happen")
+  }
+  
+  /** Request the next value from the pipe
+   * 
+   * Only one value can be requested at a time.  Also there can only be one
+   * outstanding request at a time.
+   *
+   */
+  // NOTE - whenReady's parameter has type Try[Option[T]] instead of some kind of ADT to be compatible with Callbacks
+  def pull(whenReady: Try[Option[T]] => Unit): Unit = state match {
+    case Dead(reason)  => whenReady(Failure(reason))
+    case Closed        => whenReady(Success(None))
+    case Pulling(_)    => whenReady(Failure(new PipeStateException("Pipe already being pulled")))
+    case Full(trig)    => {
+      state = Pulling(whenReady)
+      trig.trigger()
+    }
+  }
+      
+    
+  def complete() {
+    val oldstate = state
+    state = Closed
+    oldstate match {
+      case Full(trig)   => trig.trigger()
+      case Pulling(cb)  => cb(Success(None))
+      case Dead(reason) => throw new PipeTerminatedException(reason) 
+      case _ => {}
+    }
+  }
+
+  //notice in all these cases, we are not storing a PipeTerminatedException,
+  //but creating it on the spot every time so that the stack traces are more
+  //accurate
+  def terminate(reason: Throwable) {
+    val oldstate = state
+    state = Dead(new PipeTerminatedException(reason))
+    oldstate match {
+      case Full(trig)   => trig.trigger()
+      case Pulling(cb)  => cb(Failure(new PipeTerminatedException(reason)))
+      case Dead(r)      => throw new PipeStateException("Cannot terminate a pipe that has already been terminated")
+      case Closed       => {} //don't think there's anything to do here
+    }
+  }
+
+}
+
+

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -90,6 +90,11 @@ trait Source[T] extends Transport {
       case None => Callback.successful(init)
       }
   }
+
+  def reduce(reducer: (T, T) => T): Callback[T] = pullCB().flatMap {
+    case Some(i) => fold(i)(reducer)
+    case None => Callback.failed(new PipeStateException("Empty reduce on pipe"))
+  }
     
 
   def ++(next: Source[T]): Source[T] = new DualSource(this, next)

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -152,12 +152,25 @@ object Source {
  * A Pipe is a callback-based data transport abstraction meant for handling
  * streams.  It provides backpressure feedback for both the write and read
  * ends.
+ *
+ * Pipes are primarily a way to easily process incoming/outgoing streams and manage
+ * backpressure.  A Producer pushes items into a pipe and a consumer pulls them
+ * out.  Pulling is done through the use of a callback function which the Pipe
+ * holds onto until an item is pushed.  Each call to `pull` will only ever pull one
+ * item out of the pipe, so generally the consumer enters a loop by calling pull
+ * within the callback function.
+ * 
+ * Backpressure is handled differently for the producer and consumer.  In effect,
+ * the consumer is the "leader" in terms of backpressure, since the consumer must
+ * always ask for more items.  For the producer, the return value of `push` will
+ * indicate if backpressure is occurring.  When the pipe is "full", `push` returns
+ * a `Trigger`, which the producer "fills" by supplying a callback function.  This
+ * function will be called once the backpressure has been alleviated and the pipe
+ * can accept more items.
+ * 
  */
 trait Pipe[T, U] extends Sink[T] with Source[U] {
 
-  //def join[V, W](pipe : Pipe[V, W])(f : U => Seq[V]) : Pipe[T, W] = PipeCombinator.join(this, pipe)(f)
-
-  //def ->>[V, W](pipe : Pipe[V, W])(f : U => Seq[V]) : Pipe[T, W] = join(pipe)(f)
 }
 
 


### PR DESCRIPTION
So when I deleted all the streaming code in #426, I was probably a little overzealous and deleted all the `Pipe` code.  However with the new streaming API pipes are going to make a comeback and will probably work a whole lot better than they did before.

All in all, pipes will serve a slightly different purpose than before.  One of the goals behind the previous iteration of pipes was to facilitate true zero-copy data proxying.  The idea was you could take a raw `DataBuffer` received on a server-side connection and pipe it directly through to a client-side connection without ever copying it.  However, not only has doing that been impossible since 0.7.0 (with the implementation of pull-based writing), but we never actually implemented that, and I believe it was adding way too much complexity for a fairly specific use-case.

Removing that goal considerably cleans up the logic around pipes and I think will make them much more useful overall.

[This comparison](https://github.com/tumblr/colossus/compare/12916d4...132407c) shows the changes I made to the resurrected code.  The main differences are:

* `FiniteBytePipe` is dead and gone
* `InfinitePipe` is now `BufferedPipe` and now has an internal fixed-size buffer.  When the size is set to 0 it behaves as `InfinitePipe` did.
* No action on pipes will cause an exception to be thrown, which I think was previously a major source of instability.  All exceptions are now propagated inside callback functions.
* `BufferedPipe` also now has high and low watermarks for pushing items.  When the internal buffer hits the high watermark, calls to `push` will start returning `Filling` instead of `Ok`.  Likewise, the size of the low watermark determines when the trigger callback is executed, which signals to the producer that its ok to push again.  They should be useful in the future to help smooth out backpressure.

This is probably the first of several PR's that will improve and integrate pipes into the new streaming API.  Both the Streaming Http and upcoming Http/2 API's will be using this extensively.
