### PR TITLE
fixing a bug where fatal errors failed to initiate reconnect logic

### DIFF
--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -363,6 +363,11 @@ with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
     }
   }
 
+  override def fatalInputError(reason: Throwable) = {
+    worker ! Kill(id, DisconnectCause.Error(reason))
+    None
+  }
+
 
   override def idleCheck(period: FiniteDuration) {
     super.idleCheck(period)


### PR DESCRIPTION
Because `ServiceClient` didn't override `fatalInputError`, it would end up permanently closing the connection instead of going through the proper reconnection process whenever a parsing error occurred.  This would include situations where a parsed response exceeded the configured `maxResponseSize` of the client.