### PR TITLE
Streaming cleanup, part 2

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
@@ -15,6 +15,7 @@ object StreamServiceExample {
   def start(port: Int)(implicit sys: IOSystem) = {
     val bodydata = Data(DataBlock("Hello World!"))
     val headers = HttpHeaders(HttpHeader("Content-Length", bodydata.data.length.toString))
+    val body = HttpBody("Hello World!")
 
     val config = ServiceConfig.Default.copy(
       requestMetrics = false
@@ -24,10 +25,7 @@ object StreamServiceExample {
 
       def handle = {
         case StreamingHttpRequest(head, source) if (head.url == "/plaintext") => source.collected.map{_ =>
-          StreamingHttpResponse(
-            HttpResponseHead(head.version, HttpCodes.OK, None, None, None, headers),
-            Source.one(bodydata)
-          )
+          StreamingHttpResponse(HttpResponse(HttpResponseHead(head.version, HttpCodes.OK, None, None, None, headers), body))
         }
 
         case StreamingHttpRequest(head, source) if (head.url == "/chunked") => source.collected.map{_ => 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/StreamServiceSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/StreamServiceSpec.scala
@@ -46,8 +46,10 @@ class StreamServiceSpec extends ColossusSpec with MockFactory{
     "flatten and push a response" in {
       val (ctrlr, stub) = create()
       val response = HttpResponse.ok("helllo")
+      val s : GenEncoding[StreamingHttpMessage,Encoding.Server[StreamHeader]]#Output = StreamingHttpResponse(response)
       ctrlr.connected()
-      ctrlr.push(StreamingHttpResponse(response))(_ => ())
+      //you can thank Scala 2.10 for this insanity
+      ctrlr.asInstanceOf[ControllerUpstream[GenEncoding[StreamingHttpMessage,Encoding.Server[StreamHeader]]]].push(s.asInstanceOf[GenEncoding[StreamingHttpMessage,Encoding.Server[StreamHeader]]#Output])(_ => ())
       expectPush(stub, Head(response.head))
       expectPush(stub, Data(response.body.asDataBlock))
       expectPush(stub, End)

--- a/colossus-tests/src/test/scala/colossus/protocols/http/StreamServiceSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/StreamServiceSpec.scala
@@ -1,0 +1,58 @@
+package colossus
+package protocols.http
+
+import core._
+import controller._
+import testkit._
+import stream._
+import streaming._
+import GenEncoding._
+
+import org.scalamock.scalatest.MockFactory
+
+class StreamServiceSpec extends ColossusSpec with MockFactory{
+
+  "Streaming Http Response" must {
+    "build from regular response" in {
+      val r = HttpResponse.ok("Hello")
+      val s = StreamingHttpResponse(r)
+      val data = s.collapse
+      data.pull() mustBe PullResult.Item(Head(r.head))
+      data.pull() mustBe PullResult.Item(Data(r.body.asDataBlock))
+      data.pull() mustBe PullResult.Item(End)
+    }
+  }
+
+  type Con = StreamServiceController[Encoding.Server[StreamHeader]]
+
+  def create(): (Con, ControllerUpstream[Encoding.Server[StreamHttp]])  = {
+    val controllerstub = stub[ControllerUpstream[Encoding.Server[StreamHttp]]]
+    val connectionstub = stub[ConnectionManager]
+    (connectionstub.isConnected _).when().returns(true)
+    (controllerstub.connection _).when().returns(connectionstub)
+    (controllerstub.pushFrom _).when(*, *, *).returns(true)
+    (controllerstub.canPush _).when().returns(true)
+    
+    val handler = new StreamServiceController[Encoding.Server[StreamHeader]](stub[ControllerDownstream[Encoding.Server[StreamingHttp]]], StreamRequestBuilder)
+    handler.setUpstream(controllerstub)
+    (handler, controllerstub)
+  }
+
+  def expectPush(controller: ControllerUpstream[Encoding.Server[StreamHttp]], message: HttpStream[HttpResponseHead]) {
+      (controller.pushFrom _ ).verify(message, *, *)
+  }
+
+  "StreamServiceController" must {
+    "flatten and push a response" in {
+      val (ctrlr, stub) = create()
+      val response = HttpResponse.ok("helllo")
+      ctrlr.connected()
+      ctrlr.push(StreamingHttpResponse(response))(_ => ())
+      expectPush(stub, Head(response.head))
+      expectPush(stub, Data(response.body.asDataBlock))
+      expectPush(stub, End)
+    }
+  }
+
+}
+      

--- a/colossus-tests/src/test/scala/colossus/streaming/CircuitBreakerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/CircuitBreakerSpec.scala
@@ -1,0 +1,51 @@
+package colossus.streaming
+
+import colossus.testkit._
+
+class CircuitBreakerSpec extends ColossusSpec {
+
+  "CircuitBreaker" must {
+    "return no-action results when no pipe" in {
+      val p = new PipeCircuitBreaker[Int, Int]
+      p.push(3) mustBe a[PushResult.Full]
+      p.pull mustBe a[PullResult.Empty]
+    }
+    "trigger both push and pull signals when set" in {
+      val p = new PipeCircuitBreaker[Int, Int]
+      var pushsignaled = false
+      var pullsignaled = true
+      p.push(1) match {
+        case PushResult.Full(signal) => signal.notify{pushsignaled = true}
+        case _ => throw new Exception("WRONG PUSH RESULT")
+      }
+      p.pull() match {
+        case PullResult.Empty(signal) => signal.notify{pullsignaled = true}
+        case _ => throw new Exception("WRONG PULL RESULT")
+      }
+      p.set(new BufferedPipe[Int](3))
+      pushsignaled mustBe true
+      pullsignaled mustBe true
+    }
+
+    "close unsets" in {
+      val p = new PipeCircuitBreaker[Int, Int]
+      val b = new BufferedPipe[Int](1)
+      p.set(b)
+      p.complete()
+      p.inputState mustBe TransportState.Open
+      b.inputState mustBe TransportState.Closed
+      p.push(1) mustBe a [PushResult.Full]
+    }
+
+    "terminate unsets" in {
+      val p = new PipeCircuitBreaker[Int, Int]
+      val b = new BufferedPipe[Int](1)
+      p.set(b)
+      p.terminate(new Exception("WAT"))
+      p.inputState mustBe TransportState.Open
+      b.inputState mustBe a[TransportState.Terminated]
+      p.push(1) mustBe a [PushResult.Full]
+    }
+  }
+}
+

--- a/colossus-tests/src/test/scala/colossus/streaming/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/PipeSpec.scala
@@ -217,6 +217,24 @@ class PipeSpec extends ColossusSpec {
     }
 
 
+    "pullWhile triggers pushes on emptying a full buffer" in {
+      val p = new BufferedPipe[Int](2)
+      p.push(1) mustBe PushResult.Ok
+      p.push(2) mustBe PushResult.Ok
+      p.push(3) match {
+        case PushResult.Full(signal) => signal.notify{ p.push(4) }
+        case _ => throw new Exception("WRONG")
+      }
+      var sum = 0
+      p.pullWhile {
+        case PullResult.Item(i) => {
+          sum += i
+          true
+        }
+        case _ => false
+      }
+      sum mustBe 7
+    }
 
     "drain the buffer when fast-tracking" in {
       val p = new BufferedPipe[Int](10)

--- a/colossus-tests/src/test/scala/colossus/streaming/SourceSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/SourceSpec.scala
@@ -175,6 +175,7 @@ class SourceSpec extends ColossusSpec {
 
     "closing the base pipe closes the flattened pipe" taggedAs(org.scalatest.Tag("test")) in {
       val (a,b,pipe,flat) = setup
+      println("closing now")
       pipe.complete()
       flat.pull() mustBe PullResult.Item(1)
       flat.pull() mustBe PullResult.Item(2)

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -485,14 +485,3 @@ object DateHeader {
 
 }
 
-class ContentLengthHeader(length: Int) extends HttpHeader {
-  def key = "Content-Length"
-  def value = length.toString
-
-  def encode(out: DataOutBuffer) {
-    HttpHeader.encodeContentLength(out, length)
-    out write HttpParse.NEWLINE_ARRAY
-  }
-}
-
-

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -485,4 +485,14 @@ object DateHeader {
 
 }
 
+class ContentLengthHeader(length: Int) extends HttpHeader {
+  def key = "Content-Length"
+  def value = length.toString
+
+  def encode(out: DataOutBuffer) {
+    HttpHeader.encodeContentLength(out, length)
+    out write HttpParse.NEWLINE_ARRAY
+  }
+}
+
 

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -70,7 +70,7 @@ object StreamRequestBuilder extends InputMessageBuilder[HttpRequestHead] {
   }
 }
 
-class StreamServiceServerController[E <: HeadEncoding](
+class StreamServiceController[E <: HeadEncoding](
   val downstream: ControllerDownstream[GenEncoding[StreamingHttpMessage, E]],
   builder: InputMessageBuilder[E#Input]
 )
@@ -96,7 +96,7 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
   //setup routing the pipe into upstream
   pipe.pullWhile {
     case PullResult.Item(item) => {
-      upstream.push(item)(_ => ())
+      upstream.pushFrom(item, 0, _ => ())
       true
     }
     case other => {
@@ -217,7 +217,7 @@ class StreamServiceHandlerGenerator(ctx: InitContext) extends HandlerGenerator[G
   def fullHandler = handler => {
     new PipelineHandler(
       new Controller[GenEncoding[HttpStream, Encoding.Server[StreamHeader]]](
-        new StreamServiceServerController[Encoding.Server[StreamHeader]](
+        new StreamServiceController[Encoding.Server[StreamHeader]](
           new StreamingHttpServiceHandler(handler),
           StreamRequestBuilder
         ),

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -25,7 +25,7 @@ case class StreamingHttpRequest(head: HttpRequestHead, body: Source[Data]) exten
 case class StreamingHttpResponse(head: HttpResponseHead, body: Source[Data]) extends StreamingHttpMessage[HttpResponseHead]
 object StreamingHttpResponse {
   def apply(response: HttpResponse) = new StreamingHttpMessage[HttpResponseHead] {
-    def head = response.head//.withHeader(new ContentLengthHeader(response.body.size))
+    def head = response.head
     def body = Source.one(Data(response.body.asDataBlock))
 
     override def collapse = Source.fromArray(Array(Head(head), Data(response.body.asDataBlock), End))

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -16,11 +16,21 @@ trait StreamingHttpMessage[T <: HttpMessageHead] {
   def head: T
   def body: Source[Data]
 
-  def collapse: Source[HttpStream[T]] = Source.one[HttpStream[T]](Head(head)) ++ body
+  def collapse: Source[HttpStream[T]] = Source.one[HttpStream[T]](Head(head)) ++ body ++ Source.one[HttpStream[T]](End)
 }
 
 case class StreamingHttpRequest(head: HttpRequestHead, body: Source[Data]) extends StreamingHttpMessage[HttpRequestHead]
+
+
 case class StreamingHttpResponse(head: HttpResponseHead, body: Source[Data]) extends StreamingHttpMessage[HttpResponseHead]
+object StreamingHttpResponse {
+  def apply(response: HttpResponse) = new StreamingHttpMessage[HttpResponseHead] {
+    def head = response.head//.withHeader(new ContentLengthHeader(response.body.size))
+    def body = Source.one(Data(response.body.asDataBlock))
+
+    override def collapse = Source.fromArray(Array(Head(head), Data(response.body.asDataBlock), End))
+  }
+}
 
 
 trait StreamingHttp extends Protocol {
@@ -76,7 +86,33 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
 
   private var currentInputStream: Option[Sink[Data]] = None
 
-  private val outputStreams = new MessageQueue[Source[HttpStream[OutputHead]]](100)
+  def outputStream: Pipe[Source[HttpStream[OutputHead]], HttpStream[OutputHead]] = {
+    val p = new BufferedPipe[Source[HttpStream[OutputHead]]](100)
+    new Channel(p, Source.flatten(p))
+  }
+
+  val pipe = new PipeCircuitBreaker[Source[HttpStream[OutputHead]], HttpStream[OutputHead]]
+  
+  //setup routing the pipe into upstream
+  pipe.pullWhile {
+    case PullResult.Item(item) => {
+      upstream.push(item)(_ => ())
+      true
+    }
+    case other => {
+      fatal(s"Unexpected streaming item $other")
+      false
+    }
+  }
+
+  override def onConnected() {
+    pipe.set(outputStream)
+  }
+
+  override def onConnectionTerminated(reason: DisconnectCause) {
+    pipe.unset().foreach{_.terminate(new ConnectionLostException("Closed"))}
+  }
+
 
   protected def fatal(message: String) {
     println(s"FATAL ERROR: $message")
@@ -141,42 +177,16 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
   def writesEnabled: Boolean = upstream.writesEnabled
 
   // Members declared in colossus.controller.Writer
-  def canPush: Boolean = !outputStreams.isFull
+  def canPush: Boolean = true
 
   def pushFrom(item: GenEncoding[StreamingHttpMessage,E]#Output,createdMillis: Long, postWrite: QueuedItem.PostWrite): Boolean = {
-    if (canPush) {
-      val source = item.collapse
-      outputStreams.enqueue(source, postWrite, createdMillis)
-      if (outputStreams.size == 1) {
-        drain(source)
-      }
-      true
-    } else false
-  }
-
-  def drain(source: Source[HttpStream[OutputHead]]) {
-    source.pullWhile {
-      case PullResult.Item(item) => {
-        upstream.push(item)(_ => ())
-        true
-      }
-      case PullResult.Closed => {
-        upstream.push(End)(_ => ())
-        val done = outputStreams.dequeue
-        done.postWrite(OutputResult.Success)
-        if (!outputStreams.isEmpty) {
-          drain(outputStreams.head.item)
-        }
-        false
-      }
-      case PullResult.Error(reason) => {
-        fatal(s"Error writing stream: $reason")
-        false
-      }
+    val source = item.collapse
+    val res = pipe push source 
+    res match {
+      case PushResult.Ok => true
+      case _ => false
     }
   }
-
-  
 
 }
 

--- a/colossus/src/main/scala/colossus/streaming/CircuitBreaker.scala
+++ b/colossus/src/main/scala/colossus/streaming/CircuitBreaker.scala
@@ -1,8 +1,8 @@
 package colossus.streaming
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
-trait CircuitBreaker[T] {
+trait CircuitBreaker[T <: Transport] {
 
   protected var current: Option[T] = None
 
@@ -22,7 +22,7 @@ trait CircuitBreaker[T] {
   }
 
   def terminate(err: Throwable) {
-    //??? wat do here
+    unset().foreach{_.terminate(err)}
   }
 
 }
@@ -53,8 +53,7 @@ trait SinkCircuitBreaker[A, T <: Sink[A]] extends Sink[A] { self: CircuitBreaker
   }
 
   def complete(): Try[Unit] = {
-    //uhhhh
-    ???
+    unset.map{_.complete()}.getOrElse(Success(()))
   }
 
 }

--- a/colossus/src/main/scala/colossus/streaming/CircuitBreaker.scala
+++ b/colossus/src/main/scala/colossus/streaming/CircuitBreaker.scala
@@ -1,0 +1,64 @@
+package colossus.streaming
+
+import scala.util.Try
+
+trait CircuitBreaker[T] {
+
+  protected var current: Option[T] = None
+
+  protected var trigger = new Trigger()
+
+  def set(item: T): Option[T] = {
+    val t = current
+    current = Some(item)
+    trigger.triggerAll()
+    t
+  }
+
+  def unset(): Option[T] = {
+    val t = current
+    current = None
+    t
+  }
+
+  def terminate(err: Throwable) {
+    //??? wat do here
+  }
+
+}
+
+trait SourceCircuitBreaker[A, T <: Source[A]] extends  Source[A] { self: CircuitBreaker[T] => 
+
+  def pull(): PullResult[A] = current match {
+    case Some(c) => c.pull
+    case None => PullResult.Empty(trigger)
+  }
+
+  def peek: PullResult[Unit] = current match {
+    case Some(c) => c.peek
+    case None => PullResult.Empty(trigger)
+  }
+
+  def outputState = TransportState.Open
+
+}
+
+trait SinkCircuitBreaker[A, T <: Sink[A]] extends Sink[A] { self: CircuitBreaker[T] => 
+
+  def inputState = TransportState.Open
+
+  def push(item: A): PushResult = current match {
+    case Some(c) => c.push(item)
+    case None => PushResult.Full(trigger)
+  }
+
+  def complete(): Try[Unit] = {
+    //uhhhh
+    ???
+  }
+
+}
+
+class PipeCircuitBreaker[I, O] extends CircuitBreaker[Pipe[I,O]] with SourceCircuitBreaker[O, Pipe[I,O]] with SinkCircuitBreaker[I, Pipe[I,O]]
+
+

--- a/colossus/src/main/scala/colossus/streaming/Pipe.scala
+++ b/colossus/src/main/scala/colossus/streaming/Pipe.scala
@@ -203,6 +203,7 @@ class BufferedPipe[T](size: Int) extends Pipe[T, T] {
         if (!continue) {
           state = oldstate
         }
+        while (!bufferFull && pushTrigger.trigger()) {}
       }
     }
   }

--- a/colossus/src/main/scala/colossus/streaming/Source.scala
+++ b/colossus/src/main/scala/colossus/streaming/Source.scala
@@ -209,16 +209,14 @@ object Source {
     }
 
     override def pullWhile(f: NEPullResult[T] => Boolean) {
-      stop match {  
-        case Some(err) => f(PullResult.Error(err))
-        case None => {
-          var continue = true
-          while ( iterator.hasNext && continue ){
-            continue = f(PullResult.Item(iterator.next))
-          }
-          if (continue) {
-            f(PullResult.Closed)
-          }
+      var continue = true
+      while ( stop == None && iterator.hasNext && continue ){
+        continue = f(PullResult.Item(iterator.next))
+      }
+      if (continue) {
+        stop match {
+          case Some(err) => f(PullResult.Error(err))
+          case None =>  f(PullResult.Closed)
         }
       }
     }

--- a/colossus/src/main/scala/colossus/streaming/Source.scala
+++ b/colossus/src/main/scala/colossus/streaming/Source.scala
@@ -140,12 +140,41 @@ trait Source[+T] extends Transport {
 
 object Source {
 
-  def one[T](data: T): Source[T] = {
-    val p = new BufferedPipe[T](1)
-    p.push(data)
-    p.complete()
-    p
+  def one[T](data: T) = new Source[T] {
+    var item: PullResult[T] = PullResult.Item(data)
+    def pull(): PullResult[T] = {
+      val t = item
+      item match {
+        case PullResult.Error(_) => {}
+        case _ => item = PullResult.Closed
+      }
+      t
+    }
+
+    def peek = item match {
+      case PullResult.Item(_) => PullResult.Item(())
+      case other => other.asInstanceOf[PullResult[Unit]]
+    }
+
+    def terminate(reason: Throwable) {
+      item = PullResult.Error(reason)
+    }
+ 
+    def outputState = item match {
+      case PullResult.Error(err) => TransportState.Terminated(err)
+      case PullResult.Closed => TransportState.Closed
+      case _ => TransportState.Open
+    }
   }
+
+  def fromArray[T](arr: Array[T]): Source[T] = fromIterator(new Iterator[T] {
+    private var index = 0
+    def hasNext = index < arr.length
+    def next = {
+      index += 1
+      arr(index - 1)
+    }
+  })
 
   def fromIterator[T](iterator: Iterator[T]): Source[T] = new Source[T] {
     //this will either be set to a Left (terminate was called) or a Right(complete was called)
@@ -179,6 +208,13 @@ object Source {
       case _ => if (iterator.hasNext) TransportState.Open else TransportState.Closed
     }
 
+    override def pullWhile(f: NEPullResult[T] => Boolean) {
+      while (
+        iterator.hasNext && f(PullResult.Item(iterator.next)) ||
+        !iterator.hasNext && f(PullResult.Closed)
+      ){}
+    }
+
 
   }
 
@@ -210,12 +246,20 @@ object Source {
     }
     def next(): Unit = source.pullWhile{
       case PullResult.Item(subsource) => {
-        //TODO: remove possible recursion
+        //this is a little weird, but eliminates recursion that could occur when
+        //a bunch of sources are all pushed at once and all are able to complete
+        //immediately.  We only want to do the recursive call of next() if the
+        //sub-source does not immediately drain in this function call.  But if
+        //the source is already closed by the very next line, then we know we're
+        //ready for the next sub-source and can continue this pullWhile loop
+        var completedImmediately = true
         subsource.into(flattened, false, true) {
-          case TransportState.Closed => next()
+          case TransportState.Closed => {if (!completedImmediately) next()}
           case TransportState.Terminated(err) => killall(err)
         }
-        false
+        completedImmediately = false
+        //if the subsource is already finished, we can return true and immediately get the next item
+        subsource.outputState == TransportState.Closed
       }
       case PullResult.Closed => {
         flattened.complete()


### PR DESCRIPTION
This continues work on cleaning up all of the new streaming code.  There will be probably just one more cleanup PR after this one.  I also probably need to write a few more tests for this PR.

This PR does some more cleanup mainly to better integrate pipes into the streaming controller layer:

#### New CircuitBreaker

This is essentially a mutable wrapper around a pipe that allows the contained pipe to be swapped out or removed altogether.  Whenever the circuit breaker does contain a pipe, it just silently forwards all operations.  However when it contains no pipe, it behaves as if it is both full (to the producer) and empty (to the consumer) and maintains its own set of callback signals.  When a new pipe is inserted into the circuit breaker, it will fire off those signals.

The end goal of this is to be able to swap out pipes in the streaming controller layer when the connection is lost and re-established.  When the connection is lost, the contained pipe is terminated and removed.  This way any stream that was in-progress when the connection was terminated is properly killed, and we're able to properly apply backpressure to downstream layers.

#### Several Optimizations

* I reversed the changes I made to `Source.one` in my previous PR as it resulted in a noticable loss of performance (mostly due to creating tons of `LinkedList` with only one item.
* new `Source.fromArray` that creates a more efficient Array-based iterator.  Apparently the one build into to Scala (by calling `.toIterator`) is very slow.
* Other minor optimizations to Streaming http

All in all, this puts a streaming-http hello-world service at nearly the same performance as regular http.  I haven't done extensive benchmarking yet, but at least on my laptop I get about 580K requests/second with streaming, compared to about 660K with regular.  