### PR TITLE
Minor Pipe cleanup and some small optimizations

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/StreamServiceSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/StreamServiceSpec.scala
@@ -73,7 +73,7 @@ class StreamServiceSpec extends ColossusSpec with MockFactory with ControllerMoc
 
     "correctly assemble an http request" in {
       val (ctrlr, stub) = create()
-      val p = new BufferedPipe[StreamingHttpMessage[HttpRequestHead]](10)
+      val p = new BufferedPipe[StreamingHttpMessage[HttpRequestHead]](1)
       (ctrlr.downstream.incoming _).when().returns(p)
       val expected = HttpRequest.get("/foo").withHeader("key", "value").withBody(HttpBody("hello there"))
       ctrlr.connected()
@@ -90,6 +90,7 @@ class StreamServiceSpec extends ColossusSpec with MockFactory with ControllerMoc
         case other => throw new Exception("WRONG")
       }
     }
+
   }
 
 }

--- a/colossus-tests/src/test/scala/colossus/streaming/SourceSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/SourceSpec.scala
@@ -104,14 +104,15 @@ class SourceSpec extends ColossusSpec {
     "do the thing we expect it to do" in {
       val s = Source.fromArray(Array(1, 2, 3))
       var sum = 0
-      s.pullWhile{
-        case PullResult.Item(i) => {
+      s.pullWhile(
+        i => {
           sum += i
           PullAction.PullContinue
+        }, {
+          case PullResult.Closed => PullAction.Stop
+          case PullResult.Error(err) => throw err
         }
-        case PullResult.Closed => PullAction.Stop
-        case PullResult.Error(err) => throw err
-      }
+      )
       sum mustBe 6
     }
   }
@@ -140,14 +141,14 @@ class SourceSpec extends ColossusSpec {
     "terminate pullWhile correctly" in {
       val s = Source.fromArray(Array(1,2, 3))
       var sum = 0
-      s.pullWhile{
-        case PullResult.Item(i) => {
+      s.pullWhile(
+        i => {
           sum += i
           s.terminate(new Exception("BYE"))
           PullAction.PullContinue
-        }
-        case _ => PullAction.Stop
-      }
+        },
+        _ => ()
+      )
       sum mustBe 1
     }
 

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -83,6 +83,7 @@ trait StaticInputController[E <: Encoding] extends BaseController[E] {
       while (
         inputSizeTracker.track(data)(codec.decode(data)) match {
           case Some(msg) => incoming.push(msg) match {
+            case PushResult.Ok => true
             case PushResult.Full(signal) => {
               pauseReads()
               (Source.one(msg) ++ Source.fromIterator( new CodecBufferIterator(codec, data.takeCopy) {
@@ -99,7 +100,6 @@ trait StaticInputController[E <: Encoding] extends BaseController[E] {
               fatalError(new Exception("attempted to push to closed pipe"))
               false
             }
-            case PushResult.Ok => true
           }
           case None => false
         }

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -197,7 +197,7 @@ class ParsedHttpHeaders(
     connection: Option[Connection]
   ) = this(headers.headers, transferEncodingOpt, contentLength, connection)
 
-  override def transferEncoding = transferEncodingOpt.getOrElse(TransferEncoding.Identity)
+  override def transferEncoding = if (transferEncodingOpt.isDefined) transferEncodingOpt.get else TransferEncoding.Identity
 
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
@@ -7,7 +7,7 @@ import core._
 import controller._
 import service._
 
-class HttpServiceHandler(rh: RequestHandler) 
+protected[server] class HttpServiceHandler(rh: RequestHandler) 
 extends DSLService[Http](rh) {
 
   val defaults = new Http.ServerDefaults
@@ -46,10 +46,16 @@ protected[server] class Generator(context: InitContext) extends HandlerGenerator
 abstract class Initializer(ctx: InitContext) extends Generator(ctx) with ServiceInitializer[RequestHandler]
 
 
+/**
+ * A RequestHandler contains the business logic for transforming [[HttpRequest]] into [[HttpResponse]] objects.  
+ */
 abstract class RequestHandler(config: ServiceConfig, ctx: ServerContext) extends GenRequestHandler[Http](config, ctx) {
   def this(ctx: ServerContext) = this(ServiceConfig.load(ctx.name), ctx)
 }
 
+/**
+ * Entry point for starting a Http server
+ */
 object HttpServer extends ServiceDSL[RequestHandler, Initializer]{
 
   def basicInitializer = new Generator(_)

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -294,8 +294,8 @@ extends ControllerDownstream[Encoding.Client[P]] with HasUpstream[ControllerUpst
    */
   def send(request: Request): Callback[P#Response] = UnmappedCallback[P#Response](sendNow(request))
 
-  def processMessages(): Unit = incoming.pullWhile {
-    case PullResult.Item(response) => {
+  def processMessages(): Unit = incoming.pullWhile (
+    response => {
       val now = System.currentTimeMillis
       sentBuffer.pull match {
         case PullResult.Item(source) => {
@@ -315,12 +315,9 @@ extends ControllerDownstream[Encoding.Client[P]] with HasUpstream[ControllerUpst
       }
       checkGracefulDisconnect()
       PullAction.PullContinue
-    }
-    case other => {
-      //TODO what do here?
-      PullAction.Stop
-    }
-  }
+    },
+    _ => ()
+  )
 
   override def connected() {
     log.info(s"$id Connected to $address")

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -248,8 +248,8 @@ with UpstreamEventHandler[ControllerUpstream[Encoding.Server[P]]]
   }
 
   def processMessages() {
-    incoming.pullWhile {
-      case PullResult.Item(request) => {
+    incoming.pullWhile (
+      request => {
         numRequests += 1
         val promise = new SyncPromise(request)
         requestBuffer.add(promise)
@@ -276,9 +276,9 @@ with UpstreamEventHandler[ControllerUpstream[Encoding.Server[P]]]
           case Failure(err) => promise.complete(handleFailure(RecoverableError(promise.request, err)))
         }
         PullAction.PullContinue
-      }
-      case _ => ???
-    }
+      },
+      _ => ()
+    )
   }
   
   def processBadRequest(reason: Throwable) = {

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -220,7 +220,6 @@ with UpstreamEventHandler[ControllerUpstream[Encoding.Server[P]]]
             requests.hit(tags = tags)
             latency.add(tags = tags, value = (System.currentTimeMillis - done.creationTime).toInt)
           }
-          //upstream.outgoing.push(done.response)
         }
         case PushResult.Full(signal) => {
           //this might seem odd to remove the head and then add it back, but
@@ -230,7 +229,10 @@ with UpstreamEventHandler[ControllerUpstream[Encoding.Server[P]]]
           signal.notify{ checkBuffer() }
           continue = false
         }
-        case other => ???
+        case other => {
+          log.error(s"invalid state on incoming stream $other")
+          connection.forceDisconnect()
+        }
       }
     }
     checkGracefulDisconnect()

--- a/colossus/src/main/scala/colossus/streaming/Channel.scala
+++ b/colossus/src/main/scala/colossus/streaming/Channel.scala
@@ -13,8 +13,8 @@ class Channel[I,O](sink: Sink[I], source: Source[O]) extends Pipe[I,O] {
 
   def complete() = sink.complete()
 
-  override def pullWhile(fn: NEPullResult[O] => PullAction) {
-    source.pullWhile(fn)
+  override def pullWhile(fn: O => PullAction, onc: TerminalPullResult => Any) {
+    source.pullWhile(fn, onc)
   }
 
   override def pullUntilNull(fn: O => Boolean): Option[NullPullResult] = source.pullUntilNull(fn)

--- a/colossus/src/main/scala/colossus/streaming/CircuitBreaker.scala
+++ b/colossus/src/main/scala/colossus/streaming/CircuitBreaker.scala
@@ -27,7 +27,7 @@ trait CircuitBreaker[T <: Transport] {
 
 }
 
-trait SourceCircuitBreaker[A, T <: Source[A]] extends  Source[A] { self: CircuitBreaker[T] => 
+trait SourceCircuitBreaker[A, T <: Source[A]] extends  Source.BasicMethods[A] { self: CircuitBreaker[T] => 
 
   def pull(): PullResult[A] = current match {
     case Some(c) => c.pull

--- a/colossus/src/main/scala/colossus/streaming/CircuitBreaker.scala
+++ b/colossus/src/main/scala/colossus/streaming/CircuitBreaker.scala
@@ -45,10 +45,10 @@ trait SourceCircuitBreaker[A, T <: Source[A]] extends  Source[A] { self: Circuit
   //performance improvements since it lets us invoke the optimized versions
   //inside BufferedPipe
 
-  override def pullWhile(fn: NEPullResult[A] => PullAction) {
+  override def pullWhile(fn: A => PullAction, onc: TerminalPullResult => Any) {
     current match {
-      case Some(c) => c.pullWhile(fn)
-      case None    => super.pullWhile(fn)
+      case Some(c) => c.pullWhile(fn, onc)
+      case None    => super.pullWhile(fn, onc)
     }
   }
 

--- a/colossus/src/main/scala/colossus/streaming/Pipe.scala
+++ b/colossus/src/main/scala/colossus/streaming/Pipe.scala
@@ -12,25 +12,29 @@ import scala.language.higherKinds
 
 
 /**
- * A Pipe is a callback-based data transport abstraction meant for handling
- * streams.  It provides backpressure feedback for both the write and read
- * ends.
+ * A Pipe is an abstraction that mediates interactions between producers and
+ * consumers of a stream of data.  It can be thought of as a mutable buffer that
+ * has built-in features for addressing both back-pressure (when the pipe
+ * "fills") and forward-pressure (when the pipe "empties").  Items are "pushed"
+ * into the pipe and "pulled" out of it.
  *
- * Pipes are primarily a way to easily process incoming/outgoing streams and manage
- * backpressure.  A Producer pushes items into a pipe and a consumer pulls them
- * out.  Pulling is done through the use of a callback function which the Pipe
- * holds onto until an item is pushed.  Each call to `pull` will only ever pull one
- * item out of the pipe, so generally the consumer enters a loop by calling pull
- * within the callback function.
- * 
- * Backpressure is handled differently for the producer and consumer.  In effect,
- * the consumer is the "leader" in terms of backpressure, since the consumer must
- * always ask for more items.  For the producer, the return value of `push` will
- * indicate if backpressure is occurring.  When the pipe is "full", `push` returns
- * a `Trigger`, which the producer "fills" by supplying a callback function.  This
- * function will be called once the backpressure has been alleviated and the pipe
- * can accept more items.
- * 
+ * A Pipe is the combination of the [[Source]] and [[Sink]] traits, representing
+ * the producer and consumer interfaces, respectively.  It should be noted that
+ * a Pipe does not contain additional state beyond that provided by the Source
+ * and Sink interfaces.  In other words, it may be possible for the producer
+ * `Sink` side of a pipe to be Closed or Terminated, while the consumer `Source`
+ * side is in a different state.
+ *
+ * The canonical implementation is the [[BufferedPipe]], backed by a
+ * fixed-length buffer.  However pipes have many monadic and combinatorial
+ * capabilities, allowing them to be mapped, linked together, flattened, and
+ * multiplexed.
+ *
+ * As opposed to other libraries/frameworks that have a concept of streams,
+ * sources, and sinks, these pipes are intended for low-level stream management.
+ * They support several features that allow interation with pipes to be very
+ * fast and efficient.  They form the backbone of all connection handlers and as
+ * well as streaming protocols like http/2.  Pipes are *not* thread-safe.
  */
 trait Pipe[I, O] extends Sink[I] with Source[O] {
 
@@ -48,14 +52,15 @@ class PipeTerminatedException(reason: Throwable) extends Exception("Pipe Termina
 class PipeStateException(message: String) extends Exception(message) with PipeException
 
 /**
- * This is a special exception that Input/Output controllers look for when
- * error handling pipes.  In most cases they will log the error that terminated
- * the pipe, but for this one exception, the failure will be silent.  This is
- * basically for situations where a certain amount of data is expected but for
- * some reason the receiver decides to cancel for some business-logic reason.
+ * A pipe backed by a fixed-length buffer.  Items can be pushed into the buffer
+ * until it fills, at which point the `Full` [[PushResult]] is returned.  When
+ * items are pulled out of the pipe the signal return in the Full result is
+ * fired.
+ *
+ * The most efficient way to use a `BufferedPipe` is with the `pullWhile`
+ * method.  This allows the pipe to completely bypass buffering and items pushed
+ * to the pipe are fast-tracked directly into the provided processing function.
  */
-class PipeCancelledException extends Exception("Pipe Cancelled") with PipeException
-
 class BufferedPipe[T](size: Int) extends Pipe[T, T] {
   require(size > 0, "buffer size must be greater than 0")
 
@@ -135,7 +140,6 @@ class BufferedPipe[T](size: Int) extends Pipe[T, T] {
     }
     case Active if (bufferFull) => PushResult.Full(pushTrigger)
     case Active  => {
-      //this state only occurs when somebody calls pull and the buffer is empty
       buffer.add(item)
       //if someone was waiting for items to enter the buffer, let them know now.
       //It's possible the notified consumer doesn't actually pull any data, so
@@ -146,8 +150,6 @@ class BufferedPipe[T](size: Int) extends Pipe[T, T] {
     case Dead(reason) => PushResult.Error(reason)
     case Closed       => PushResult.Closed
   }
-
-  val hasItem = PullResult.Item[Unit](())
 
   def peek: PullResult[T] = state match {
     case Dead(reason) => PullResult.Error(reason)
@@ -249,6 +251,8 @@ class BufferedPipe[T](size: Int) extends Pipe[T, T] {
         if (!continue && state.isInstanceOf[PullFastTrack]) {
           state = oldstate
         }
+        // notice if the buffer wasn't full when we started then there couldn't
+        // have been any push triggers, so we don't need to check 
         while (!bufferFull && pushTrigger.trigger()) {}
       }
     }

--- a/colossus/src/main/scala/colossus/streaming/PullResult.scala
+++ b/colossus/src/main/scala/colossus/streaming/PullResult.scala
@@ -4,11 +4,12 @@ package colossus.streaming
 sealed trait PullResult[+T]
 sealed trait NEPullResult[+T] extends PullResult[T]
 sealed trait NullPullResult extends PullResult[Nothing]
+sealed trait TerminalPullResult extends NullPullResult
 object PullResult {
   case class Item[T](item: T) extends NEPullResult[T]
   case class Empty(whenReady: Signal) extends NullPullResult
-  case object Closed extends NEPullResult[Nothing] with NullPullResult
-  case class Error(reason: Throwable) extends NEPullResult[Nothing] with NullPullResult
+  case object Closed extends NEPullResult[Nothing] with TerminalPullResult
+  case class Error(reason: Throwable) extends NEPullResult[Nothing] with TerminalPullResult
 
   implicit object NEPullResultMapper extends Functor[NEPullResult] {
     def map[A,B](p: NEPullResult[A], f: A => B): NEPullResult[B] = p match {

--- a/colossus/src/main/scala/colossus/streaming/Signal.scala
+++ b/colossus/src/main/scala/colossus/streaming/Signal.scala
@@ -1,5 +1,23 @@
 package colossus.streaming
 
+/**
+ * A `Signal` is a callback mechanism used by both [[Source]] and [[Sink]] to manage forward/back-pressure.  In both cases it is returned when a requested operation cannot immediately complete, but can at a later point in time.  For example, when pulling from a [[Source]], if no item is immediately available, a signal is returned that will be triggered when an item is available to pull.
+ * {{{
+ * val stream: Source[Int] = //...
+ * stream.pull() match {
+ *  case PullResult.Item(num) => //...
+ *  case PullResult.Full(signal) => signal.notify {
+ *    //when this callback function is called, it is guaranteed that an item is now available
+ *    stream.pull()//...
+ *  }
+ *}
+ }}}
+ * Signals are multi-listener, so that multiple consumers can attach callbacks
+ * to a single listener.  Callbacks are fired in the order they are queued, and
+ * generally conditions for triggering a signal are re-checked for each listener
+ * (so that, for example, if one item is pushed to an empty Source, only one
+ * listener is signaled).
+ */
 trait Signal {
   def notify(cb: => Unit)
 }

--- a/colossus/src/main/scala/colossus/streaming/Source.scala
+++ b/colossus/src/main/scala/colossus/streaming/Source.scala
@@ -3,24 +3,56 @@ package colossus.streaming
 import scala.util.{Try, Success, Failure}
 import colossus.service.{Callback, UnmappedCallback}
 
+
 sealed trait PullAction
+
+/**
+ * A PullAction is the return type of a processing function passed to
+ * [[Source]].`pullWhile` method.  It signals to the source what action should
+ * be taken after the processing function has processed the next item from the
+ * source.
+ */
 object PullAction {
+  /**
+   * Pull the item just processed from the source and immediately process the next item when it becomes available
+   */
   case object PullContinue extends PullAction
+
+  /**
+   * Pull the item just processed from the source and do not process any further items
+   */
   case object PullStop extends PullAction //might not need this one
+
+  /**
+   * Do not pull the item from the source and stop processing
+   */
   case object Stop extends PullAction //might not need this one
+
+  /**
+   * Do not pull the item from the source and halt processing until the provided signal is invoked
+   */
   case class Wait(signal: Signal) extends PullAction
+
+  /**
+   * immediately terminate the source
+   */
   case class Terminate(reason: Throwable) extends PullAction
 }
 
 /**
- * A Source is the read side of a pipe.  You provide a handler for when an item
- * is ready and the Source will call it.  Note that if the underlying pipe has
- * multiple items ready, onReady will only be called once.  This is so that the
- * consumer of the sink can implicitly apply backpressure by only pulling when
- * it is able to
+ * A `Source` is the read interface for a [[Pipe]].  Items can be pulled out of
+ * the source if available.  When no item is available, a returned [[Signal]]
+ * can be used to be notified when items are available.
+ *
+ * Sources can be mapped using the functionality provided in the
+ * [[SourceMapper]] typeclass
  */
 trait Source[+T] extends Transport {
   
+  /**
+   * Pull the next item from the Source if available.  The returned
+   * [[PullResult]] will indicate whether an item was successfully pulled.
+   */
   def pull(): PullResult[T]
 
   def peek: PullResult[T]
@@ -41,6 +73,25 @@ trait Source[+T] extends Transport {
   }
 
 
+  /**
+   * Repeatedly pull items out of a pipe, even if items are not immediately
+   * available.  The `Source` will hold onto the given processing function and
+   * immediately forward items into it as they become available.  The returned
+   * `PullAction` determines how the `Source` will proceed with the next item.
+   * If `PullContinue` or `Wait` are returned, the `Source` will hold onto the
+   * processing function for either when the next item is available or when the
+   * returned `Signal` is fired.  `onComplete` is only called if the Source is
+   * closed or terminated while the processing function is in use.
+   *
+   * When `Wait` is returned, the item that was passed into the processing
+   * function is _not_ pulled from the source.  Thus when the returned signal is
+   * fired and processing resumes, the same item will be passed to the
+   * processing function.
+   *
+   * This method is generally intended for linking the output of a `Source` to
+   * the input of a [[Sink]]`.  For a simplified version of this functionality, see
+   * `Source.into`.
+   */
   def pullWhile(fn: T => PullAction, onComplete: TerminalPullResult => Any) 
 
   /**
@@ -96,9 +147,10 @@ trait Source[+T] extends Transport {
   /**
    * Link this source to a sink.  Items will be pulled from the source and
    * pushed to the sink, respecting backpressure, until either the source is
-   * closed or an error occurs.  The sink will be closed when this source is
-   * closed.  If the sink is closed before this source, this source will be
-   * terminated.  Other terminations are propagated in both directions.
+   * closed or an error occurs.  The `linkClosed` and `linkTerminated`
+   * parameters determine whether to propagate closure/termination of this
+   * Source to the linked Sink.  However if the sink is closed or terminated first, this
+   * source will be terminated.
    *
    * @param sink The sink to link to this source
    * @param linkClosed if true, the linked sink will be closed when this source is closed
@@ -107,8 +159,8 @@ trait Source[+T] extends Transport {
   def into[U >: T] (sink: Sink[U], linkClosed: Boolean, linkTerminated: Boolean)(onComplete: NonOpenTransportState => Any) {
     pullWhile (
       i => sink.push(i) match {
-        case PushResult.Full(signal)        => PullAction.Wait(signal)
         case PushResult.Ok                  => PullAction.PullContinue
+        case PushResult.Full(signal)        => PullAction.Wait(signal)
         case PushResult.Closed              => PullAction.Terminate(new PipeStateException("Downstream link unexpectedly closed"))
         case PushResult.Error(reason)       => PullAction.Terminate(reason)
       }, {
@@ -184,6 +236,9 @@ object Source {
 
   }
 
+  /**
+   * Create a source containing only one item
+   */
   def one[T](data: T) = new Source[T] with BasicMethods[T] {
     var item: PullResult[T] = PullResult.Item(data)
     def pull(): PullResult[T] = {
@@ -208,6 +263,10 @@ object Source {
     }
   }
 
+  /**
+   * Create a source containing items in the given array.  The source will be
+   * closed after the last item in the array has been pulled
+   */
   def fromArray[T](arr: Array[T]): Source[T] = fromIterator(new Iterator[T] {
     private var index = 0
     def hasNext = index < arr.length
@@ -217,6 +276,10 @@ object Source {
     }
   })
 
+  /**
+   * Create a Source backed by the given iterator.  The source will closed after
+   * the last item is pulled from the iterator.
+   */
   def fromIterator[T](iterator: Iterator[T]): Source[T] = new Source[T] with BasicMethods[T] {
     //this will either be set to a Left (terminate was called) or a Right(complete was called)
     private var stop : Option[Throwable] = None
@@ -247,6 +310,9 @@ object Source {
 
   }
 
+  /**
+   * Create a source that contains no items and is immediately closed
+   */
   def empty[T] = new Source[T] with BasicMethods[T] {
     def pull() = PullResult.Closed 
     def peek = PullResult.Closed

--- a/colossus/src/main/scala/colossus/streaming/package.scala
+++ b/colossus/src/main/scala/colossus/streaming/package.scala
@@ -21,8 +21,8 @@ package object streaming {
       def terminate(err: Throwable) {
         source.terminate(err)
       }
-      override def pullWhile(whilefn: NEPullResult[B] => PullAction) {
-        source.pullWhile{x => whilefn(x.map(fn))}
+      override def pullWhile(whilefn: B => PullAction, onc: TerminalPullResult => Any) {
+        source.pullWhile(x => whilefn(fn(x)), onc)
       }
     }
 

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -65,8 +65,10 @@ class ParserSizeTracker(maxSize: Option[DataSize], histogramOpt: Option[Histogra
 
   private var used = 0L
 
-  def reset() {
-    histogramOpt.foreach{_.add(used.toInt)}
+  @inline private final def reset() {
+    if (histogramOpt.isDefined) {
+      histogramOpt.foreach{_.add(used.toInt)}
+    }
     used = 0
   }
 
@@ -81,7 +83,7 @@ class ParserSizeTracker(maxSize: Option[DataSize], histogramOpt: Option[Histogra
     val start = buffer.taken
     val res = op
     add(buffer.taken - start)
-    res.foreach{_ => reset()}
+    if (res.isDefined) { reset()}
     res
   }
 }


### PR DESCRIPTION
After doing a bit more benchmarking and profiling, found a few small things to cleanup.

The largest change is that `pipe.pullWhile` now requires two functions instead of one.  The first function is used whenever an item is ready to be pulled, and the second is used when the pipe is closed/terminated.  Not only does this (slightly) improve performance by vastly reducing how often an item needs to be wrapped in `PullResult.Item`, but it cleans up the logic since a `PullAction` isn't actually needed when the pipe is closed or terminated.

The other changes are small optimizations and some updated docs.