### PR TITLE
Streaming Http Service, part 1

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/Main.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/Main.scala
@@ -44,5 +44,7 @@ object Main extends App {
 
   val streamServer = StreamExample.start(9009)
 
+  val streamServiceServer = StreamServiceExample.start(9010)
+
 
 }

--- a/colossus-examples/src/main/scala/colossus-examples/StreamExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamExample.scala
@@ -5,6 +5,7 @@ import colossus._
 import protocols.http._
 import stream._
 import core.{DataBlock, ServerContext}
+import controller._
 
 import scala.util.{Failure, Success, Try}
 

--- a/colossus-examples/src/main/scala/colossus-examples/StreamExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamExample.scala
@@ -18,7 +18,7 @@ object StreamExample {
           case Success(num) => {
             upstream.push (Head(HttpResponseHead(head.version, HttpCodes.OK, HttpHeaders.fromString("transfer-encoding" -> "chunked")))){_ => ()}
             def sendNumbers(num: Int): Unit = num match {
-              case 0 => upstream.push(End()){_ => ()}
+              case 0 => upstream.push(End){_ => ()}
               case n => {
                 upstream.push (BodyData(DataBlock(s"$n\r\n"))){_ => sendNumbers(n - 1)}
               }

--- a/colossus-examples/src/main/scala/colossus-examples/StreamExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamExample.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success, Try}
 object StreamExample {
 
   class Handler(ctx: ServerContext) extends StreamServerHandler(ctx) {
-    def handle(message: StreamHttpMessage[HttpRequestHead]) {
+    def handle(message: HttpStream[HttpRequestHead]) {
       message match {
         case Head(head) if (head.path == "/zop") => head.parameters.getFirstAs[Int]("num") match {
           case Success(num) => {
@@ -20,7 +20,7 @@ object StreamExample {
             def sendNumbers(num: Int): Unit = num match {
               case 0 => upstream.push(End){_ => ()}
               case n => {
-                upstream.push (BodyData(DataBlock(s"$n\r\n"))){_ => sendNumbers(n - 1)}
+                upstream.push (Data(DataBlock(s"$n\r\n"))){_ => sendNumbers(n - 1)}
               }
             }
             sendNumbers(num)

--- a/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
@@ -1,0 +1,30 @@
+package colossus.examples
+
+import colossus._
+
+import protocols.http._
+import stream._
+import core.{DataBlock, ServerContext}
+import controller._
+import service._
+
+import scala.util.{Failure, Success, Try}
+
+object StreamServiceExample {
+
+  def start(port: Int)(implicit sys: IOSystem) = {
+    StreamHttpServiceServer.basic("stream-service", port, new GenRequestHandler[StreamingHttp](_) {
+
+      def handle = {
+        case StreamingHttpRequest(head, source) => source.collected.map{_ => 
+          StreamingHttpResponse(
+            HttpResponseHead(head.version, HttpCodes.OK,  HttpHeaders(HttpHeader("transfer-encoding",TransferEncoding.Chunked.value))), 
+            Source.fromIterator(List("hello", "world", "blah").toIterator.map{s => BodyData(DataBlock(s))})
+          )
+        }
+      }
+    })
+
+  }
+}
+

--- a/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
@@ -25,14 +25,14 @@ object StreamServiceExample {
       def handle = {
         case StreamingHttpRequest(head, source) if (head.url == "/plaintext") => source.collected.map{_ =>
           StreamingHttpResponse(
-            HttpResponseHead(head.version, HttpCodes.OK, headers),
+            HttpResponseHead(head.version, HttpCodes.OK, None, None, None, headers),
             Source.one(bodydata)
           )
         }
 
         case StreamingHttpRequest(head, source) if (head.url == "/chunked") => source.collected.map{_ => 
           StreamingHttpResponse(
-            HttpResponseHead(head.version, HttpCodes.OK,  HttpHeaders(HttpHeader("transfer-encoding",TransferEncoding.Chunked.value))), 
+            HttpResponseHead(head.version, HttpCodes.OK,  Some(TransferEncoding.Chunked), None, None, HttpHeaders.Empty), 
             Source.fromIterator(List("hello", "world", "blah").toIterator.map{s => Data(DataBlock(s))})
           )
         }

--- a/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
@@ -13,13 +13,27 @@ import scala.util.{Failure, Success, Try}
 object StreamServiceExample {
 
   def start(port: Int)(implicit sys: IOSystem) = {
-    StreamHttpServiceServer.basic("stream-service", port, new GenRequestHandler[StreamingHttp](_) {
+    val bodydata = Data(DataBlock("Hello World!"))
+    val headers = HttpHeaders(HttpHeader("Content-Length", bodydata.data.length.toString))
+
+    val config = ServiceConfig.Default.copy(
+      requestMetrics = false
+    )
+
+    StreamHttpServiceServer.basic("stream-service", port, new GenRequestHandler[StreamingHttp](config, _) {
 
       def handle = {
-        case StreamingHttpRequest(head, source) => source.collected.map{_ => 
+        case StreamingHttpRequest(head, source) if (head.url == "/plaintext") => source.collected.map{_ =>
+          StreamingHttpResponse(
+            HttpResponseHead(head.version, HttpCodes.OK, headers),
+            Source.one(bodydata)
+          )
+        }
+
+        case StreamingHttpRequest(head, source) if (head.url == "/chunked") => source.collected.map{_ => 
           StreamingHttpResponse(
             HttpResponseHead(head.version, HttpCodes.OK,  HttpHeaders(HttpHeader("transfer-encoding",TransferEncoding.Chunked.value))), 
-            Source.fromIterator(List("hello", "world", "blah").toIterator.map{s => BodyData(DataBlock(s))})
+            Source.fromIterator(List("hello", "world", "blah").toIterator.map{s => Data(DataBlock(s))})
           )
         }
       }

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -46,14 +46,14 @@ trait ControllerMocks extends MockFactory {self: org.scalamock.scalatest.MockFac
 
   val defaultConfig = ControllerConfig(4, 50.milliseconds, 2000.bytes)
 
-  def get(config: ControllerConfig = defaultConfig)(implicit sys: ActorSystem): (CoreUpstream, TestController[Raw#ServerEncoding], ControllerDownstream[Raw#ServerEncoding]) = {
+  def get(config: ControllerConfig = defaultConfig)(implicit sys: ActorSystem): (CoreUpstream, TestController[Encoding.Server[Raw]], ControllerDownstream[Encoding.Server[Raw]]) = {
     val upstream = stub[CoreUpstream]
-    val downstream = stub[ControllerDownstream[Raw#ServerEncoding]]
+    val downstream = stub[ControllerDownstream[Encoding.Server[Raw]]]
     (downstream.controllerConfig _).when().returns(config)
     (downstream.context _).when().returns(FakeIOSystem.fakeContext)
     (downstream.onFatalError _).when(*).returns(None)
 
-    val controller = new Controller(downstream, RawServerCodec) with TestController[Raw#ServerEncoding]
+    val controller = new Controller(downstream, RawServerCodec) with TestController[Encoding.Server[Raw]]
     controller.setUpstream(upstream)
     (upstream, controller, downstream)
   }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/StreamHttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/StreamHttpSpec.scala
@@ -22,7 +22,7 @@ class StreamHttpSpec extends ColossusSpec with MockFactory{
         "content-length" -> "10", "something-else" -> "bleh"
       ))))
       codec.decode(requestBytes) mustBe Some(BodyData(DataBlock("0123456789")))
-      codec.decode(requestBytes) mustBe Some(End())
+      codec.decode(requestBytes) mustBe Some(End)
       codec.decode(requestBytes) mustBe None
     }
 
@@ -38,7 +38,7 @@ class StreamHttpSpec extends ColossusSpec with MockFactory{
       codec.decode(requestBytes1) mustBe None
       codec.decode(requestBytes2) mustBe Some(BodyData(DataBlock("hello")))
       codec.decode(requestBytes2) mustBe Some(BodyData(DataBlock("ok")))
-      codec.decode(requestBytes2) mustBe Some(End())
+      codec.decode(requestBytes2) mustBe Some(End)
       codec.decode(requestBytes2) mustBe None
     }
 
@@ -49,7 +49,7 @@ class StreamHttpSpec extends ColossusSpec with MockFactory{
       val expected = "HTTP/1.1 200 OK\r\nfoo: bar\r\ncontent-length: 10\r\n\r\n0123456789"
       codec.encode(Head(resp), out)
       codec.encode(BodyData(DataBlock("0123456789")), out)
-      codec.encode(End(), out)
+      codec.encode(End, out)
       out.data.asByteString.utf8String mustBe expected
     }
 
@@ -61,7 +61,7 @@ class StreamHttpSpec extends ColossusSpec with MockFactory{
       codec.encode(Head(resp), out)
       codec.encode(BodyData(DataBlock("hello")), out)
       codec.encode(BodyData(DataBlock("world!")), out)
-      codec.encode(End(), out)
+      codec.encode(End, out)
       out.data.asByteString.utf8String mustBe expected
     }
 
@@ -72,7 +72,7 @@ class StreamHttpSpec extends ColossusSpec with MockFactory{
       intercept[StreamHttpException] {
         codec.encode(Head(HttpResponse.ok("foo").head), out)
       }
-      codec.encode(End(), out)
+      codec.encode(End, out)
       //now it should work
       codec.encode(Head(HttpResponse.ok("foo").head), out)
     }
@@ -110,8 +110,8 @@ class StreamHttpSpec extends ColossusSpec with MockFactory{
       val response = HttpResponse.ok("hello").withHeader("content-length", "5").withHeader("Content-Type", "text/plain")
       inSequence {
         (controllerStub.push (_: Encoding.Server[StreamHttp]#Output) (_: QueuedItem.PostWrite)).verify(Head(response.head), *)
-        (controllerStub.push (_: Encoding.Server[StreamHttp]#Output) (_: QueuedItem.PostWrite)).verify(BodyData[HttpResponseHead](DataBlock("hello")), *)
-        (controllerStub.push (_: Encoding.Server[StreamHttp]#Output) (_: QueuedItem.PostWrite)).verify(End[HttpResponseHead](), *)
+        (controllerStub.push (_: Encoding.Server[StreamHttp]#Output) (_: QueuedItem.PostWrite)).verify(BodyData(DataBlock("hello")), *)
+        (controllerStub.push (_: Encoding.Server[StreamHttp]#Output) (_: QueuedItem.PostWrite)).verify(End, *)
       }
     }
   }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/StreamHttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/StreamHttpSpec.scala
@@ -102,16 +102,16 @@ class StreamHttpSpec extends ColossusSpec with MockFactory{
     }
     
     "push a full response" in {
-      val controllerStub = stub[ControllerUpstream[StreamHttp#ServerEncoding]]
+      val controllerStub = stub[ControllerUpstream[Encoding.Server[StreamHttp]]]
       val handler        = new MyHandler(FakeIOSystem.fakeServerContext)
       val controller = new ServerStreamController(handler)
       controller.setUpstream(controllerStub)
       controller.processMessage(Head(HttpRequest.get("/foo").head))
       val response = HttpResponse.ok("hello").withHeader("content-length", "5").withHeader("Content-Type", "text/plain")
       inSequence {
-        (controllerStub.push (_: StreamHttp#ServerEncoding#Output) (_: QueuedItem.PostWrite)).verify(Head(response.head), *)
-        (controllerStub.push (_: StreamHttp#ServerEncoding#Output) (_: QueuedItem.PostWrite)).verify(BodyData[HttpResponseHead](DataBlock("hello")), *)
-        (controllerStub.push (_: StreamHttp#ServerEncoding#Output) (_: QueuedItem.PostWrite)).verify(End[HttpResponseHead](), *)
+        (controllerStub.push (_: Encoding.Server[StreamHttp]#Output) (_: QueuedItem.PostWrite)).verify(Head(response.head), *)
+        (controllerStub.push (_: Encoding.Server[StreamHttp]#Output) (_: QueuedItem.PostWrite)).verify(BodyData[HttpResponseHead](DataBlock("hello")), *)
+        (controllerStub.push (_: Encoding.Server[StreamHttp]#Output) (_: QueuedItem.PostWrite)).verify(End[HttpResponseHead](), *)
       }
     }
   }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -45,7 +45,7 @@ class ServiceClientSpec extends ColossusSpec with MockFactory {
     )
     implicit val w = fakeWorker.worker
     class TestClient extends ServiceClient[Redis](new RedisClientCodec, config, w.generateContext) {
-      val mockController: ControllerUpstream[Redis#ClientEncoding] = stub[ControllerUpstream[Redis#ClientEncoding]]
+      val mockController: ControllerUpstream[Encoding.Client[Redis]] = stub[ControllerUpstream[Encoding.Client[Redis]]]
       val mockConnectionHandler = stub[ClientConnectionHandler]
       override protected def fullHandler(me: ServiceClient[Redis]) = {
         this.setUpstream(mockController)

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -42,8 +42,8 @@ class ServiceServerSpec extends ColossusSpec with MockFactory {
     endpoint
   }
 
-  def fs(fn: ByteString => Callback[ByteString] = x => Callback.successful(x)): (FakeService, ControllerUpstream[Raw#ServerEncoding])  = {
-    val controllerstub = stub[ControllerUpstream[Raw#ServerEncoding]]
+  def fs(fn: ByteString => Callback[ByteString] = x => Callback.successful(x)): (FakeService, ControllerUpstream[Encoding.Server[Raw]])  = {
+    val controllerstub = stub[ControllerUpstream[Encoding.Server[Raw]]]
     val connectionstub = stub[ConnectionManager]
     (connectionstub.isConnected _).when().returns(true)
     (controllerstub.connection _).when().returns(connectionstub)
@@ -55,7 +55,7 @@ class ServiceServerSpec extends ColossusSpec with MockFactory {
     (handler, controllerstub)
   }
 
-  def expectPush(controller: ControllerUpstream[Raw#ServerEncoding], message: ByteString) {
+  def expectPush(controller: ControllerUpstream[Encoding.Server[Raw]], message: ByteString) {
       (controller.pushFrom _ ).verify(message, *, *)
   }
 

--- a/colossus/src/main/scala/colossus/controller/Codec.scala
+++ b/colossus/src/main/scala/colossus/controller/Codec.scala
@@ -25,7 +25,7 @@ object Codec {
 
   import service.Protocol
 
-  type Server[P <: Protocol] = Codec[P#ServerEncoding]
+  type Server[P <: Protocol] = Codec[Encoding.Server[P]]
   type Client[P <: Protocol] = Codec[Encoding.Client[P]]
 
 }

--- a/colossus/src/main/scala/colossus/controller/Codec.scala
+++ b/colossus/src/main/scala/colossus/controller/Codec.scala
@@ -26,7 +26,7 @@ object Codec {
   import service.Protocol
 
   type Server[P <: Protocol] = Codec[P#ServerEncoding]
-  type Client[P <: Protocol] = Codec[P#ClientEncoding]
+  type Client[P <: Protocol] = Codec[Encoding.Client[P]]
 
 }
 

--- a/colossus/src/main/scala/colossus/controller/Encoding.scala
+++ b/colossus/src/main/scala/colossus/controller/Encoding.scala
@@ -1,5 +1,7 @@
 package colossus.controller
 
+import colossus.service.Protocol
+
 trait Encoding {
   type Input
   type Output
@@ -7,4 +9,7 @@ trait Encoding {
 
 object Encoding {
   type Apply[I,O] = Encoding { type Input = I; type Output = O }
+
+  type Server[P <: Protocol] = Encoding { type Input = P#Request; type Output = P#Response }
+  type Client[P <: Protocol] = Encoding { type Input = P#Response; type Output = P#Request }
 }

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -97,6 +97,8 @@ trait Source[+T] extends Transport {
 
   def ++[U >: T](next: Source[U]): Source[U] = new DualSource(this, next)
 
+  def collected: Callback[Iterator[T]] = fold(new collection.mutable.ArrayBuffer[T]){ case (next, buf) => buf append next ; buf } map {_.toIterator}
+
 }
 
 object Source {
@@ -142,6 +144,16 @@ object Source {
 
     def isClosed = !iterator.hasNext
 
+  }
+
+  def empty[T] = new Source[T] {
+    def isClosed = true
+    def terminated = false
+    def pull(on: Try[Option[T]] => Unit) {
+      on(Success(None))
+    }
+
+    def terminate(reason: Throwable){}
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -190,6 +190,13 @@ class ParsedHttpHeaders(
   override val connection: Option[Connection]
 ) extends HttpHeaders(headers) {
 
+  def this(
+    headers: HttpHeaders, 
+    transferEncodingOpt: Option[TransferEncoding],
+    contentLength: Option[Int],
+    connection: Option[Connection]
+  ) = this(headers.headers, transferEncodingOpt, contentLength, connection)
+
   override def transferEncoding = transferEncodingOpt.getOrElse(TransferEncoding.Identity)
 
 }
@@ -199,7 +206,7 @@ class ParsedHttpHeaders(
 /**
  * A Wrapper class for a set of Http headers, for a request or response.
  */
-class HttpHeaders(private val headers: JList[HttpHeader]) {
+class HttpHeaders(private[http] val headers: JList[HttpHeader]) {
 
   // NOTE - the headers value should contain ALL headers, even ones like
   // content-length that we track separately

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClientCodec.scala
@@ -6,9 +6,9 @@ import colossus.service._
 import parsing._
 import Combinators.Parser
 
-import controller.Codec
+import controller.{Codec, Encoding}
 
-class StaticHttpClientCodec extends Codec[Http#ClientEncoding] {
+class StaticHttpClientCodec extends Codec[Encoding.Client[Http]] {
 
   private var parser : Parser[HttpResponse] = HttpResponseParser.static()
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -36,7 +36,7 @@ case class BuiltHead(firstLine: BuildFL, headers: HttpHeaders) extends HttpReque
 
 case class ParsedHead(firstLine: ParsedFL, headers: HttpHeaders) extends HttpRequestHead
 
-trait HttpRequestHead extends Encoder with HttpMessageHead[HttpRequestHead] {
+trait HttpRequestHead extends Encoder with HttpMessageHead {
   def firstLine: FirstLine
   def headers: HttpHeaders
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -72,6 +72,17 @@ object HttpResponseHead{
   def apply(version: HttpVersion, code: HttpCode, headers: HttpHeaders): HttpResponseHead = {
     HttpResponseHead(BasicResponseFL(version, code), headers)
   }
+
+  def apply(
+    version: HttpVersion,
+    code: HttpCode,
+    transferEncoding: Option[TransferEncoding],
+    contentLength: Option[Int],
+    connection: Option[Connection],
+    extraHeaders: HttpHeaders
+  ): HttpResponseHead = {
+    apply(version, code, new ParsedHttpHeaders(extraHeaders, transferEncoding, contentLength, connection))
+  }
 }
   
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -49,7 +49,7 @@ case class ParsedResponseFL(data: Array[Byte]) extends ResponseFL with LazyParsi
 
 case class BasicResponseFL(version : HttpVersion, code: HttpCode) extends ResponseFL
 
-case class HttpResponseHead(fl: ResponseFL, headers : HttpHeaders ) extends HttpMessageHead[HttpResponseHead] {
+case class HttpResponseHead(fl: ResponseFL, headers : HttpHeaders ) extends HttpMessageHead {
 
   def version = fl.version
   def code = fl.code
@@ -93,7 +93,7 @@ case class HttpResponse(head: HttpResponseHead, body: HttpBody) extends Encoder 
   }
 
 
-  def withHeader(key: String, value: String) = copy(head = head.withHeader(key,value))
+  def withHeader(key: String, value: String) = copy(head = head.withHeader(HttpHeader(key,value)))
 
   def code = head.code
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
@@ -14,7 +14,7 @@ extends DSLService[Http](rh) {
 
   override def tagDecorator = new ReturnCodeTagDecorator
 
-  override def processRequest(input: Http#Input): Callback[Http#Output] = {
+  override def processRequest(input: Http#Request): Callback[Http#Response] = {
     val response = super.processRequest(input)
     if(!input.head.persistConnection) connection.disconnect()
     response

--- a/colossus/src/main/scala/colossus/protocols/http/HttpServerCodec.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpServerCodec.scala
@@ -5,7 +5,7 @@ package protocols.http
 import core._
 import controller.Codec
 
-class StaticHttpServerCodec(headers: HttpHeaders) extends Codec[Http#ServerEncoding] {
+class StaticHttpServerCodec(headers: HttpHeaders) extends Codec.Server[Http] {
   private var parser = HttpRequestParser()
 
   def encode(response: HttpResponse, buffer: DataOutBuffer){ response.encode(buffer, headers) }

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -23,8 +23,9 @@ case class StreamingHttpResponse(head: HttpResponseHead, body: Source[BodyData[H
 
 
 
+
 object GenEncoding {
-  type StreamingHttp = Protocol {
+  trait StreamingHttp extends Protocol {
     type Request = StreamingHttpMessage[HttpRequestHead]
     type Response = StreamingHttpMessage[HttpResponseHead]
   }
@@ -47,6 +48,8 @@ object GenEncoding {
     type Request = HttpRequestHead
     type Response = HttpResponseHead
   }
+
+  //type StreamingEncoding = Encoding { type Input <: StreamingHttpMessage
 }
 import GenEncoding._
 
@@ -67,8 +70,8 @@ class StreamServiceServerController[E <: GenEncoding.HeadEncoding](
 )
 extends ControllerDownstream[GenEncoding[StreamHttpMessage, E]] 
 with ControllerUpstream[GenEncoding[StreamingHttpMessage, E]]
-with DownstreamEventHandler[ControllerDownstream[GenEncoding[StreamingHttpMessage, E]]] 
-with UpstreamEventHandler[ControllerUpstream[GenEncoding[StreamHttpMessage, E]]] {
+with DownstreamEventHandler[ControllerDownstream[GenEncoding[StreamHttpMessage, E]]] 
+with UpstreamEventHandler[ControllerUpstream[GenEncoding[StreamingHttpMessage, E]]] {
 
   downstream.setUpstream(this)
 
@@ -204,7 +207,7 @@ class StreamServiceHandlerGenerator(ctx: InitContext) extends HandlerGenerator[G
   
   def fullHandler = handler => {
     new PipelineHandler(
-      new Controller(
+      new Controller[GenEncoding[StreamHttpMessage, StreamHeader#ServerEncoding]](
         new StreamServiceServerController[StreamHeader#ServerEncoding](
           new StreamingHttpServiceHandler(handler),
           StreamRequestBuilder

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -1,0 +1,110 @@
+package colossus
+package protocols.http
+package stream
+
+import controller._
+import service.Protocol
+import core._
+
+import scala.language.higherKinds
+
+trait StreamingHttpMessage[T <: HttpMessageHead[T]] {
+
+  def head: T
+  def body: Source[BodyData[T]]
+
+  def collapse: Source[StreamHttpMessage[T]] = Source.one[StreamHttpMessage[T]](Head(head)) ++ body
+}
+
+case class StreamingHttpRequest(head: HttpRequestHead, body: Source[BodyData[HttpRequestHead]]) extends StreamingHttpMessage[HttpRequestHead]
+case class StreamingHttpResponse(head: HttpResponseHead, body: Source[BodyData[HttpResponseHead]]) extends StreamingHttpMessage[HttpResponseHead]
+
+
+trait StreamingHttp extends Protocol {
+  type Request = StreamingHttpRequest
+  type Response = StreamingHttpResponse
+}
+
+object GenEncoding {
+  trait HeadEncoding extends Encoding {
+    type Input <: HttpMessageHead[Input]
+    type  Output <: HttpMessageHead[Output]
+  }
+
+  type GenEncoding[M[T <: HttpMessageHead[T]], E <: HeadEncoding] = Encoding {
+    type Input = M[E#Input]
+    type Output = M[E#Output]
+  }
+}
+import GenEncoding._
+
+trait HttpHeadProtocol extends Protocol {
+  type Request = HttpRequestHead
+  type Response = HttpResponseHead
+}
+
+trait InputMessageBuilder[T <: HttpMessageHead[T]] {
+  def build(head: T): (Sink[BodyData[T]], StreamingHttpMessage[T])
+}
+
+class StreamServiceServerController[E <: GenEncoding.HeadEncoding](builder: InputMessageBuilder[E#Input])
+extends ControllerDownstream[GenEncoding[StreamHttpMessage, E]] with ControllerUpstream[GenEncoding[StreamingHttpMessage, E]]
+with DownstreamEventHandler[ControllerDownstream[GenEncoding[StreamingHttpMessage, E]]] 
+with UpstreamEventHandler[ControllerUpstream[GenEncoding[StreamHttpMessage, E]]] {
+
+
+  type InputHead = E#Input
+  type OutputHead = E#Output
+
+  private var currentInputStream: Option[Sink[BodyData[InputHead]]] = None
+
+  protected def fatal(message: String) {
+    println(s"FATAL ERROR: $message")
+    upstream.connection.forceDisconnect()
+  }
+
+  def processMessage(input: StreamHttpMessage[InputHead]) {
+    input match {
+      case Head(head) => currentInputStream match {
+        case None => {
+          val (sink, msg) = builder.build(head)
+          currentInputStream = Some(sink)
+          downstream.processMessage(msg)
+        }
+        case Some(uhoh) => {
+          //we got a head before the last stream finished, not good
+          fatal("received head during unfinished stream")
+        }
+      }
+      case b @ BodyData(_, _) => currentInputStream match {
+        case Some(sink) => sink.push(b) match {
+          case PushResult.Filled(signal) => {
+            upstream.pauseReads()
+            signal.react{
+              upstream.resumeReads()
+            }
+          }
+          case bad: PushResult.NotPushed => {
+            // :(
+            fatal("failed to push message to stream")
+          }
+          case other => {}
+        }
+        case None => {
+          fatal("Received body data but no input stream exists")
+        }
+      }
+      case e @ End() => currentInputStream match {
+        case Some(sink) => {
+          sink.complete()
+          currentInputStream = None
+        }
+        case None => {
+          fatal("attempted to end non-existant input stream")
+        }
+      }
+    }
+  }
+  
+
+}

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -64,14 +64,14 @@ object StreamRequestBuilder extends InputMessageBuilder[HttpRequestHead] {
   }
 }
 
-class StreamServiceServerController[E <: GenEncoding.HeadEncoding](
+class StreamServiceServerController[E <: HeadEncoding](
   val downstream: ControllerDownstream[GenEncoding[StreamingHttpMessage, E]],
   builder: InputMessageBuilder[E#Input]
 )
 extends ControllerDownstream[GenEncoding[StreamHttpMessage, E]] 
+with DownstreamEventHandler[ControllerDownstream[GenEncoding[StreamingHttpMessage, E]]] 
 with ControllerUpstream[GenEncoding[StreamingHttpMessage, E]]
-with DownstreamEventHandler[ControllerDownstream[GenEncoding[StreamHttpMessage, E]]] 
-with UpstreamEventHandler[ControllerUpstream[GenEncoding[StreamingHttpMessage, E]]] {
+with UpstreamEventHandler[ControllerUpstream[GenEncoding[StreamHttpMessage, E]]] {
 
   downstream.setUpstream(this)
 
@@ -207,8 +207,8 @@ class StreamServiceHandlerGenerator(ctx: InitContext) extends HandlerGenerator[G
   
   def fullHandler = handler => {
     new PipelineHandler(
-      new Controller[GenEncoding[StreamHttpMessage, StreamHeader#ServerEncoding]](
-        new StreamServiceServerController[StreamHeader#ServerEncoding](
+      new Controller[GenEncoding[StreamHttpMessage, Encoding.Server[StreamHeader]]](
+        new StreamServiceServerController[Encoding.Server[StreamHeader]](
           new StreamingHttpServiceHandler(handler),
           StreamRequestBuilder
         ),

--- a/colossus/src/main/scala/colossus/protocols/http/StreamingHttp.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamingHttp.scala
@@ -179,7 +179,7 @@ trait StreamEncoder[T <: HttpMessageHead] {
 
 }
 
-class StreamHttpServerCodec extends Codec[StreamHttp#ServerEncoding] with StreamDecoder[HttpRequestHead] with StreamEncoder[HttpResponseHead] {
+class StreamHttpServerCodec extends Codec.Server[StreamHttp] with StreamDecoder[HttpRequestHead] with StreamEncoder[HttpResponseHead] {
 
   def parserProvider = HeadParserProvider.RequestHeadParserProvider
 
@@ -189,7 +189,7 @@ class StreamHttpServerCodec extends Codec[StreamHttp#ServerEncoding] with Stream
   }
 
 }
-class StreamHttpClientCodec extends Codec[StreamHttp#ClientEncoding] with StreamDecoder[HttpResponseHead] with StreamEncoder[HttpRequestHead] {
+class StreamHttpClientCodec extends Codec.Client[StreamHttp] with StreamDecoder[HttpResponseHead] with StreamEncoder[HttpRequestHead] {
 
   def parserProvider = HeadParserProvider.ResponseHeadParserProvider
 
@@ -238,7 +238,7 @@ trait StreamHandle[ E <: Encoding {type Output = StreamHttpMessage[H]}, H <: Htt
 
 }
 
-class ServerStreamController(downstream: StreamServerHandler) extends StreamController[StreamHttp#ServerEncoding, HttpResponseHead, HttpResponse](downstream) {
+class ServerStreamController(downstream: StreamServerHandler) extends StreamController[Encoding.Server[StreamHttp], HttpResponseHead, HttpResponse](downstream) {
 
   val codec = new StreamHttpServerCodec
 
@@ -253,7 +253,7 @@ extends UpstreamEventHandler[StreamHandle[E,H,T]] with HandlerTail with Downstre
 
 
 abstract class StreamServerHandler(serverContext: ServerContext) 
-extends StreamHandler[StreamHttp#ServerEncoding, HttpResponseHead, HttpResponse](serverContext.context) {
+extends StreamHandler[Encoding.Server[StreamHttp], HttpResponseHead, HttpResponse](serverContext.context) {
 
 
 }

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -44,7 +44,7 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
     }
   }
 
-  trait HttpMessage[H <: HttpMessageHead[H]] {
+  trait HttpMessage[H <: HttpMessageHead] {
     def head: H
     def body: HttpBody
   }
@@ -52,16 +52,26 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
   /**
    * common methods of both request and response heads
    */
-  trait HttpMessageHead[H <: HttpMessageHead[H]] { self: H =>
+  trait HttpMessageHead {
     def headers: HttpHeaders
     def version: HttpVersion
-
-    def withHeader(header: HttpHeader): H
-
-    def withHeader(key: String, value: String): H = withHeader(HttpHeader(key,value))
-
     def encode(out: core.DataOutBuffer)
   }
+
+  trait HeadOps[H <: HttpMessageHead] {
+    def withHeader(head: H, header: HttpHeader): H
+    def withHeader(head: H, key: String, value: String): H = withHeader(head, HttpHeader(key,value))
+  }
+
+  implicit object RequestHeadOps extends HeadOps[HttpRequestHead] {
+    def withHeader(head: HttpRequestHead, header: HttpHeader) = head.withHeader(header)
+  }
+
+  implicit object ResponseHeadOps extends HeadOps[HttpResponseHead] {
+    def withHeader(head: HttpResponseHead, header: HttpHeader) = head.withHeader(header)
+  }
+
+
 
   class ReturnCodeTagDecorator extends TagDecorator[Http] {
     override def tagsFor(request: HttpRequest, response: HttpResponse): TagMap = {

--- a/colossus/src/main/scala/colossus/service/Async.scala
+++ b/colossus/src/main/scala/colossus/service/Async.scala
@@ -12,7 +12,7 @@ import colossus.core.WorkerRef
  */
 trait Sender[C <: Protocol, M[_]] {
 
-  def send(input: C#Input): M[C#Output]
+  def send(input: C#Request): M[C#Response]
 
   def disconnect()
 

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -97,7 +97,7 @@ class LoadBalancingClient[P <: Protocol] (
   update(initialClients)
 
   //note, this type must be inner to avoid type erasure craziness
-  case class Send(request: P#Input, promise: Promise[P#Output])
+  case class Send(request: P#Request, promise: Promise[P#Response])
 
 
   private def regeneratePermutations() {
@@ -146,9 +146,9 @@ class LoadBalancingClient[P <: Protocol] (
   }
       
 
-  def send(request: P#Input): Callback[P#Output] = {
+  def send(request: P#Request): Callback[P#Response] = {
     val retryList =  permutations.next().take(maxTries)
-    def go(next: Sender[P, Callback], list: List[Sender[P, Callback]]): Callback[P#Output] = next.send(request).recoverWith{
+    def go(next: Sender[P, Callback], list: List[Sender[P, Callback]]): Callback[P#Response] = next.send(request).recoverWith{
       case err => list match {
         case head :: tail => go(head, tail)
         case Nil => Callback.failed(new SendFailedException(retryList.size, err))

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -13,26 +13,9 @@ import java.net.InetSocketAddress
 import metrics.MetricAddress
 import controller.{Encoding, Codec}
 
-trait Protocol {self =>
+trait Protocol {
   type Request
   type Response
-
-  //deprecated
-  type Input = Request
-  //deprecated
-  type Output = Response
-
-  trait ServerEncoding extends Encoding {
-    type Input = Request
-    type Output = Response
-  }
-
-  trait ClientEncoding extends Encoding {
-    type Input = Response
-    type Output = Request
-  }
-
-
 }
 
 object Protocol {

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -20,13 +20,13 @@ trait Protocol {
 
 object Protocol {
 
-  type PartialHandler[C <: Protocol] = PartialFunction[C#Input, Callback[C#Output]]
+  type PartialHandler[C <: Protocol] = PartialFunction[C#Request, Callback[C#Response]]
 
   type Receive = PartialFunction[Any, Unit]
 
-  type ErrorHandler[C <: Protocol] = PartialFunction[ProcessingFailure[C#Input], C#Output]
+  type ErrorHandler[C <: Protocol] = PartialFunction[ProcessingFailure[C#Request], C#Response]
 
-  type ParseErrorHandler[C <: Protocol] = PartialFunction[Throwable, C#Output]
+  type ParseErrorHandler[C <: Protocol] = PartialFunction[Throwable, C#Response]
 }
 
 import Protocol._
@@ -44,7 +44,7 @@ with DownstreamEventHandler[GenRequestHandler[C]] {
     requestHandler.setConnection(upstream.connection)
   }
 
-  protected def unhandled: PartialHandler[C] = PartialFunction[C#Input,Callback[C#Output]]{
+  protected def unhandled: PartialHandler[C] = PartialFunction[C#Request,Callback[C#Response]]{
     case other =>
       Callback.successful(processFailure(RecoverableError(other, new UnhandledRequestException(s"Unhandled Request $other"))))
   }
@@ -57,9 +57,9 @@ with DownstreamEventHandler[GenRequestHandler[C]] {
   private lazy val handler: PartialHandler[C] = requestHandler.handle orElse unhandled
   private lazy val errorHandler: ErrorHandler[C] = requestHandler.onError orElse unhandledError
 
-  protected def processRequest(i: C#Input): Callback[C#Output] = handler(i)
+  protected def processRequest(i: C#Request): Callback[C#Response] = handler(i)
 
-  protected def processFailure(error: ProcessingFailure[C#Input]): C#Output = errorHandler(error)
+  protected def processFailure(error: ProcessingFailure[C#Request]): C#Response = errorHandler(error)
 
 }
 
@@ -301,9 +301,9 @@ trait LiftedClient[C <: Protocol, M[_] ] extends Sender[C,M] {
   def client: Sender[C,M]
   implicit val async: Async[M]
 
-  def send(input: C#Input): M[C#Output] = client.send(input)
+  def send(input: C#Request): M[C#Response] = client.send(input)
 
-  protected def executeAndMap[T](i : C#Input)(f : C#Output => M[T]) = async.flatMap(send(i))(f)
+  protected def executeAndMap[T](i : C#Request)(f : C#Response => M[T]) = async.flatMap(send(i))(f)
 
   def disconnect() {
     client.disconnect()

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -112,14 +112,14 @@ trait ServiceUpstream[P <: Protocol] extends UpstreamEvents
  *
  */
 abstract class ServiceServer[P <: Protocol](val config: ServiceConfig)
-extends ControllerDownstream[P#ServerEncoding] 
+extends ControllerDownstream[Encoding.Server[P]] 
 with ServiceUpstream[P] 
-with UpstreamEventHandler[ControllerUpstream[P#ServerEncoding]] 
+with UpstreamEventHandler[ControllerUpstream[Encoding.Server[P]]] 
 {
   import ServiceServer._
 
-  type I = P#ServerEncoding#Input
-  type O = P#ServerEncoding#Output
+  type I = P#Request
+  type O = P#Response
 
   protected def serverContext: ServerContext
 


### PR DESCRIPTION
**Be Aware - This is the first of Several PR's**.  In an effort to keep my PR's small, I'll be breaking all of this work into several smaller PR's, so in this PR things are a little disorganized and lacking tests.  Notice that the base branch is not develop.  All PR's will go into `develop-streaming-http` and then we'll do one last big PR into develop.

There are a few significant changes in this PR:

### New Streaming Http Service API

Oh boy, it's back!!  The stream service API provides a way to write services that stream in/out requests/responses.  So instead of having the body of a message be a `HttpBody` (which is just a wrapper around a byte array), it is a `Source[BodyData]` which allows you to read in chunks of a message as they arrive (in a non-blocking manner).  

While this functionality has been around since Colossus 0.6.0, this new version works quite differently.  The `StreamService` API is built on top of the streaming http API, so we now have two layers of message processing:

On the input side:

1.  Raw Data is received on the connection and passed to the streaming http API.
2.  The data is decoded into a series of `HttpStream` objects, which can either be a `Head`, `Data` or `End`.  So for example, a http request with no body would just be a `Head` and `End`, but a request with a body would have one or more `Data` objects as well.
3.  These messages are passed to the `StreamService` layer, which will create and manage `StreamHttpMessage` objects.  Each message contains a `Source[Data]`.

On the output side:

1.  The `StreamService` layer receives output `StreamingHttpMessage` objects which contain a header and a `Source[Data]`.  These messages are buffered and written out one at a time.
2.  The head of the queue is "collapsed" into a `Source[HttpStream]`.  The message objects read from the source are pushed to the streaming http layer.
3.  When the collapsed source is complete, the message is dequeued and the process begins again with the next one.

So all in all, we now have 3 different Http API's:

1.  The plain old http service API, which is unchanged
2.  The streaming http API, which has an actor-like interface and sends/receives pieces of http messages
3.  The stream service API, which sits on top of the streaming API and presents a service-like interface for incoming/outgoing streams.

### Other Supporting Changes

1.  Renamed `StreamHttpMessage` to `HttpStream` to eliminate confusion with the new `StreamingHttpMessage` type.  Also renamed `BodyData` to just `Data`
2.  `HttpMessageHead` is no longer a recursive type.  This was initially done so we could have generic versions of the `withHeader` method that returned the correct type.  Now this functionality has been moved to a typeclass, which overall makes things a bit easier to follow and more straightforward
3.  Replacing the `Protocol#ServerEncoding` and `Protocol#ClientEncoding`type members with type constructors `Encoding.Server` and `Encoding.Client`.  I ran into a whole bunch of bizarre compile errors with the members, so switching to type constructors basically offers the same functionality