### PR TITLE
Pipe multiplexing

### DIFF
--- a/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
@@ -206,6 +206,42 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
       triggered mustBe true
     }
 
+    "fast-track pushes" in {
+      val p = new BufferedPipe[Int](5)
+      var sum = 0
+      p.pullWhile{
+        case PullResult.Item(i) => {
+          sum += i
+          if (i == 1) true else false
+        }
+        case _ => true
+      }
+      p.push(1)
+      sum mustBe 1
+      p.push(2)
+      sum mustBe 3
+      p.push(1)
+      sum mustBe 3
+    }
+
+    "drain the buffer when fast-tracking" in {
+      val p = new BufferedPipe[Int](10)
+      p.push(1)
+      p.push(2)
+      p.push(3)
+      var sum = 0
+      p.pullWhile{
+        case PullResult.Item(i) => {
+          sum += i
+          true
+        }
+        case _ => true
+      }
+      sum mustBe 6
+      p.push(1)
+      sum mustBe 7
+    }
+
   }
 
   "Sink" must {

--- a/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
@@ -18,10 +18,10 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
 
   implicit val duration = 1.second
 
-  "BufferedPipe (no buffering)" must {
+  "BufferedPipe" must {
 
     "push an item after pull request without buffering" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       var v = 0
       pipe.pull{x => v = x.get.get}
       pipe.push(2) mustBe Ok
@@ -29,7 +29,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
     }
 
     "push an item after pull request with another request during execution" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       var v = 0
       def pl() {
         pipe.pull{x => v = x.get.get;pl()}
@@ -40,16 +40,16 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
     }
 
     "pull an item immediately while triggering a push signal" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       pipe.push(1) match {
-        case PushResult.Full(sig) => sig.react{_ => pipe.push(1);()}
+        case PushResult.Filled(sig) => sig.notify{pipe.push(1);()}
         case _ => throw new Exception("wrong push result")
       }
       pipe.pull() mustBe PullResult.Item(1)
     }
 
     "reject pushes after pipe is closed" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       pipe.pull{x => pipe.complete()}
       pipe.push(2) must equal(Ok)
       pipe.push(3) mustBe Closed
@@ -57,37 +57,38 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
 
 
     "fail to push when pipe is full" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
+      pipe.push(1) mustBe an[Filled]
       pipe.push(1) mustBe an[Full]
     }
 
     "received Close if pipe is closed outside pull execution" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       pipe.complete()
       pipe.push(1) must equal(Closed)
     }
 
     "fail to push when pipe has been terminated" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       pipe.terminate(new Exception("sadfsadf"))
       pipe.push(1) mustBe an[Error]
     }
 
     "full trigger fired when pipe opens up" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       val f = pipe.push(1) match {
-        case Full(trig) => trig
+        case Filled(trig) => trig
         case other => fail(s"didn't get trigger, got $other")
       }
       var triggered = false
-      f.react{_ => triggered = true}
+      f.notify{triggered = true}
       triggered must equal(false)
       pipe.pull{_ => ()}
       triggered must equal(true)
     }
 
     "immediately fail pulls when terminated" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       pipe.terminate(new Exception("asdf"))
       var pulled = false
       pipe.pull{r => pulled = true; r mustBe an[Failure[_]]}
@@ -95,7 +96,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
     }
 
     "fold" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       var executed = false
       pipe.fold(0){case (a, b) => a + b}.execute{
         case Success(6) => {executed = true}
@@ -115,7 +116,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
     }
 
     "foldWhile folds before terminal condition is met" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       var executed = false
       pipe.foldWhile(0){(a, b) => a + b}{_ != 10}.execute{
         case Success(x) if x < 10 => {executed = true}
@@ -135,7 +136,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
     }
 
     "foldWhile stops folding after terminal condition" in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       var executed = false
       pipe.foldWhile(0){(a, b) => a + b}{_ != 10}.execute{
         case Success(10) => {executed = true}
@@ -156,16 +157,19 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
     }
 
     "handle multiple push triggers"  in {
-      val pipe = new BufferedPipe[Int](0)
+      val pipe = new BufferedPipe[Int](1)
       def tryPush(i: Int): Unit = pipe.push(i) match {
         case PushResult.Full(t) => t.notify{ println(s"triggered $i");pipe.push(i) match { 
           case PushResult.Ok => ()
+          case PushResult.Filled(_) => ()
           case other => throw new Exception(s"wrong notify result $other")
         }}
         case other => throw new Exception(s"wrong pushresult $other")
       }
+      pipe.push(0)//fill the pipe
       tryPush(1)
       tryPush(2)
+      pipe.pull() mustBe PullResult.Item(0)
       pipe.pull() mustBe PullResult.Item(1)
       pipe.pull() mustBe PullResult.Item(2)
     }
@@ -282,7 +286,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
   "Pipe.fuse" must {
     "weld two pipes" in {
       import PipeOps._
-      val p1 = new BufferedPipe[Int](0)
+      val p1 = new BufferedPipe[Int](1)
       val p2 = new BufferedPipe[String](5)
       val p3: Pipe[Int, String] = p1 map {_.toString} weld p2
       p3.push(1) mustBe PushResult.Ok
@@ -295,7 +299,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
   "Source.into" must {
     "push items into sink"  in {
       val x = Source.fromIterator(Array(2, 4).toIterator)
-      val y = new BufferedPipe[Int](0)
+      val y = new BufferedPipe[Int](1)
       x into y
       y.pull mustBe PullResult.Item(2)
       y.pull mustBe PullResult.Item(4)

--- a/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
@@ -217,13 +217,35 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
     }
   }
 
+  "Source" must {
+    "map" in {
+      import PipeOps._
+      val s = Source.fromIterator(Array(1, 2).toIterator)
+      val t = s.map{_.toString}
+      t.pull() mustBe PullResult.Item("1")
+    }
+  }
+
+  "Pipe" must {
+    "map" in {
+      import PipeOps._
+      val p = new BufferedPipe[Int](5)
+      val q = p.map{_.toString}
+      q.push(4)
+      q.pull() mustBe PullResult.Item("4")
+    }
+  }
+
   "Pipe.fuse" must {
     "weld two pipes" in {
+      import PipeOps._
       val p1 = new BufferedPipe[Int](0)
-      val p2 = new BufferedPipe[Int](0)
-      val p3 = p1 weld p2
-      p3.push(1)
-      p3.pull() mustBe PullResult.Item(1)
+      val p2 = new BufferedPipe[String](5)
+      val p3: Pipe[Int, String] = p1 map {_.toString} weld p2
+      p3.push(1) mustBe PushResult.Ok
+      p3.push(2) mustBe PushResult.Ok
+      p3.pull() mustBe PullResult.Item("1")
+      p3.pull() mustBe PullResult.Item("2")
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
@@ -255,6 +255,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
 
   "Source" must {
     "map" in {
+      import Types._
       import PipeOps._
       val s = Source.fromIterator(Array(1, 2).toIterator)
       val t = s.map{_.toString}

--- a/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/PipeSpec.scala
@@ -386,7 +386,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
     "start a new stream" in {
       val s = new BufferedPipe[FooFrame](5)
       
-      val dem: Source[Substream[Int, FooFrame]] = Multiplexing.demultiplex(s)
+      val dem: Source[SubSource[Int, FooFrame]] = Multiplexing.demultiplex(s)
 
       s.push(FooFrame(1, Head, 1))
 
@@ -405,7 +405,7 @@ class PipeSpec extends ColossusSpec with MustMatchers with CallbackMatchers {
       import PipeOps._
       val s = new BufferedPipe[FooFrame](5)
       
-      val dem: Source[Substream[Int, FooFrame]] = Multiplexing.demultiplex(s)
+      val dem: Source[SubSource[Int, FooFrame]] = Multiplexing.demultiplex(s)
       var results = Map[Int, Int]()
       dem.map{sub => sub.stream.fold(0){case (build, next) => next + build.value}.execute{ 
         case Success(v) => results += (sub.id -> v)

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -68,9 +68,21 @@ trait Sink[T] extends Transport {
     }
   }
 
+}
 
-    
-
+object Sink {
+  def blackHole[T]: Sink[T] = new Sink[T] {
+    private var state: TransportState = TransportState.Open
+    def push(item: T): PushResult = PushResult.Ok
+    def inputState = state
+    def complete() = {
+      state = TransportState.Closed
+      Success(())
+    }
+    def terminate(reason: Throwable) {
+      state = TransportState.Terminated(reason)
+    }
+  }
 }
 
 sealed trait PullResult[+T]

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -73,7 +73,11 @@ trait Sink[T] extends Transport {
 object Sink {
   def blackHole[T]: Sink[T] = new Sink[T] {
     private var state: TransportState = TransportState.Open
-    def push(item: T): PushResult = PushResult.Ok
+    def push(item: T): PushResult = state match {
+      case TransportState.Open => PushResult.Ok
+      case TransportState.Closed => PushResult.Closed
+      case TransportState.Terminated(err) => PushResult.Error(err)
+    }
     def inputState = state
     def complete() = {
       state = TransportState.Closed

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -388,30 +388,23 @@ object Signal {
  */
 class Trigger[T] extends Signal[T]{
 
-  private var callbacks = new java.util.LinkedList[Either[T => Unit, () => Unit]]
+  private var callbacks = new java.util.LinkedList[() => Unit]
 
   def empty = callbacks.size == 0
 
-  def react(cb: T => Unit) {
-    callbacks.add(Left(cb))
-  }
-
   def notify(cb: => Unit) {
-    callbacks.add(Right(() => cb))
+    callbacks.add(() => cb)
   }
 
-  def trigger(forNotify: => Unit, forReact: => T): Boolean = {
+  def trigger(): Boolean = {
     if (callbacks.size == 0) false else {
-      callbacks.remove() match {
-        case Left(reactor) => reactor(forReact)
-        case Right(notifier) => {forNotify; notifier()}
-      }
+      callbacks.remove()() 
       true
     }
   }
 
-  def triggerAll(forNotify: => Unit, forReact: => T) {
-    while (trigger(forNotify, forReact)) {}
+  def triggerAll() {
+    while (trigger()) {}
   }
 
   def clear() {
@@ -421,13 +414,6 @@ class Trigger[T] extends Signal[T]{
 }
 
 class BlankTrigger extends Trigger[Unit] {
-  def trigger(): Boolean = {
-    trigger(() , ())
-  }
-
-  def triggerAll() {
-    while (trigger()) {}
-  }
     
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -153,7 +153,7 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
   }
 
   def drain(source: Source[HttpStream[OutputHead]]) {
-    def handlePull(res : PullResult[HttpStream[OutputHead]]) : Boolean = res match {
+    source.pullWhile {
       case PullResult.Item(item) => {
         upstream.push(item)(_ => ())
         true
@@ -171,12 +171,7 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
         fatal(s"Error writing stream: $reason")
         false
       }
-      case PullResult.Empty(signal) => {
-        signal.react(handlePull)
-        false
-      }
     }
-    while (handlePull(source.pull())) {}
   }
 
   

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -167,7 +167,7 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
         }
         false
       }
-      case PullResult.Terminated(reason) => {
+      case PullResult.Error(reason) => {
         fatal(s"Error writing stream: $reason")
         false
       }

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -99,7 +99,7 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
         case Some(sink) => sink.push(b) match {
           case PushResult.Filled(signal) => {
             upstream.pauseReads()
-            signal.react{
+            signal.react{_ =>
               upstream.resumeReads()
             }
           }

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -99,7 +99,8 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
         case Some(sink) => sink.push(b) match {
           case PushResult.Filled(signal) => {
             upstream.pauseReads()
-            signal.react{_ =>
+            signal.notify{
+              sink.push(b)
               upstream.resumeReads()
             }
           }

--- a/colossus/src/main/scala/colossus/streaming/PipeMultiplexer.scala
+++ b/colossus/src/main/scala/colossus/streaming/PipeMultiplexer.scala
@@ -1,0 +1,70 @@
+package colossus
+package streaming
+
+import controller._
+
+trait MultiStream[K, T] extends Stream[T] {
+  def streamId(t: T): K
+}
+
+case class Substream[K,T](id: K, stream: Source[T])
+
+object Multiplexing {
+
+  def demultiplex[K,T](base: Source[T])(implicit ms: MultiStream[K,T]): Source[Substream[K,T]] = {
+    var active = Map[K, Pipe[T,T]]()
+    def fatal(reason: String): Boolean = {
+      base.terminate(new PipeStateException(reason))
+      active.foreach{case (_, sink) => sink.terminate(new PipeStateException(reason))}
+      false
+    }
+    val sources = new BufferedPipe[Substream[K,T]](10)
+    def doPull(): Unit = base.pullWhile {
+      case PullResult.Item(item) => {
+        println(s"GOT A $item")
+        val id = ms.streamId(item)
+        def tryPush(close: Boolean): Boolean = if (active contains id) {
+          active(id).push(item) match {
+            case PushResult.Full(signal) => {
+              signal.notify{
+                if (tryPush(close)) {
+                  doPull()
+                }
+              }
+              false
+            }
+            case PushResult.Closed => fatal(s"sub-pipe $id unexpectedly closed")
+            case PushResult.Error(error) => fatal(s"sub-pipe error: $error")
+            case other => {
+              if (close) {
+                active(id).complete()
+                active = active - id
+              }
+              true
+            }
+          }
+        } else {
+          fatal(s"tried to push to non-existant stream $id")
+        }
+        ms.component(item) match {
+          case StreamComponent.Head => if (active contains id) {
+            fatal(s"duplicate id $id")
+          } else {
+            val n = new BufferedPipe[T](10)
+            n.push(item)
+            //TODO sources backpressure
+            active = active + (id -> n)
+            sources.push(Substream(id, n))
+            true
+          }
+          case StreamComponent.Body => tryPush(false)
+          case StreamComponent.Tail => tryPush(true)
+        }
+      }
+      case PullResult.Closed => fatal(s"Source Pipe closed unexpectedly")
+      case PullResult.Error(error) => fatal(s"Source terminated with error: $error")
+    }
+    doPull()
+    sources
+  }
+}

--- a/colossus/src/main/scala/colossus/streaming/Stream.scala
+++ b/colossus/src/main/scala/colossus/streaming/Stream.scala
@@ -1,0 +1,18 @@
+package colossus
+package streaming
+
+
+sealed trait StreamComponent
+object StreamComponent {
+  case object Head extends StreamComponent
+  case object Body extends StreamComponent
+  case object Tail extends StreamComponent
+}
+
+trait Stream[T] {
+
+  def component(t: T) : StreamComponent
+
+}
+
+


### PR DESCRIPTION
This PR has some substantial changes and improvements to pipes, as well as a first run of multiplexing support for pipes, a crucial prerequisite for http/2 support.

_Notice that, as with my other PR's, the base branch is `develop-streaming-http`, so as a whole this is all still a work in progress._

### What is Multiplexing

In short, it's merging several independent sub-streams into a single multiplexed stream.  Demultiplexing is the process of taking a multiplexed stream and splitting it into its constituent substreams.  

In other words, a multiplexing pipe has the type `Pipe[Source[T], T]` and a demultiplexing pipe has the type `Pipe[T, Source[T]]`.

In order for demultiplexing to work, every message in the multiplexed stream must have a stream id that the demultiplexer can use to forward the message to the correct sub-stream.  Furthermore, it needs to know which messages start and end a sub-stream.  All of these are handled by the `MultiStream[K,T]` typeclass, which must have an instance in scope for messages of type `T` with stream ids of type `K`.

### Changes to Pipes

oh boy here we go:

As a quick recap, the whole point of a `Pipe[I,O]` is to provide a buffer that can mediate back-pressure.  Unlike a regular queue, pipes provide the ability to gracefully block overflow attempts and can provide callback signals to both producers waiting for the buffer to empty and consumers waiting for the buffer to fill.

#### Pipe.pull now returns an ADT

Previously this method required a function `Try[Option[T]] => Unit` and would either immediately call this function if it had a buffered item, or would hold onto it until it did.  This had two major problems:

1.  Repeatedly pulling from a pipe was very inefficient.  Basically you'd have to call `pull` again inside the callback function, resulting in some nasty recursion.
2.  It was impossible to "attempt" to pull.  In some cases you want to try pulling an item out of a pipe, but if nothing is there you _don't_ want to give the pipe a callback that is eventually called.  Sometimes you just want nothing and move on.

It also made testing a lot weirder.  So now `pull()` takes no parameters and returns a `PullResult` ADT.  

#### Pipe Fast-Tracking

So as I mentioned you can pull multiple items from a pipe more efficiently simply by looping until something besides `Item` is returned.

However there is an even faster way to do this.  The consumer can give the pipe a function of type `NEPullResult[T] => Boolean`  (`NEPullResult` is a subset of `PullResult` without the `Empty` case) and the pipe will simply hold onto this function and completely bypass buffering or backpressure logic until the function returns `false` (or until the pipe is closed or terminated).

This is now used in the `Pipe.pullWhile` method.  

#### Signals can either notify or react

**This was removed in a subsequent commit**

~~A `Signal[T]` is the trait returned to either a producer attempting to push to a full pipe, or to a consumer trying to pull from an empty pipe.  Previously you could "listen" on a signal with function of type `() => Unit` that would be called when the pipe is ready for action.~~

~~Now signals also support listening with a callback of type `T => Unit`.  This is not used in signals on the producer side, but on the consumer side this is used to signal a consumer immediately with a `NEPullResult[T]`.  This is primarily needed to be able to support pipes with 0-sized buffers.~~

#### Signals now support multiple listeners

This was needed for multiplexing, particularly so a pipe can have multiple producers, but this will also allow them to support multiple consumers.  This effectively makes pipes more like simple pub-sub channels.

Previously a signal would simply hold onto a single callback, but now it contains a queue.  So, for example, if multiple producers are trying to push to a single pipe but the pipe is full, each producer can add a listener to the signal.  When the pipe finally drains and can accept more items, each listener is signaled one-by-one until the pipe is full again.

This also then means that whereas before a new `Signal` was created each time the pipe filled, a single persistent signal is used.  This way, if the pipe fills up again while the signals are being triggered such that some listeners are still waiting, we can hold onto them and be ready to signal them once the pipe drains again.

#### New combinator methods

Lots of fun stuff here.  In particular, I'm now using a `Functor` typeclass to correctly implement `map` for pipes and sources.  `Pipe` inherits from `Source`, but we want `source.map` to return a source and `pipe.map` to return a pipe.  There are other ways to accomplish that (like how scala collections work), but the typeclass approach seems the simplest.

It is a bit weird that this one function is a typeclass and the others are methods, so this might need some more work.

#### Removed low/high watermarks

This was an interesting idea, but ultimately I realized it's not actually going to work in practice very well.  The idea behind it was to give a producer a heads-up that the pipe was filling up, but not entirely full.  This way the producer could initiate some kind async back-off but not get immediately rejected in case it had a bunch of items it was trying to push at once.

This won't work for a few reasons, but mainly because the producer can never know for sure that they won't try to overflow the pipe.  So even with the watermarks, we still need all the logic to handle an overflow attempt...which in the end isn't actually a whole lot of logic

### What Still Needs to be Done

#### Code organization

Right after this PR, I'll will be opening another that will move all the pipe code into the new `streaming` package and correctly breaking things up into separate files.  

#### Test Coverage

I wrote a bunch of tests but I'm assuming coverage is pretty low right now.  Will continue to work on that as things solidify more.  

#### Feature re-evaluation

**This was addressed in a subsquent commit.  Pipes must have >0 buffer size now**

~~Currently pipes are allowed to have a buffer size of 0, meaning a producer can only push if a consumer is waiting to pull or fast-tracking.  In some cases there is some weird logic that could be solved by having a minimum buffer size of 1.  I initially had some performance concerns around this, but the new pull fast-tracking probably eliminates this.~~

#### Integration with Http2

Stream multiplexing is a central feature of Http2, and while everything here definitely gets us close to achieving that, I'm fairly certain more changes will be needed to actually integrate all this logic into a functional Http2 API.  In particular, Http2 has a bunch of flow-control and prioritization features that we will need to somehow plug-in to multiplexing.