### PR TITLE
Docs: Worker updates

### DIFF
--- a/_sass/navi.scss
+++ b/_sass/navi.scss
@@ -122,7 +122,7 @@ Licence: <a href="http://www.os-templates.com/template-terms">Website Template L
 	margin:0;
 	padding:5px 10px 5px 20px;
 	color:#777777;
-	background:url("../images/orange_file.gif") no-repeat 10px center #F9F9F9;
+	background: #F9F9F9;
 	text-decoration:none;
 	border-bottom:1px dotted #666666;
 	}

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,9 @@ categories: docs
 
 [Quickstart](quickstart)
 
-[Working with Clients](clients)
+[Clients](clients)
+
+[Workers](workers)
 
 [Configuration](configuration)
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -105,7 +105,7 @@ A counter simply allows you to set, increment, and decrement values:
 
 {% highlight scala %}
 
-val counter = Counter("/my-counter")
+val counter = Counter("my-counter")
 
 counter.set(2, Map("foo" -> "bar"))
 
@@ -121,7 +121,7 @@ interval.  Rates are also tracked for every interval.
 
 {% highlight scala %}
 
-val rate = Rate("/my-rate")
+val rate = Rate("my-rate")
 
 rate.hit()
 
@@ -138,7 +138,7 @@ this can be overridden.
 
 {% highlight scala %}
 
-val hist = Histogram("/my-histogram", percentiles = List(0.5, 0.99, 0.999))
+val hist = Histogram("my-histogram", percentiles = List(0.5, 0.99, 0.999))
 
 hist.add(12)
 hist.add(1)

--- a/docs/workers.md
+++ b/docs/workers.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title:  "Workers"
+categories: docs
+---
+
+Workers are the reactive event-loops that handle the service business logic and consist of an Initializer and Request Handler. Initializers are created for each worker and provide a place to share resources among all connections handled by the worker. It also provides access for updating data for the request handler and clients.
+
+{% highlight scala %}
+
+val server = Server.start("http-server", 8888) { workerRef =>
+  new Initializer(workerRef) {
+    var currentName = "Jones"
+
+    override def receive = {
+      case NameChange(name) => currentName = name
+    }
+
+    override def onConnect = new HttpService(_) {
+      override def handle: PartialHandler[Http] = {
+        case request @ Get on Root => 
+          Callback.successful(request.ok(s"My name is $currentName"))
+      }
+    }
+  }
+}
+  
+{% endhighlight %}
+
+Actor messages can then be broadcast to all workers using the `delegatorBroadcast` method on `ServerRef`.
+
+{% highlight scala %}
+
+server.delegatorBroadcast(NameChange("Smith"))
+
+{% endhighlight %}


### PR DESCRIPTION
Apart from minor changes (orange_file.gif doesn't exist, and slash on metric names is unnecessary) I have added a section about how workers and their request handlers/clients can get updates. I thought I'd add a new page since it didn't seem appropriate for the quick start page where workers/initializers are discussed.