### PR TITLE
fixing bytestring conversion in redis client

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/redis/RedisOpsSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/redis/RedisOpsSpec.scala
@@ -1,0 +1,17 @@
+package colossus.protocols.redis
+
+import akka.util.ByteString
+import colossus.service._
+import org.scalatest._
+
+class RedisOpsSpec extends FlatSpec with ShouldMatchers with RedisClient[Callback]{
+
+  override def client: Sender[Redis, Callback] = new BasicLiftedClient(null)
+  override implicit val async: Async[Callback] = CallbackAsync
+
+  it should "convert Double to a string properly" in {
+    bs(1234) should equal (ByteString("1234"))
+    bs(1234.5) should equal (ByteString("1234.5"))
+    bs(123456789) should equal (ByteString("123456789"))
+  }
+}

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
@@ -1,6 +1,8 @@
 package colossus
 package protocols.redis
 
+import java.text.DecimalFormat
+
 import akka.util.ByteString
 import colossus.service._
 
@@ -46,8 +48,9 @@ trait RedisClient[M[_]] extends LiftedClient[Redis, M] {
   import Command.{c => cmd}
   import async._
 
+  private val DecimalFormat = new DecimalFormat("#.#")
   private implicit def bs(l : Long) : ByteString = ByteString(l.toString)
-  private implicit def bs(d : Double) : ByteString = ByteString(d.toString)
+  protected implicit def bs(d : Double) : ByteString = ByteString(DecimalFormat.format(d))
   private def seconds(fd : FiniteDuration) = ByteString(fd.toSeconds.toString)
   private def millis(fd : FiniteDuration) = ByteString(fd.toMillis.toString)
 
@@ -336,8 +339,8 @@ trait RedisClient[M[_]] extends LiftedClient[Redis, M] {
   def zcard(key : ByteString) : M[Long] = integerReplyCommand(cmd(CMD_ZCARD, key), key)
 
   def zcount(key : ByteString, from : Option[Double] = None, to : Option[Double]) : M[Long] = {
-    val fromB = from.fold(ByteString("-inf")){x => ByteString(x.toString)}
-    val toB = to.fold(ByteString("+inf")){x => ByteString(x.toString)}
+    val fromB = from.fold(ByteString("-inf")){x => bs(x)}
+    val toB = to.fold(ByteString("+inf")){x => bs(x)}
     integerReplyCommand(cmd(CMD_ZCOUNT, key, fromB, toB), key)
   }
 


### PR DESCRIPTION
We are currently calling toString on Double, this converts large numbers to scientific notation and adds decimals when one isn't passed in.  Example:

```
scala> val a:Double = 123000000
a: Double = 1.23E8

scala> val b:Double = 12345
b: Double = 12345.0
```

This PR switches the conversion to DecimalFormat, which fixes this issue
