### PR TITLE
fixing bug in retrypolicy with duration overflow

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/RetryPolicySpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/RetryPolicySpec.scala
@@ -61,6 +61,16 @@ class RetryPolicySpec extends ColossusSpec {
       i.nextAttempt() must equal(Stop)
     }
 
+    "not cause overlow after enough attempts" in {
+      val p = BackoffPolicy(20.milliseconds, Exponential(1.second), maxTime = Some(50.milliseconds), immediateFirstAttempt = false)
+      val i = p.start()
+      (1 to 50).foreach{_ =>
+        i.nextAttempt()
+      }
+      i.nextAttempt() must equal(RetryIn(1.second))
+    }
+      
+
 
   }
 

--- a/colossus/src/main/scala/colossus/core/RetryPolicy.scala
+++ b/colossus/src/main/scala/colossus/core/RetryPolicy.scala
@@ -129,9 +129,21 @@ object BackoffMultiplier {
     
     def max: FiniteDuration
 
+    //needed to avoid possible out-of-range issue with FiniteDuration
+    private var hitMax = false
+
     def value(base: FiniteDuration, attempt: Int) = {
-      val i = increaseValue(base, attempt)
-      if (i > max) max else i
+      if (hitMax) {
+        max
+      } else {
+        val i = increaseValue(base, attempt)
+        if (i > max) {
+          hitMax = true
+          max 
+        } else {
+          i
+        }
+      }
     }
 
     protected def increaseValue(base: FiniteDuration, attempt: Int): FiniteDuration
@@ -148,7 +160,9 @@ object BackoffMultiplier {
    * A multiplier that will double the backoff time with each attempt, up to `max`
    */
   case class Exponential(max: FiniteDuration) extends IncreasingMultiplier {
-    protected def increaseValue(base: FiniteDuration, attempt: Int) = base * math.pow(2, attempt - 1).toLong
+    protected def increaseValue(base: FiniteDuration, attempt: Int) = {
+      base * math.pow(2, attempt - 1).toLong
+    }
   }
 }
 


### PR DESCRIPTION
This fixes an odd bug that occurred on exponential retry policies.  Even though there is a max value, it continued to calculate values larger than the max, eventually resulting in an exception being thrown by `FiniteDuration` once the number of attempts got high enough.  This ensures that once the max value is hit, it doesn't attempt to further recalculate an exponential value.