### PR TITLE
Remove trailing whitespace

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/ChatExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/ChatExample.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
  * encode output messages.  There is no coupling between input and output
  * messages.  The service layer extends this layer to add request/response
  * semantics.
- * 
+ *
  * This example is a simple chat server built on the controller layer.  This example is largely
  * a motivator for cleaning up the controller API.  It should become simpler as
  * we improve the interface.
@@ -43,7 +43,7 @@ class ChatCodec extends Codec[ChatMessage, String]{
   def reset(){}
 
 }
-  
+
 class Broadcaster extends Actor {
   import Broadcaster._
 
@@ -78,7 +78,7 @@ extends Controller[String, ChatMessage](new ChatCodec, ControllerConfig(50, 10.s
 with ProxyActor with ServerConnectionHandler {
 
   implicit val namespace = context.server.namespace
-  
+
   sealed trait State
   object State {
     case object LoggingIn extends State
@@ -136,7 +136,7 @@ object ChatExample {
     val broadcaster = io.actorSystem.actorOf(Props[Broadcaster])
 
     Server.basic("chat", port)(context => new ChatHandler(broadcaster, context))
-  
+
   }
 
 }

--- a/colossus-examples/src/main/scala/colossus-examples/EchoExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/EchoExample.scala
@@ -28,7 +28,7 @@ object EchoExample {
   def start(port: Int)(implicit io: IOSystem): ServerRef = {
 
     Server.basic("echo", port)(new EchoHandler(_))
-  
+
   }
 
 }

--- a/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/HttpExample.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 object HttpExample {
 
   class HttpExampleService(redis: RedisClient[Callback], context: ServerContext) extends HttpService(ServiceConfig.Default, context){
-    
+
     def invalidReply(reply: Reply) = s"Invalid reply from redis $reply"
 
     def handle = {

--- a/colossus-examples/src/main/scala/colossus-examples/KeyValExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/KeyValExample.scala
@@ -31,7 +31,7 @@ object KeyValDB {
 }
 
 object KeyValExample {
-  
+
 
   def start(port: Int)(implicit io: IOSystem): ServerRef = {
     import io.actorSystem.dispatcher
@@ -59,4 +59,4 @@ object KeyValExample {
     }}
   }
 }
-        
+

--- a/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/WebsocketExample.scala
@@ -38,17 +38,17 @@ class PrimeGenerator extends Actor {
 }
 
 case object Next
-    
+
 
 
 object WebsocketExample {
 
   def start(port: Int)(implicit io: IOSystem) = {
-    
+
     val generator = io.actorSystem.actorOf(Props[PrimeGenerator])
 
     WebsocketServer.start("websocket", port){worker => new WebsocketInitializer(worker) {
-      
+
       def onConnect = ctx => new WebsocketServerHandler[RawString](ctx) with ProxyActor {
         private var sending = false
 

--- a/colossus-metrics/src/main/scala/colossus/metrics/Metric.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Metric.scala
@@ -22,7 +22,7 @@ case class MetricAddress(components: List[String]) {
   def pieceString = components.mkString("/")
 
   def idString = components.mkString("_")
-  
+
   /**
    * String version the address used for loading configuration
    */

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricClock.scala
@@ -101,8 +101,8 @@ class SystemMetricsCollector(namespace: MetricNamespace) {
         (namespace.namespace / "system" / "gc" / "msec") -> msec
       )
     }
-    
-    val fdInfo: MetricMap = ManagementFactory.getOperatingSystemMXBean match {    
+
+    val fdInfo: MetricMap = ManagementFactory.getOperatingSystemMXBean match {
       case u: com.sun.management.UnixOperatingSystemMXBean => Map(
         (namespace.namespace / "system" / "fd_count") -> Map(Map() -> u.getOpenFileDescriptorCount)
       )

--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -93,7 +93,7 @@ case class MetricContext(namespace: MetricAddress, collection: Collection, tags:
 case class SystemMetricsConfig(enabled: Boolean, namespace: MetricAddress)
 
 
-/** 
+/**
  * Configuration object for a [[MetricSystem]]
  *
  * @param enabled true to enable all functionality.  Setting to false will effectively create a dummy system that does nothing
@@ -119,7 +119,7 @@ object MetricSystemConfig {
    * config object, the format should be that of the `colossus.metrics` section
    * in the reference.conf.  For example, if creating a metric system named
    * "foo" that will create a rate named "bar", the config should look like:
-   * 
+   *
    * ```
    foo {
      system.enabled = true

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -309,7 +309,7 @@ class DefaultHistogram private[metrics](
   private def withHist[T](collectionInterval: FiniteDuration, tags: TagMap)(op: BaseHistogram => T): Option[T] = {
     Option(tagHists(collectionInterval).get(tags)).map(op)
   }
-    
+
 
   def percentile(collectionInterval: FiniteDuration, percent: Double, tags: TagMap = TagMap.Empty): Int = {
     withHist(collectionInterval, tags)(_.percentile(percent)).getOrElse(0)

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -29,7 +29,7 @@ trait Rate extends Collector{
    *
    * @param collectionInterval The collection interval to retrieve the value for.  Collection intervals are configured per [[MetricSystem]]
    * @param tags The tags for the value to get, defaults to an empty tagmap
-   * 
+   *
    */
   def value(collectionInterval: FiniteDuration, tags: TagMap = TagMap.Empty): Long
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/CollectionMapSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CollectionMapSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest._
 class CollectionMapSpec extends WordSpec with MustMatchers with BeforeAndAfterAll{
 
   "CollectionMap" must {
-      
+
     "increment a non-existing value" in {
       val c = new CollectionMap[String]
       c.get("foo") must equal(None)

--- a/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
@@ -49,7 +49,7 @@ class CounterSpec extends MetricIntegrationSpec {
 
     }
 
-    
+
   }
 
 }

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricSpec.scala
@@ -26,7 +26,7 @@ class MetricSpec(_system : ActorSystem) extends MetricIntegrationSpec(_system) w
   "MetricSystem" must {
     "allow multiple systems to start without any conflicts" in {
       val config = MetricSystemConfig.load("foo")
-      
+
       val m1 = MetricSystem(config)
       val m2 = MetricSystem(config.copy(name = "different-name"))
       //no exceptions means the test passed

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -95,7 +95,7 @@ class RateSpec extends MetricIntegrationSpec {
       implicit val ns = MetricContext("/foo", Collection.withReferenceConf(Seq(1.second))) / "bar"
       val r = Rate("/baz")
       r.address must equal(MetricAddress("/foo/bar/baz"))
-      
+
     }
   }
 }

--- a/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/HttpServiceSpec.scala
@@ -33,7 +33,7 @@ abstract class HttpServiceSpec extends ServiceSpec[Http] {
     assert(response.head.code == expectedCode, msg)
   }
 
-    
+
   def assertBody(request : HttpRequest, response : HttpResponse, expectedBody : String){
     val body = response.body.bytes.utf8String
     assert(body == expectedBody, s"$body did not equal $expectedBody")

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockConnection.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockConnection.scala
@@ -8,7 +8,7 @@ import akka.testkit.TestProbe
 import scala.concurrent.duration._
 
 trait MockConnection extends Connection with MockChannelActions {
-  
+
   /**
    * Simulate event-loop iterations, calling readyForData until this buffer
    * fills or everything is written.  This can be used to test backpressure
@@ -42,7 +42,7 @@ trait MockConnection extends Connection with MockChannelActions {
       clearBuffer()
     }
   }
-    
+
 
   def iterate(bsize: Int = 100) = iterate[Unit](bsize)({})
 
@@ -58,7 +58,7 @@ trait MockConnection extends Connection with MockChannelActions {
 
   /**
    * checks to see if the connection handler has attempted to close the
-   * connection.  
+   * connection.
    */
   def expectDisconnectAttempt() {
     workerProbe.expectMsg(100.milliseconds, WorkerCommand.Disconnect(id))

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockWriteBuffer.scala
@@ -99,9 +99,9 @@ trait MockChannelActions extends ChannelActions {
     val call = writeCalls.dequeue()
     f(call)
   }
-    
 
-    
+
+
 }
 
 class MockWriteBuffer(val maxWriteSize: Int) extends WriteBuffer with MockChannelActions {

--- a/colossus-testkit/src/main/scala/colossus-testkit/PipeFoldTester.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/PipeFoldTester.scala
@@ -22,7 +22,7 @@ class PipeFoldTester[T](foldCB: Callback[T]) {
   private var res: Option[Try[T]] = None
   foldCB.execute{result => res = Some(result)}
 
-  private def expectRes(r: Try[T] => Unit) { 
+  private def expectRes(r: Try[T] => Unit) {
     res.map(r).getOrElse{
       throw new Exception("Callback did not complete")
     }

--- a/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
@@ -12,13 +12,13 @@ import service._
 import scala.reflect.ClassTag
 
 abstract class ServiceSpec[C <: Protocol](implicit provider: ServiceCodecProvider[C], clientProvider: ClientCodecProvider[C]) extends ColossusSpec {
-  
+
   type Request = C#Input
   type Response = C#Output
 
   implicit val sys = IOSystem("test-system", Some(2), MetricSystem.deadSystem)
 
-  
+
   def service: ServerRef
   def requestTimeout: FiniteDuration
 

--- a/colossus-testkit/src/test/scala/colossus/FakeIOSystemSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/FakeIOSystemSpec.scala
@@ -32,6 +32,6 @@ class FakeIOSystemSpec extends ColossusSpec with CallbackMatchers {
 
 
 
-      
+
 
 }

--- a/colossus-testkit/src/test/scala/colossus/MockWriteBufferSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/MockWriteBufferSpec.scala
@@ -43,7 +43,7 @@ class MockWriteBufferSpec extends WordSpec with MustMatchers{
       m.expectOneWrite(ByteString("cd"))
     }
 
-      
+
   }
 }
 

--- a/colossus-testkit/src/test/scala/colossus/ServiceSpecSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/ServiceSpecSpec.scala
@@ -37,7 +37,7 @@ class ServiceSpecSpec extends ServiceSpec[Redis] {
       expectResponseType[ErrorReply](Command("ASDF"))
     }
 
-    
+
   }
 }
 
@@ -52,6 +52,6 @@ class ServiceSpecTimeoutSpec extends ServiceSpec[Redis] {
       intercept[TestFailedException]{
         expectResponse(Command("DELAY"), StatusReply("OK"))
       }
-    }      
+    }
   }
 }

--- a/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala
@@ -44,7 +44,7 @@ class MemcacheITSpec extends ColossusSpec with ScalaFutures{
     f.futureValue must be (mutable.HashSet(true, false)) //some keys are deleted by the tests.
     super.afterAll()
   }
-  
+
   val mValue = ByteString("value")
   "Memcached client" should {
     "add" in {

--- a/colossus-tests/src/it/scala/colossus/RedisITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/RedisITSpec.scala
@@ -10,7 +10,7 @@ class RedisITSpec extends BaseRedisITSpec{
   val keyPrefix = "colossusKeyIT"
 
   "Redis key and string commands" should {
-    
+
     val value = ByteString("value")
 
     "append" in {
@@ -204,7 +204,7 @@ class RedisITSpec extends BaseRedisITSpec{
         }
       res.futureValue.toSet must be (Set(key1, key2))
     }
-    
+
     "mget" in {
       val key1 = getKey()
       val key2 = getKey()
@@ -218,7 +218,7 @@ class RedisITSpec extends BaseRedisITSpec{
       }
       res.futureValue must be (Seq(Some(value), Some(value), None))
     }
-    
+
     "mset" in {
       val key1 = getKey()
       val key2 = getKey()
@@ -231,7 +231,7 @@ class RedisITSpec extends BaseRedisITSpec{
 
       res.futureValue must be ((true, Seq(Some(value), Some(value))))
     }
-    
+
     "msetnx" in {
       val key1 = getKey()
       val key2 = getKey()

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -24,7 +24,7 @@ class EchoHandler(c: ServerContext) extends BasicSyncHandler(c.context) with Ser
     out.write(buffer.dequeue)
     if (buffer.isEmpty) MoreDataResult.Complete else MoreDataResult.Incomplete
   }
-      
+
 
 }
 
@@ -43,12 +43,12 @@ object RawProtocol {
   }
 
   implicit object RawClientLifter extends ClientLifter[Raw, RawClient] {
-    
+
     def lift[M[_]](client: Sender[Raw,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with RawClient[M]
   }
 
   object Raw extends ClientFactories[Raw, RawClient]{
-    
+
   }
 
   trait RawClient[M[_]] extends LiftedClient[Raw, M]
@@ -56,7 +56,7 @@ object RawProtocol {
   object RawClient {
   }
 
-  
+
 
   implicit object RawCodecProvider extends ServiceCodecProvider[Raw] {
     def provideCodec() = RawCodec

--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -15,7 +15,7 @@ case class TestInputImpl(data: FiniteBytePipe) extends TestInput{
   def source = data
   def sink = data
 }
-  
+
 case class TestOutput(data: Source[DataBuffer])
 
 

--- a/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 import scala.util.Success
 
 class InputControllerSpec extends ColossusSpec with CallbackMatchers{
-  
+
   import TestController._
 
   "Input Controller" must {
@@ -62,7 +62,7 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers{
       //now it should be done
       executed must equal(true)
     }
-    
+
     "reject data above the size limit" in {
       val input = ByteString("hello")
       val config = ControllerConfig(4, 50.milliseconds, 2.bytes)
@@ -75,7 +75,7 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers{
 
     "stream is terminated when connection disrupted" in {
       var source: Option[Source[DataBuffer]] = None
-      val (endpoint, con) = createController({input => 
+      val (endpoint, con) = createController({input =>
         source = Some(input.source)
       })
       con.receivedData(DataBuffer(ByteString("4\r\n")))
@@ -92,12 +92,12 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers{
         }
       }
       wrong must equal(false)
-      failed must equal(true)   
+      failed must equal(true)
     }
 
     "input stream allowed to complete during graceful disconnect" in {
       var source: Option[Source[DataBuffer]] = None
-      val (endpoint, con) = createController({input => 
+      val (endpoint, con) = createController({input =>
         source = Some(input.source)
       })
       endpoint.readsEnabled must equal(true)
@@ -119,8 +119,8 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers{
 
     }
     */
-        
-      
+
+
 
   }
 

--- a/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
@@ -86,7 +86,7 @@ class OutputControllerSpec extends ColossusSpec {
       endpoint.writeReadyEnabled must equal(false)
     }
 
-      
+
 
     "drain output buffer on disconnect" in {
       val endpoint = static()
@@ -133,7 +133,7 @@ class OutputControllerSpec extends ColossusSpec {
     }
 
 
-      
+
   }
 
 

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -28,7 +28,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
 
         def receivedData(data: DataBuffer) {}
       }
-      withServer(context => new MyHandler(context)) { server => 
+      withServer(context => new MyHandler(context)) { server =>
         val c = TestClient(server.system, TEST_PORT)
         probe.expectMsg(100.milliseconds, "BOUND")
       }

--- a/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
@@ -27,7 +27,7 @@ class CoreHandlerSpec extends ColossusSpec {
   }
 
   "Core Handler" must {
-    
+
     "set connectionStatus to Connected" in {
       val con = MockConnection.server(srv => new BasicCoreHandler(srv.context))
       con.typedHandler.connectionState must equal(NotConnected)
@@ -77,7 +77,7 @@ class CoreHandlerSpec extends ColossusSpec {
       con.typedHandler.connectionState must equal(NotConnected)
     }
 
-      
+
 
     "not call shutdown when disconnect is called while in the shuttingdown state" in {
       val con = setup(false)
@@ -87,9 +87,9 @@ class CoreHandlerSpec extends ColossusSpec {
       con.typedHandler.shutdownRequest()
       con.typedHandler.shutdownCalled must equal(false)
     }
-      
 
-      
+
+
 
   }
 

--- a/colossus-tests/src/test/scala/colossus/core/DataBlockSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/DataBlockSpec.scala
@@ -7,7 +7,7 @@ import akka.util.{ByteString, ByteStringBuilder}
 class DataBlockSpec extends ColossusSpec {
 
   "DataBlock" must {
-    
+
     "respect equality" in {
       DataBlock("123456") == DataBlock("123456") must equal(true)
     }
@@ -27,5 +27,5 @@ class DataBlockSpec extends ColossusSpec {
   }
 }
 
-    
+
 

--- a/colossus-tests/src/test/scala/colossus/core/DataOutBufferSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/DataOutBufferSpec.scala
@@ -7,7 +7,7 @@ import akka.util.ByteString
 class DataOutBufferSpec extends ColossusSpec {
 
   "DynamicOutBuffer" must {
-    
+
     "handle overflow" in {
       val data = ByteString("123456789")
       val n = new DynamicOutBuffer(5)
@@ -30,6 +30,6 @@ class DataOutBufferSpec extends ColossusSpec {
       n.write(DataBuffer(data))
       ByteString(n.data.takeAll) must equal(data)
     }
-      
+
   }
 }

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -8,7 +8,7 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 
 class ServerConfigLoadingSpec  extends ColossusSpec {
-  
+
   val refBindingRetry =  BackoffPolicy(100.milliseconds, BackoffMultiplier.Exponential(1.second), immediateFirstAttempt = false)
   val refDelegatorCreationPolicy = WaitPolicy(500.milliseconds, BackoffPolicy(100.milliseconds, BackoffMultiplier.Constant, immediateFirstAttempt = false))
 

--- a/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
+++ b/colossus-tests/src/test/scala/colossus/core/TaskTest.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
 
 class TaskTest extends ColossusSpec {
 
-  /* 
+  /*
    * Notice in these tests we have to explicitly provide the sender when
    * sending an actor message from within the task, since there's ambiguous
    * implicits (the task's self actor and the testkit implicit sender pulled
@@ -33,13 +33,13 @@ class TaskTest extends ColossusSpec {
 
           def receive = {case _ => ()}
         })
-            
+
         probe.expectMsg(500.milliseconds, "BOUND")
       }
-    }    
+    }
 
     "receive a message through the proxy" in {
-      withIOSystem{ implicit io => 
+      withIOSystem{ implicit io =>
         val probe = TestProbe()
         val task = Task.start(new Task(_) {
           def run(){
@@ -57,7 +57,7 @@ class TaskTest extends ColossusSpec {
     }
 
     "receive through self" in {
-      withIOSystem{ implicit io => 
+      withIOSystem{ implicit io =>
         val probe = TestProbe()
         val task = Task.start(new Task(_) {
           def run(){
@@ -90,7 +90,7 @@ class TaskTest extends ColossusSpec {
         probe.expectMsg(100.milliseconds, "BOUND")
         task ! PoisonPill
         probe.expectMsg(100.milliseconds, "UNBOUND")
-        
+
       }
 
     }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
@@ -7,7 +7,7 @@ import java.text.SimpleDateFormat
 
 
 class HttpRequestHeadSuite extends WordSpec with MustMatchers{
-  
+
   import HttpHeader.Conversions._
 
   "Cookie" must {
@@ -26,7 +26,7 @@ class HttpRequestHeadSuite extends WordSpec with MustMatchers{
       HttpHeaders(HttpHeader("a", "b"), HttpHeader("b", "c")) must equal(HttpHeaders(HttpHeader("b", "c"), HttpHeader("a", "b")))
     }
   }
-  
+
 
   "HttpRequestHead" must {
     "correctly parse a cookie" in {
@@ -90,7 +90,7 @@ class HttpRequestHeadSuite extends WordSpec with MustMatchers{
 
     val formatter = new SimpleDateFormat(DateHeader.DATE_FORMAT)
     def date(time: Long) = "Date: " + formatter.format(new Date(time)) + "\r\n"
-    
+
     "generate a correct date" in {
       val time = System.currentTimeMillis + 1000000
       (new DateHeader(123)).bytes(time).utf8String must equal(date(time))

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -32,8 +32,8 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "authorization" -> "Basic XXX",
           "accept-encoding" -> "gzip, deflate"
         )
-      ), HttpBody.NoBody)        
-      
+      ), HttpBody.NoBody)
+
       parser.parse(DataBuffer(ByteString(req))).toList must equal(List(expected))
     }
 
@@ -51,11 +51,11 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "authorization" -> "Basic XXX",
           "accept-encoding" -> "gzip, deflate"
         )
-      ), HttpBody.NoBody)        
+      ), HttpBody.NoBody)
 
       (0 until req.length).foreach{splitIndex =>
         val p1 = req.take(splitIndex)
-        val p2 = req.drop(splitIndex)      
+        val p2 = req.drop(splitIndex)
         try {
           parser.parse(DataBuffer(ByteString(p1))).toList must equal(Nil)
           parser.parse(DataBuffer(ByteString(p2))).toList must equal(List(expected))
@@ -86,10 +86,10 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "accept" ->  "*/*",
           "content-length" -> len.toString
         )
-      ), HttpBody(body))        
+      ), HttpBody(body))
 
       val parser = requestParser
-      
+
       parser.parse(DataBuffer(ByteString(req))).toList must equal(List(expected))
     }
 
@@ -104,10 +104,10 @@ class HttpParserSuite extends WordSpec with MustMatchers{
           "accept" -> "*/*",
           "content-length" -> "0"
         )
-      ), HttpBody.NoBody)        
+      ), HttpBody.NoBody)
 
       val parser = requestParser
-      
+
       parser.parse(DataBuffer(ByteString(req))).toList must equal(List(expected))
 
     }
@@ -204,10 +204,10 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       parsed.body must equal(HttpBody(ByteString("foo123456789abcde")))
       data.remaining must equal(0)
     }
-    
-      
 
-      
+
+
+
   }
 
   "HttpMethod" must {
@@ -247,7 +247,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
 
     def h(url: String) = HttpRequestHead(HttpMethod.Get, url, HttpVersion.`1.1`, Nil).parameters
     def p(params: (String, String)*) = QueryParameters(params.toSeq)
-      
+
     "parse a basic url" in {
       h("/hello/blah.php?foo=bar&baz=moo") must equal(p("foo" -> "bar" , "baz" -> "moo"))
     }
@@ -259,7 +259,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
     "handle terminating &" in {
       h("/x?a=b&") must equal(p("a" -> "b"))
     }
-    
+
     "handle empty value" in {
       h("/x?a=&b=c") must equal(p("a" -> "", "b" -> "c"))
     }
@@ -284,8 +284,8 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       p.contains("b") must equal(true)
       p.contains("c") must equal(false)
     }
-      
-    
+
+
   }
 
   "Http Url Matcher" must {
@@ -308,7 +308,7 @@ class HttpParserSuite extends WordSpec with MustMatchers{
       }
       r must equal(true)
     }
-      
+
 
 
     "match url" in {
@@ -381,9 +381,9 @@ class HttpParserSuite extends WordSpec with MustMatchers{
         case _ => throw new Exception(s"$req failed to parse correctly")
       }
     }
-      
-      
+
+
   }
-      
+
 
 }

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpPipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpPipeSpec.scala
@@ -17,7 +17,7 @@ import scala.util.{Try, Success, Failure}
 
 
 class HttpPipeSuite extends WordSpec with MustMatchers{
-    
+
   val chunkedBody = ByteString("3\r\nfoo\r\nb\r\n12345678901\r\n0\r\n\r\n")
   val badChunkedBody = ByteString("3\r\nfoo\r\n1WHATTT\r\n12345678901\r\n0\r\n\r\n")
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpResponseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpResponseSpec.scala
@@ -46,7 +46,7 @@ class HttpResponseSpec extends ColossusSpec with TryValues with OptionValues wit
       val payload = "look ma, no hands!"
 
       val expected = StreamingHttpResponse(
-        HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, HttpHeaders(HttpHeader("content-length", "18"))), 
+        HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, HttpHeaders(HttpHeader("content-length", "18"))),
         Some(Source.one(DataBuffer(ByteString("test conversion"))))
       )
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
@@ -125,7 +125,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       decodedResponse must equal(expected)
       encodedResponse.remaining must equal(0)
     }
-    
+
     "parse a response with chunked transfer encoding" in {
       val res = "HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\n\r\n3\r\nfoo\r\ne\r\n123456789abcde\r\n0\r\n\r\n"
       val parser = HttpResponseParser.static()
@@ -133,7 +133,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       val parsed = parser.parse(DataBuffer(ByteString(res))).get
       parsed.value.body.bytes must equal (ByteString("foo123456789abcde"))
     }
-      
+
 
   }
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/StreamingHttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/StreamingHttpResponseParserSpec.scala
@@ -148,7 +148,7 @@ class StreamingHttpResponseParserSpec extends ColossusSpec with MustMatchers wit
 
   private def validateEncodedStreamingHttpResponse(body : Option[ByteString]){
     val res = StreamingHttpResponse(
-      HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector("a"->"b", "content-length"->body.map{_.size.toString}.getOrElse("0"))), 
+      HttpResponseHead(HttpVersion.`1.1`, HttpCodes.OK, Vector("a"->"b", "content-length"->body.map{_.size.toString}.getOrElse("0"))),
       body.map{bod => Source.one(DataBuffer(bod))}
     )
     val clientProtocol = new StreamingHttpClientCodec

--- a/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheCommandSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheCommandSpec.scala
@@ -32,7 +32,7 @@ class MemcacheCommandSuite extends FlatSpec with ShouldMatchers{
     experimental.toString() should equal("replace key 0 30 5\r\nmagic\r\n")
     experimental.bytes(NoCompressor) should equal(ByteString("replace key 0 30 5\r\nmagic\r\n"))
   }
-  
+
   it should "format an APPEND correctly" in {
     val experimental = Append(ByteString("key"), ByteString("magic"))
     experimental.toString() should equal("append key 0 0 5\r\nmagic\r\n")

--- a/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheParserSpec.scala
@@ -23,7 +23,7 @@ class MemcacheParserSpec extends FlatSpec with ShouldMatchers{
     val reply = DataBuffer(ByteString(86, 65, 76, 85, 69, 32, 102, 111, 111, 32, 48, 32, 51, 13, 10, 104, 101, 108, 13, 10, 69, 78, 68, 13, 10))
     val p = new MemcacheReplyParser
     p.parse(reply) should equal (Some(Value(ByteString("foo"), ByteString("hel"), 0)))
-  } 
+  }
 
   it should "parse a single END as no data" in {
     val reply = DataBuffer(ByteString("END\r\n"))

--- a/colossus-tests/src/test/scala/colossus/protocols/redis/RedisParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/redis/RedisParserSpec.scala
@@ -147,7 +147,7 @@ class FastReplySuite extends FlatSpec with ShouldMatchers{
 
   it should "parse bulk reply in fragments" in {
     val reply = ByteString("$5\r\nabcde\r\n")
-    (1 until reply.size-1).foreach{i => 
+    (1 until reply.size-1).foreach{i =>
       val parser = replyParser
       val (p1, p2) = reply.splitAt(i)
       parser.parse(DataBuffer.fromByteString(p1)) should equal (None)

--- a/colossus-tests/src/test/scala/colossus/protocols/redis/ScatterGatherSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/redis/ScatterGatherSpec.scala
@@ -29,8 +29,8 @@ class ScatterGatherSpec extends WordSpec with MustMatchers{
       val s = new MGetScatterGather(mget, hasher)
       s.scatter
       val replies = Seq(
-        MBulkReply(List(BulkReply(ByteString("vb2")), BulkReply(ByteString("vb1")))), 
-        MBulkReply(List(BulkReply(ByteString("va1")), BulkReply(ByteString("va2")))), 
+        MBulkReply(List(BulkReply(ByteString("vb2")), BulkReply(ByteString("vb1")))),
+        MBulkReply(List(BulkReply(ByteString("va1")), BulkReply(ByteString("va2")))),
         MBulkReply(List(BulkReply(ByteString("vc1"))))
       )
       val expected = MBulkReply(mget.args.map{arg => BulkReply(ByteString("v" + arg.utf8String))})
@@ -48,8 +48,8 @@ class ScatterGatherSpec extends WordSpec with MustMatchers{
         "c" -> Command(CMD_MSET, "c1", "vc1")
       )
       new MSetScatterGather(mset, hasher).scatter must equal(expected)
-      
-      
+
+
     }
     "gather replies" in {
       //notice - right now mset gathering doesn't depend on scattering (unlike mget which needs the indices), that may eventually change

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -65,7 +65,7 @@ class WebsocketSpec extends ColossusSpec {
       val masked = DataBlock("abcd") ++ DataBlock(ByteString(41, 7, 15, 8, 14, 66, 52, 11, 19, 14, 7, 69).toArray)
       FrameParser.unmask(true, masked).byteString must equal(ByteString("Hello World!"))
     }
-    
+
     "parse a frame" in {
       val data = ByteString(-119, -116, 115, 46, 27, -120, 59, 75, 119, -28, 28, 14, 76, -25, 1, 66, 127, -87).toArray
       val expected = Frame(Header(OpCodes.Ping, true), DataBlock("Hello World!"))
@@ -104,7 +104,7 @@ class WebsocketSpec extends ColossusSpec {
 
 
   "WebsocketHandler" must {
-    //a simple codec to test decoding errors 
+    //a simple codec to test decoding errors
     trait CString extends Protocol {
       type Input = String
       type Output = String
@@ -112,13 +112,13 @@ class WebsocketSpec extends ColossusSpec {
 
     class CStringCodec extends FrameCodec[CString] {
       def encode(str: String): DataBlock = DataBlock(":" + str)
-      def decode(block: DataBlock): Try[String] = { 
-        val x = block.utf8String 
+      def decode(block: DataBlock): Try[String] = {
+        val x = block.utf8String
         if (x.startsWith(":")) {
           Success(x.drop(1))
         } else {
           Failure(new Exception("Bad formatting!"))
-        }      
+        }
       }
     }
 
@@ -177,8 +177,8 @@ class WebsocketSpec extends ColossusSpec {
       con.expectDisconnectAttempt()
     }
 
-      
-    
+
+
   }
 
   "WebsocketHttp" must {

--- a/colossus-tests/src/test/scala/colossus/service/LoadBalancingClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/LoadBalancingClientSpec.scala
@@ -26,7 +26,7 @@ trait PR extends Protocol {
 class LoadBalancingClientSpec extends ColossusSpec with MockitoSugar{
 
   type C = ServiceClient[PR]
-  
+
   def mockClient(address: InetSocketAddress, customReturn: Option[Try[Int]]): C = {
     val config = ClientConfig(
       address = address,
@@ -38,7 +38,7 @@ class LoadBalancingClientSpec extends ColossusSpec with MockitoSugar{
     when(c.send("hey")).thenReturn(Callback.complete(r))
     when(c.config).thenReturn(config)
     when(c.connectionState).thenReturn(core.ConnectionState.Connected(mock[core.WriteEndpoint]))
-    c        
+    c
   }
 
   def mockClient(port: Int, customReturn: Option[Try[Int]] = None): C = mockClient(new InetSocketAddress("0.0.0.0", port), customReturn)
@@ -71,12 +71,12 @@ class LoadBalancingClientSpec extends ColossusSpec with MockitoSugar{
 
 
     "evenly divide requests among clients" in {
-      (1 to 5).foreach{num => 
+      (1 to 5).foreach{num =>
         val ops = (1 to num).permutations.toList.size //lazy factorial
         val clients = addrs(num)
         val (probe, worker) = FakeIOSystem.fakeWorkerRef
         val l = new LoadBalancingClient[PR](worker, mockGenerator, maxTries = 2, initialClients = clients)
-        (1 to ops).foreach{i => 
+        (1 to ops).foreach{i =>
           l.send("hey").execute()
         }
         l.currentClients.foreach{case (i,c) =>
@@ -93,10 +93,10 @@ class LoadBalancingClientSpec extends ColossusSpec with MockitoSugar{
       val l = new LoadBalancingClient[PR](worker, staticClients(List(good, bad)), maxTries = 2, initialClients = addrs(2))
       //sending a bunch of commands ensures both clients are attempted as the first try at least once
       //the test succeeds if no exception is thrown
-      (1 to 10).foreach{i => 
+      (1 to 10).foreach{i =>
         l.send("hey").execute{
           case Success(_) => {}
-          case Failure(wat) => throw wat 
+          case Failure(wat) => throw wat
         }
       }
     }
@@ -123,7 +123,7 @@ class LoadBalancingClientSpec extends ColossusSpec with MockitoSugar{
       removed.connectionState.isInstanceOf[ConnectionState.ShuttingDown] must equal(true)
 
     }
-      
+
   }
 
   "ServiceClientPool" must {
@@ -138,8 +138,8 @@ class LoadBalancingClientSpec extends ColossusSpec with MockitoSugar{
         x.typedHandler
       }
     )
-    
-    
+
+
     "create and get a client" in {
       val p = pool
       val addr = new InetSocketAddress("1.2.3.4", 123)

--- a/colossus-tests/src/test/scala/colossus/service/RetryPolicySpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/RetryPolicySpec.scala
@@ -69,7 +69,7 @@ class RetryPolicySpec extends ColossusSpec {
       }
       i.nextAttempt() must equal(RetryIn(1.second))
     }
-      
+
 
 
   }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -147,7 +147,7 @@ class ServiceClientSpec extends ColossusSpec with MockFactory {
         Command(CMD_GET, "foo") -> BulkReply(ByteString("foo")),
         Command(CMD_GET, "123456789012345678901234567890") -> BulkReply(ByteString("big")),
         Command(CMD_DEL, "bar") -> IntegerReply(1)
-      
+
       )
       val (endpoint, client, probe) = newClient()
 
@@ -458,10 +458,10 @@ class ServiceClientSpec extends ColossusSpec with MockFactory {
       val msg = probe.receiveOne(500.milliseconds)
       msg mustBe a[WorkerCommand.Kill]
     }
-      
+
 
     "timeout requests while waiting to reconnect" taggedAs(org.scalatest.Tag("test")) in {
-      withIOSystem{ implicit io => 
+      withIOSystem{ implicit io =>
         val config = ClientConfig(
           name = "/test",
           requestTimeout = 100.milliseconds,
@@ -494,7 +494,7 @@ class ServiceClientSpec extends ColossusSpec with MockFactory {
       CallbackAwait.result(c.send(HttpRequest.get("/foo")), 1.second) mustBe resp
 
     }
-      
+
 
   }
 }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -33,7 +33,7 @@ class ServiceServerSpec extends ColossusSpec {
     def processRequest(input: ByteString) = handler(input)
 
     def receivedMessage(x: Any, s: ActorRef){}
-    
+
     def testCanPush = canPush //expose protected method
   }
 
@@ -165,7 +165,7 @@ class ServiceServerSpec extends ColossusSpec {
         }
       }
     }
-    
+
     "gracefully handle bad input" in {
       val t = fakeService()
       // this is above  max request size

--- a/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/util/CombinatorSpec.scala
@@ -231,7 +231,7 @@ class CombinatorSuite extends WordSpec with MustMatchers{
       }
     }
 
-      
+
 
 
   }
@@ -292,5 +292,5 @@ class CombinatorSuite extends WordSpec with MustMatchers{
   }
 
 }
-      
+
 

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -95,16 +95,16 @@ extends CoreHandler(context) with InputController[Input, Output] with OutputCont
     outputGracefulDisconnect()
     checkControllerGracefulDisconnect()
   }
-  
+
   def fatalInputError(reason: Throwable) = {
-    
+
     processBadRequest(reason).foreach { output =>
       push(output) { _ => {} }
     }
     disconnect()
     //throw reason
   }
-  
+
   /**
    * Checks the status of the shutdown procedure.  Only when both the input and
    * output sides are terminated do we call shutdownRequest on the parent
@@ -118,7 +118,7 @@ extends CoreHandler(context) with InputController[Input, Output] with OutputCont
         //can happen when disconnect is called before being connected
         super.shutdown()
       }
-      case _ => {} 
+      case _ => {}
     }
   }
 

--- a/colossus/src/main/scala/colossus/controller/InputController.scala
+++ b/colossus/src/main/scala/colossus/controller/InputController.scala
@@ -8,7 +8,7 @@ import colossus.service.{DecodedResult, NotConnectedException}
 
 sealed trait InputState
 object InputState {
-  
+
   /**
    * The controller is waiting for more data to begin or continue decoding a message
    */
@@ -45,7 +45,7 @@ class InvalidInputStateException(state: InputState) extends Exception(s"Invalid 
  * - Terminating the stream at any point kills the connection
  * - Closing a stream outside of a pull callback will kill the connection without logging the error
  * - Closing a stream inside of a pull callback will complete the stream and the controller will resset
- * 
+ *
  */
 trait InputController[Input, Output] extends MasterController[Input, Output] {
   import InputState._
@@ -56,8 +56,8 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
   //maybe not
   private var _readsEnabled = true
   def readsEnabled = _readsEnabled
-  
-  
+
+
   //this has to be lazy to avoid initialization-order NPE
   lazy val inputSizeHistogram = if (controllerConfig.metricsEnabled) {
     Some(Histogram("input_size", sampleRate = 0.10, percentiles = List(0.75,0.99)))
@@ -191,7 +191,7 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
         case PushResult.Filled(trigger) => connectionState match {
           case a: AliveState => {
             a.endpoint.disableReads()
-            trigger.fill{() => 
+            trigger.fill{() =>
               resumeReads()
               inputState = ReadingStream(sink)
             }
@@ -214,11 +214,11 @@ trait InputController[Input, Output] extends MasterController[Input, Output] {
       case other => throw new InvalidInputStateException(other)
     }
   }
-  
+
   protected def fatalInputError(reason: Throwable)
 
   protected def processMessage(message: Input)
-  
+
   protected def processBadRequest(reason: Throwable): Option[Output] = None
 
 }

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -176,7 +176,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
    * messages to either get sent or timeout
    */
   private[controller] def outputGracefulDisconnect() {
-    manualDisconnect = true 
+    manualDisconnect = true
     outputState match {
       case a : AliveOutputState => {
         checkOutputGracefulDisconnect()
@@ -191,7 +191,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
     }
   }
 
-  
+
   /**
    * returns true if the state is switched to Terminated
    */
@@ -238,7 +238,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
 
   protected def canPush = outputState.canPush && !msgq.isFull
 
-  private def drainSource(){ 
+  private def drainSource(){
     outputState match {
       case Streaming(source, dataQ, post) => source.pull {
         case Success(Some(data)) => {
@@ -262,7 +262,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
 
 
   /** Purge all pending messages
-   * 
+   *
    * If a message is currently being written, it is not affected
    */
   protected def purgePending(reason: Throwable) {
@@ -350,7 +350,7 @@ trait OutputController[Input, Output] extends MasterController[Input, Output] {
       case _ => MoreDataResult.Complete
     }
   }
-        
+
   def idleCheck(period: FiniteDuration): Unit = {
     val time = System.currentTimeMillis
     while (!msgq.isEmpty && msgq.head.isTimedOut(time, controllerConfig.sendTimeout)) {

--- a/colossus/src/main/scala/colossus/controller/Pipe.scala
+++ b/colossus/src/main/scala/colossus/controller/Pipe.scala
@@ -81,14 +81,14 @@ trait Source[T] extends Transport {
       case None => Callback.successful(init)
       }
   }
-    
+
 
   def ++(next: Source[T]): Source[T] = new DualSource(this, next)
 
 }
 
 abstract class Generator[T] extends Source[T] {
-  
+
   private var _terminated: Option[Throwable] = None
   private var _closed = false
 
@@ -204,7 +204,7 @@ object PushResult {
 }
 
 /** A pipe designed to accept a fixed number of bytes
- * 
+ *
  * BE AWARE: when pushing buffers into this pipe, if the pipe completes, the
  * buffer may still contain unread data meant for another consumer
  */
@@ -233,7 +233,7 @@ class FiniteBytePipe(totalBytes: Long) extends InfinitePipe[DataBuffer] {
         }
         //need to get this value here, since remaining might be 0 after call
         val toAdd = partial.remaining
-        val res = super.push(partial) 
+        val res = super.push(partial)
         if (res.isInstanceOf[PushResult.Pushed]) {
           taken += toAdd
           if (taken == totalBytes) {
@@ -322,7 +322,7 @@ class InfinitePipe[T] extends Pipe[T, T] {
    * The value will only be successfully pushed only if there has already a
    * been a request for data on the pulling side.  In other words, the pipe
    * will never interally queue a value.
-   * 
+   *
    * @return the result of the push
    * @throws PipeException when pushing to a full pipe
    */
@@ -351,9 +351,9 @@ class InfinitePipe[T] extends Pipe[T, T] {
     case Closed       => PushResult.Closed
     case Pulling(cb)  => throw new PipeStateException("This should never happen")
   }
-  
+
   /** Request the next value from the pipe
-   * 
+   *
    * Only one value can be requested at a time.  Also there can only be one
    * outstanding request at a time.
    *
@@ -368,15 +368,15 @@ class InfinitePipe[T] extends Pipe[T, T] {
       trig.trigger()
     }
   }
-      
-    
+
+
   def complete() {
     val oldstate = state
     state = Closed
     oldstate match {
       case Full(trig)   => trig.trigger()
       case Pulling(cb)  => cb(Success(None))
-      case Dead(reason) => throw new PipeTerminatedException(reason) 
+      case Dead(reason) => throw new PipeTerminatedException(reason)
       case _ => {}
     }
   }

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -64,7 +64,7 @@ trait ConnectionInfo {
    * The address of the remote host for this connection, if connected
    */
   def remoteAddress: Option[InetSocketAddress]
-  
+
 }
 
 /**
@@ -143,7 +143,7 @@ abstract class Connection(val id: Long, initialHandler: ConnectionHandler, val w
       }
     }
   }
-    
+
   val startTime = System.currentTimeMillis
 
   def remoteAddress: Option[InetSocketAddress] = None
@@ -208,7 +208,7 @@ abstract class Connection(val id: Long, initialHandler: ConnectionHandler, val w
       //request, so it should have something to write
       val more  = handler.readyForData(data)
       val toWrite = data.data
-      
+
       //its possible for the handler to not actually have written anything, this
       //can occur due to the fact that we use the writeReady flag to track both
       //pending data from the handler and from the partial buffer, so we can end up
@@ -258,7 +258,7 @@ abstract class Connection(val id: Long, initialHandler: ConnectionHandler, val w
 /**
  * This mixin is used with all real connections, not in tests
  */
-private[core] trait LiveConnection extends ChannelActions { self: Connection => 
+private[core] trait LiveConnection extends ChannelActions { self: Connection =>
 
   protected def channel: SocketChannel
   def key: SelectionKey
@@ -304,7 +304,7 @@ private[core] trait LiveConnection extends ChannelActions { self: Connection =>
 }
 
 abstract class ServerConnection(
-  id: Long, 
+  id: Long,
   handler: ServerConnectionHandler,
   val server: ServerRef,
   worker: WorkerRef
@@ -327,7 +327,7 @@ abstract class ServerConnection(
 }
 
 abstract class ClientConnection(
-  id: Long, 
+  id: Long,
   val clientHandler: ClientConnectionHandler,
   worker: WorkerRef
 )  extends Connection(id, clientHandler, worker) {

--- a/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionHandler.scala
@@ -81,7 +81,7 @@ trait ServerConnectionHandler extends ConnectionHandler {}
 
 
 /**
- * ClientConnectionHandler is a trait meant to be used with outgoing connections.  
+ * ClientConnectionHandler is a trait meant to be used with outgoing connections.
  */
 trait ClientConnectionHandler extends ConnectionHandler {
 

--- a/colossus/src/main/scala/colossus/core/ConnectionLimiter.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionLimiter.scala
@@ -64,7 +64,7 @@ case class ConnectionLimiterConfig(enabled: Boolean, initial: Int, duration: Fin
 
 object ConnectionLimiterConfig {
   import colossus.metrics.ConfigHelpers._
-  
+
   def fromConfig(config: Config): ConnectionLimiterConfig = {
     val enabled   = config.getBoolean("enabled")
     val initial   = config.getInt("initial")

--- a/colossus/src/main/scala/colossus/core/ConnectionSnapshot.scala
+++ b/colossus/src/main/scala/colossus/core/ConnectionSnapshot.scala
@@ -27,6 +27,6 @@ case class ConnectionSnapshot(
 ) {
 
   def timeIdle = math.min(readIdle, writeIdle)
-  
+
 }
 

--- a/colossus/src/main/scala/colossus/core/CoreHandler.scala
+++ b/colossus/src/main/scala/colossus/core/CoreHandler.scala
@@ -1,7 +1,7 @@
 package colossus.core
 
 sealed abstract class ShutdownAction(val rank: Int) {
-  
+
   def >=(a: ShutdownAction): Boolean = rank >= a.rank
 
 }

--- a/colossus/src/main/scala/colossus/core/DataBlock.scala
+++ b/colossus/src/main/scala/colossus/core/DataBlock.scala
@@ -17,7 +17,7 @@ import akka.util.ByteString
  */
 
 case class DataBlock(data: Array[Byte]) {
-  
+
   def size = data.length
   def length = data.length
 

--- a/colossus/src/main/scala/colossus/core/DataOutBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/DataOutBuffer.scala
@@ -57,7 +57,7 @@ trait DataOutBuffer {
  * buffer to avoid copying
  */
 class DynamicOutBuffer(baseSize: Int, allocateDirect: Boolean = true) extends DataOutBuffer {
-  
+
   private val base = if (allocateDirect) {
     ByteBuffer.allocateDirect(baseSize)
   } else {

--- a/colossus/src/main/scala/colossus/core/Delegator.scala
+++ b/colossus/src/main/scala/colossus/core/Delegator.scala
@@ -25,7 +25,7 @@ abstract class Delegator(val server: ServerRef,  _worker: WorkerRef) {
 
   //this is so users can do import context.worker
   implicit val worker = _worker
-  
+
   val log = Logging(worker.system.actorSystem, s"${server.name}-delegator-${worker.id}")
 
   implicit val executor = server.system.actorSystem.dispatcher

--- a/colossus/src/main/scala/colossus/core/RetryPolicy.scala
+++ b/colossus/src/main/scala/colossus/core/RetryPolicy.scala
@@ -69,7 +69,7 @@ case class IncidentReport(totalTime: FiniteDuration, totalAttempts: Int)
  * operation is and takes no action itself, but instead is used by the performer
  * of the operation as a control flow mechanism.  For example, when a
  * [[colossus.service.ServiceClient]] fails to connect to its target host, it
- * will create a new `RetryIncident` from it's given [[RetryPolicy]].  
+ * will create a new `RetryIncident` from it's given [[RetryPolicy]].
  *
  * On each successive failure of the operation, a call to [[nextAttempt()]]
  * should be made that will return a `RetryAttempt` indicating what action
@@ -110,7 +110,7 @@ object BackoffMultiplier {
 
   def fromConfig(config: Config) = {
     val mtype = config.getString("type").toUpperCase
-    mtype match { 
+    mtype match {
       case "CONSTANT"     => Constant
       case "LINEAR"       => Linear(config.getFiniteDuration("max"))
       case "EXPONENTIAL"  => Exponential(config.getFiniteDuration("max"))
@@ -126,7 +126,7 @@ object BackoffMultiplier {
   }
 
   trait IncreasingMultiplier extends BackoffMultiplier {
-    
+
     def max: FiniteDuration
 
     //needed to avoid possible out-of-range issue with FiniteDuration
@@ -139,7 +139,7 @@ object BackoffMultiplier {
         val i = increaseValue(base, attempt)
         if (i > max) {
           hitMax = true
-          max 
+          max
         } else {
           i
         }
@@ -206,7 +206,7 @@ case class BackoffPolicy(
     def nextAttempt() = {
       val now = System.currentTimeMillis
       if (
-        maxTime.map{t => start + t.toMillis < now}.getOrElse(false) || 
+        maxTime.map{t => start + t.toMillis < now}.getOrElse(false) ||
         maxTries.map{_ <= attempt}.getOrElse(false)
       ) {
         Stop
@@ -230,7 +230,7 @@ case class BackoffPolicy(
  * A [[RetryPolicy]] that will never retry
  */
 case object NoRetry extends RetryPolicy with RetryIncident {
-  
+
   def start() = this
 
   def attempts = 1

--- a/colossus/src/main/scala/colossus/core/Server.scala
+++ b/colossus/src/main/scala/colossus/core/Server.scala
@@ -461,7 +461,7 @@ private[colossus] class Server(io: IOSystem, serverConfig: ServerConfig,
 
 /**
  * Represents the startup status of the server.
- *  
+ *
  *  - `Initializing` : The server was just started and is registering with the IOSystem
  *  - `Binding` : The server is registered and in the process of binding to its port
  *  - `Bound` : The server is actively listening on the port and accepting connections
@@ -496,7 +496,7 @@ object Server extends ServerDSL {
   case class ConnectionClosed(id: Long, cause : RootDisconnectCause)
 
   /** Sent from a worker to the server when the server is not registered with the worker.
-   * 
+   *
    * This generally happens when a worker has just been killed and restarted.  See Server.MaxConnectionRegisterAttempts
    */
   private[core] case class ConnectionRefused(channel: SocketChannel, attempt: Int)

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -403,13 +403,13 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
   }
 
   /** Removes a closed connection and possibly unbinds the associated Connection Handler
-    * 
+    *
     * In general, the only time we don't want to unbind the handler is when the
     * connection is a client connection with the ManualUnbindHandler mixed in
     * and the disconnect cause is an error.  This allows the client to possibly
     * reconnect and still receive messages.
     *
-    * Here's the table 
+    * Here's the table
     *
     *   Server/Client   ManualUnbindHandler   DisconnectError   Unbind?
     *         S                 -                   -             Y

--- a/colossus/src/main/scala/colossus/core/WorkerItem.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerItem.scala
@@ -151,20 +151,20 @@ trait IdleCheck extends WorkerItem {
 /**
  * This is a mixin for [[WorkerItem]] that gives it actor-like capabilities.  A
  * "proxy" Akka actor is spun up, such that any message sent to the proxy will
- * be relayed to the WorkerItem.  
+ * be relayed to the WorkerItem.
  *
  * The proxy actors lifecycle will be linked to the lifecycle of this
  * workeritem, so if the actor is kill, the `shutdownRequest` method will be
  * invoked, and likewise if this item is unbound the proxy actor will be killed.
  */
-trait ProxyActor extends WorkerItem { 
-  
+trait ProxyActor extends WorkerItem {
+
   import ProxyActor._
-  
+
   implicit val self : ActorRef = context.proxy
 
   private var currentReceiver : Receive = receive
-    
+
   def becomeReceive(receive: Receive) {
     currentReceiver = receive
   }
@@ -183,7 +183,7 @@ trait ProxyActor extends WorkerItem {
       self ! WorkerItemProxy.Unbound
     }
   }
-    
+
   private var lastSender = ActorRef.noSender
   private var killedByProxy = false
   def sender() : ActorRef = lastSender

--- a/colossus/src/main/scala/colossus/core/WorkerManager.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerManager.scala
@@ -188,7 +188,7 @@ extends Actor with ActorLogging with Stash {
     }
     def retryRegister(message: String) = {
       val incident = retry.getOrElse(server.config.settings.delegatorCreationPolicy.retryPolicy.start())
-      val fullMessage = s"Failed to register server ${server.name} after ${incident.attempts} attempts:" 
+      val fullMessage = s"Failed to register server ${server.name} after ${incident.attempts} attempts:"
       incident.nextAttempt() match {
         case RetryAttempt.Stop => {
           log.error(s"$fullMessage, aborting")

--- a/colossus/src/main/scala/colossus/core/WriteBuffer.scala
+++ b/colossus/src/main/scala/colossus/core/WriteBuffer.scala
@@ -18,7 +18,7 @@ object WriteStatus {
 }
 
 /**
- * This trait abstracts actions performed on a raw socket channel.  
+ * This trait abstracts actions performed on a raw socket channel.
  *
  * This is essentially the only trait that should differ between live
  * connections and fake connections in testing
@@ -136,7 +136,7 @@ private[colossus] trait WriteBuffer extends KeyInterestManager {
       }
     } catch {
       case t: CancelledKeyException => {
-        //no cleanup is required since the connection is closed for good, 
+        //no cleanup is required since the connection is closed for good,
         Failed
       }
     }

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -64,7 +64,7 @@ object HttpMethod {
       case head :: tail => if (head.name == ucase) head else loop(tail)
       case Nil => throw new ParseException(s"Invalid http method $str")
     }
-    loop(methods)    
+    loop(methods)
   }
 }
 
@@ -103,7 +103,7 @@ object HttpHeader {
   private val ContentLengthKey = ByteString("Content-Length: ")
   private val ContentLengthKeyArray = ContentLengthKey.toArray
 
-  /** 
+  /**
    * Directly write a content-length header to a buffer.  Note that this does
    * NOT write the terminating newline
    */
@@ -139,7 +139,7 @@ object HttpHeader {
   def apply(key: String, value: String) : HttpHeader = new EncodedHttpHeader((key + ": " + value + "\r\n").getBytes("UTF-8"))
 
   implicit object FPHZero extends parsing.Zero[EncodedHttpHeader] {
-    def isZero(t: EncodedHttpHeader) = t.data.size == 2 //just the /r/n 
+    def isZero(t: EncodedHttpHeader) = t.data.size == 2 //just the /r/n
   }
 
 }
@@ -193,7 +193,7 @@ class ParsedHttpHeaders(
 
 }
 
-    
+
 
 /**
  * A Wrapper class for a set of Http headers, for a request or response.
@@ -214,7 +214,7 @@ class HttpHeaders(private val headers: JList[HttpHeader]) {
   }
 
   /** Returns the value of the content-length header, if it exists.
-   * 
+   *
    * Be aware that lacking this header may or may not be a valid request,
    * depending if the "transfer-encoding" header is set to "chunked"
    */
@@ -406,7 +406,7 @@ class DateHeader(start: Long = System.currentTimeMillis) extends HttpHeader {
   import java.text.SimpleDateFormat
 
   private val formatter = new SimpleDateFormat(DateHeader.DATE_FORMAT)
-  
+
   private def generate(time: Long) = HttpHeader("Date", formatter.format(new Date(time)))
   private var lastDate = generate(start)
   private var lastTime = start

--- a/colossus/src/main/scala/colossus/protocols/http/HttpBody.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpBody.scala
@@ -86,9 +86,9 @@ trait HttpBodyEncoders {
 }
 
 object HttpBody extends HttpBodyEncoders {
-  
+
   val NoBody = new HttpBody(Array(), None)
-  
+
   def apply[T](data: T)(implicit encoder: HttpBodyEncoder[T]): HttpBody = encoder.encode(data)
 
   def apply[T](data: T, contentType: String)(implicit encoder: HttpBodyEncoder[T]) = {

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -5,7 +5,7 @@ import scala.language.higherKinds
 import service._
 import scala.concurrent.{ExecutionContext, Future}
 
-trait HttpClient[M[_]]  extends LiftedClient[Http, M] with HttpRequestBuilder[M[HttpResponse]]{ //self: LiftedClient[Http, M] => 
+trait HttpClient[M[_]]  extends LiftedClient[Http, M] with HttpRequestBuilder[M[HttpResponse]]{ //self: LiftedClient[Http, M] =>
 
   protected def build(req: HttpRequest) = client.send(req)
 
@@ -19,7 +19,7 @@ trait HttpClient[M[_]]  extends LiftedClient[Http, M] with HttpRequestBuilder[M[
 object HttpClient {
 
   implicit object HttpClientLifter extends ClientLifter[Http, HttpClient] {
-    
+
     def lift[M[_]](client: Sender[Http,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with HttpClient[M]
   }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpParse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpParse.scala
@@ -48,7 +48,7 @@ object HttpParse {
       if (co.isEmpty && header.matches(HttpHeaders.Connection)) {
         co = Some(Connection(header.value))
       }
-      
+
       this
     }
 
@@ -56,7 +56,7 @@ object HttpParse {
     def buildHeaders: ParsedHttpHeaders = {
       new ParsedHttpHeaders(build.asInstanceOf[java.util.List[HttpHeader]], te, cl, co) //silly invariant java collections :/
     }
-    
+
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequest.scala
@@ -41,7 +41,7 @@ trait HttpRequestHead extends Encoder {
   def headers: HttpHeaders
 
   def copy(
-    method  : HttpMethod  = firstLine.method, 
+    method  : HttpMethod  = firstLine.method,
     path    : String      = firstLine.path,
     version : HttpVersion = firstLine.version,
     headers : HttpHeaders = headers
@@ -103,7 +103,7 @@ trait HttpRequestHead extends Encoder {
 }
 
 object HttpRequestHead {
-  
+
   def apply(method: HttpMethod, url: String, version: HttpVersion, headers: HttpHeaders): HttpRequestHead = {
     BuiltHead(BuildFL(method, url, version), headers)
   }
@@ -138,7 +138,7 @@ case class HttpRequest(head: HttpRequestHead, body: HttpBody) extends Encoder wi
       buffer write HttpParse.N2
       body encode buffer
     }
-      
+
   }
 
 }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
@@ -7,7 +7,7 @@ import Combinators._
 
 object HttpRequestParser {
   import HttpParse._
-  
+
   def apply() = httpRequest
 
   //TODO : don't parse body as a bytestring
@@ -22,11 +22,11 @@ object HttpRequestParser {
   }
 
   protected def httpHead = firstLine ~ headers >> {case fl ~ headersBuilder =>
-    ParsedHead(fl, headersBuilder.buildHeaders) 
+    ParsedHead(fl, headersBuilder.buildHeaders)
   }
 
   def firstLine = line(ParsedFL.apply, true)
-  
+
 }
 
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpResponse.scala
@@ -75,9 +75,9 @@ object HttpResponseHead{
     HttpResponseHead(BasicResponseFL(version, code), headers)
   }
 }
-  
 
-sealed trait BaseHttpResponse { 
+
+sealed trait BaseHttpResponse {
 
   def head: HttpResponseHead
 
@@ -173,13 +173,13 @@ case class StreamingHttpResponse(head: HttpResponseHead, body: Option[Source[Dat
     builder write NEWLINE_ARRAY
 
     val headerBytes = builder.data
-    body.map{stream => 
+    body.map{stream =>
       DataStream(new DualSource[DataBuffer](Source.one(headerBytes), stream))
     }.getOrElse(headerBytes)
 
   }
 
-  def resolveBody: Option[Callback[ByteString]] = body.map{data => 
+  def resolveBody: Option[Callback[ByteString]] = body.map{data =>
     data.fold(new ByteStringBuilder){(buffer: DataBuffer, builder: ByteStringBuilder) => builder.putBytes(buffer.takeAll)}.map{_.result}
   }
 
@@ -195,7 +195,7 @@ object StreamingHttpResponse {
 
   def apply[T : HttpBodyEncoder](version : HttpVersion, code : HttpCode, headers : HttpHeaders, data : T) : StreamingHttpResponse = {
     fromStatic(HttpResponse(
-      HttpResponseHead(version, code, headers), 
+      HttpResponseHead(version, code, headers),
       HttpBody(data)
     ))
   }

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -40,8 +40,8 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
         case IrrecoverableError(reason) =>
           HttpResponse(HttpResponseHead(HttpVersion.`1.1`, HttpCodes.BAD_REQUEST,  HttpHeaders.Empty), HttpBody("Bad Request"))
       }
-        
-        
+
+
 
     }
 
@@ -51,7 +51,7 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
     }
 
     object defaults  {
-      
+
       implicit val httpServerDefaults = new ServerDefaults
 
       implicit val httpClientDefaults = new ClientDefaults
@@ -80,7 +80,7 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
 
   abstract class HttpService(config: ServiceConfig, context: ServerContext)
   extends BaseHttpServiceHandler[Http](config, Http.defaults.httpServerDefaults, context) {
-      
+
     def this(context: ServerContext) = this(ServiceConfig.load(context.server.name.idString), context)
   }
 
@@ -101,9 +101,9 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
         toStreamed(
           HttpResponse(HttpResponseHead(HttpVersion.`1.1`, HttpCodes.BAD_REQUEST,  HttpHeaders.Empty), HttpBody("Bad Request"))
         )
-      
+
     }
-      
+
 
     private def toStreamed(response : HttpResponse) : StreamingHttpResponse = {
       StreamingHttpResponse.fromStatic(response)

--- a/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
@@ -115,9 +115,9 @@ import scala.language.higherKinds
   }
   object MemcacheClient {
 
-  
+
     implicit object MemcacheClientLifter extends ClientLifter[Memcache, MemcacheClient] {
-      
+
       def lift[M[_]](client: Sender[Memcache,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with MemcacheClient[M]
     }
 

--- a/colossus/src/main/scala/colossus/protocols/redis/Command.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/Command.scala
@@ -35,7 +35,7 @@ case class Command(command: String, args: Seq[ByteString]) {
 }
 
 object Command {
-  
+
   def apply(args: String*): Command = {
     Command(args.head, args.tail.map{ByteString(_)})
   }

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
@@ -404,7 +404,7 @@ trait RedisClient[M[_]] extends LiftedClient[Redis, M] {
    * Additional arguments for this function are the limit/offset/count options.
    *
    * http://redis.io/commands/zrangebyscore
-   * 
+   *
    * @param key
    * @param min
    * @param max
@@ -498,7 +498,7 @@ trait RedisClient[M[_]] extends LiftedClient[Redis, M] {
 object RedisClient {
 
   implicit object RedisClientLifter extends ClientLifter[Redis, RedisClient] {
-    
+
     def lift[M[_]](client: Sender[Redis,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with RedisClient[M]
   }
 

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisReplyParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisReplyParser.scala
@@ -10,7 +10,7 @@ object RedisReplyParser {
   import Combinators._
 
   def apply(): Parser[Reply] = reply
-  
+
 
   def reply: Parser[Reply] = byte |> {
     case BULK_BYTE    => bulkReply
@@ -26,7 +26,7 @@ object RedisReplyParser {
   }
 
   protected def statusReply = stringReply >> {s => StatusReply(s)}
-  
+
   protected def errorReply = stringReply >> {s => ErrorReply(s)}
 
   protected def integerReply = intUntil('\r') <~ byte >> {i => IntegerReply(i)}

--- a/colossus/src/main/scala/colossus/protocols/redis/ScatterGather.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/ScatterGather.scala
@@ -39,7 +39,7 @@ object ScatterGather {
       argIndex += 1
       i += groupSize
     }
-        
+
     i = 0
     val res = shardCommands.map{case (shard, args) =>
       val s = Command(cmd.utf8String, args)
@@ -93,7 +93,7 @@ class MGetScatterGather[T](orig: Command, hasher: CommandHasher[T]) extends Scat
 
 class MSetScatterGather[T](orig: Command, hasher: CommandHasher[T]) extends ScatterGather[T]{
   val MSET_BYTES = ByteString("MSET")
-  
+
   def scatter: Seq[(T,Command)] = {
     val (i, s) = ScatterGather.scatterGrouped(orig.args, hasher, MSET_BYTES, 2)
     s

--- a/colossus/src/main/scala/colossus/protocols/telnet/Telnet.scala
+++ b/colossus/src/main/scala/colossus/protocols/telnet/Telnet.scala
@@ -57,13 +57,13 @@ package object telnet {
           argBuilder = new StringBuilder
         }
       }
-          
+
 
       def result = TelnetCommand(args.reverse)
     }
 
     var builder: Builder = new Builder
-    
+
 
     def parse(data: DataBuffer): Option[TelnetCommand] = {
       var line: Option[TelnetCommand] = None
@@ -108,7 +108,7 @@ package object telnet {
           builder.argBuilder.append(next.toChar)
         }
       }
-      line        
+      line
     }
   }
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/SubProtocol.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/SubProtocol.scala
@@ -17,7 +17,7 @@ trait FrameCodec[P <: Protocol] {
 object subprotocols {
 
   object rawstring {
-    
+
     trait RawString extends Protocol {
       type Input = String
       type Output = String
@@ -35,7 +35,7 @@ object subprotocols {
 }
 
 trait FrameCodecProvider[P <: Protocol] {
-  
+
   def provideCodec(): FrameCodec[P]
 
 }

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -16,7 +16,7 @@ object UpgradeRequest {
   import protocols.http._
 
   val salt = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11" //GUID for websocket
-  
+
   val b64 = new BASE64Encoder
 
   def processKey(key: String): String = {
@@ -25,7 +25,7 @@ object UpgradeRequest {
     digest.update((key + salt).getBytes("UTF-8"))
     new String(b64.encode(digest.digest()))
   }
-  
+
 
   /**
    * Validate a HttpRequest as a websocket upgrade request, returning the
@@ -34,12 +34,12 @@ object UpgradeRequest {
   def validate(request : HttpRequest): Option[HttpResponse] = {
     val headers = request.head.headers
     for {
-      cheader   <- headers.firstValue("connection") 
-      uheader   <- headers.firstValue("upgrade") 
+      cheader   <- headers.firstValue("connection")
+      uheader   <- headers.firstValue("upgrade")
       host      <- headers.firstValue("host")
       origin    <- headers.firstValue("origin")
       seckey    <- headers.firstValue("sec-websocket-key")
-      secver    <- headers.firstValue("sec-websocket-version") 
+      secver    <- headers.firstValue("sec-websocket-version")
       if (request.head.version  == HttpVersion.`1.1`)
       if (request.head.method   == HttpMethod.Get)
       if (secver == "13")
@@ -56,7 +56,7 @@ object UpgradeRequest {
         )
       ),
       HttpBody.NoBody
-    )      
+    )
   }
 }
 
@@ -72,7 +72,7 @@ object OpCodes {
   val Pong      = 0x0A.toByte
 
   def fromHeaderByte(b: Byte) = b & 0x0F
-  
+
   implicit val byteOrder = java.nio.ByteOrder.BIG_ENDIAN
 
 }
@@ -149,9 +149,9 @@ object FrameParser {
     val payload = data.drop(4)
     Frame.mask(mask, payload)
   }
-  
 
-  
+
+
   //see https://tools.ietf.org/html/rfc6455#section-5.2
   def frame = bytes(2) |> {head =>
     val opcode = head(0) & 0x0F
@@ -236,7 +236,7 @@ object WebsocketHandler {
   val NoopPostWrite: OutputResult => Unit = _ => ()
 }
 
- 
+
 abstract class WebsocketServerHandler[P <: Protocol](serverContext: ServerContext, config: ControllerConfig)(implicit provider: FrameCodecProvider[P])
 extends WebsocketHandler[P](serverContext.context, config)(provider) with ServerConnectionHandler {
 
@@ -281,11 +281,11 @@ object WebsocketServer {
    */
   def start(name: String, port: Int, upgradePath: String = "/")(init: WorkerRef => WebsocketInitializer)(implicit io: IOSystem) = {
     Server.start(name, port){worker => new Initializer(worker) {
-    
+
       val websockinit : WebsocketInitializer = init(worker)
 
       def onConnect = new WebsocketHttpHandler(_, websockinit, upgradePath)
-      
+
     }}
   }
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/package.scala
@@ -27,7 +27,7 @@ import java.util.Random
 package object websocket {
 
   class WebsocketCodec extends Codec[Frame, Frame]{
-    
+
     private val random = new Random
     private val parser = FrameParser.frame
 
@@ -48,7 +48,7 @@ package object websocket {
     def provideCodec() = new WebsocketCodec
 
   }
-    
+
 
 }
 

--- a/colossus/src/main/scala/colossus/service/Async.scala
+++ b/colossus/src/main/scala/colossus/service/Async.scala
@@ -23,7 +23,7 @@ trait Sender[C <: Protocol, M[_]] {
  * A Typeclass for abstracting over callbacks and futures
  */
 trait Async[M[_]] {
-  
+
   //the environment type is really only needed by futures (the execution context
   //when mapping and flatmapping)
   type E
@@ -43,7 +43,7 @@ trait Async[M[_]] {
 
 /**
  * A Typeclass for building Async instances, used internally by ClientFactory.
- * This is needed to get the environment into the Async.  
+ * This is needed to get the environment into the Async.
  */
 trait AsyncBuilder[M[_], E] {
 
@@ -63,7 +63,7 @@ object AsyncBuilder {
 
 
 object CallbackAsync extends Async[Callback] {
-  
+
   type E = Unit //we don't actually need any environment for callbacks
 
   implicit val environment: E = ()

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 
 
 class ProxyWatchdog(proxy: ActorRef, signal: AtomicBoolean) extends Actor {
-  
+
   override def preStart() {
     context.watch(proxy)
   }

--- a/colossus/src/main/scala/colossus/service/Callback.scala
+++ b/colossus/src/main/scala/colossus/service/Callback.scala
@@ -222,7 +222,7 @@ case class ConstantCallback[O](value: Try[O]) extends Callback[O] {
   def mapTry[U](f: Try[O] => Try[U]): Callback[U] = try { ConstantCallback(f(value)) } catch {
     case t: Throwable => ConstantCallback(Failure(t))
   }
-  
+
 
   def recover[U >: O](p: PartialFunction[Throwable, U]): Callback[U] = ConstantCallback(value.recover(p))
 

--- a/colossus/src/main/scala/colossus/service/Codec.scala
+++ b/colossus/src/main/scala/colossus/service/Codec.scala
@@ -36,7 +36,7 @@ trait Codec[Output,Input] {
 
   def encode(out: Output): DataReader
   /**
-   * Decode a single object from a bytestream.  
+   * Decode a single object from a bytestream.
    */
   def decode(data: DataBuffer): Option[DecodedResult[Input]]
 

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -127,7 +127,7 @@ class StaleClientException(msg : String) extends Exception(msg)
 
 sealed trait ClientState
 object ClientState {
-  
+
 
   case object Initializing  extends ClientState
   case object Connecting    extends ClientState
@@ -221,7 +221,7 @@ with ClientConnectionHandler with Sender[P, Callback] with ManualUnbindHandler {
       log.info(s"client $id connecting to $address")
       worker ! Connect(address, id)
       clientState = ClientState.Connecting
-      
+
     }else{
       throw new StaleClientException("This client has already been manually disconnected and cannot be reused, create a new one.")
     }

--- a/colossus/src/main/scala/colossus/service/ServiceClientPool.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClientPool.scala
@@ -47,7 +47,7 @@ class ServiceClientPool[T <: Sender[_, Callback]](val commonConfig: ClientConfig
   }
 
   def get(address: InetSocketAddress) = clients.get(address)
-  
+
 
 }
 

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -125,7 +125,7 @@ with ServerConnectionHandler {
   def tagDecorator: TagDecorator[I,O] = TagDecorator.default[I,O]
   def requestLogFormat : Option[RequestFormatter[I]] = None
 
-  
+
   private val requests  = Rate("requests", "connection-handler-requests")
   private val latency   = Histogram("latency", "connection-handler-latency")
   private val errors    = Rate("errors", "connection-handler-errors")
@@ -188,7 +188,7 @@ with ServerConnectionHandler {
 
     }
   }
-    
+
   /**
    * Pushes the completed responses down to the controller so they can be returned to the client.
    */
@@ -276,7 +276,7 @@ with ServerConnectionHandler {
       case Failure(err) => promise.complete(handleFailure(RecoverableError(promise.request, err)))
     }
   }
-  
+
   override def processBadRequest(reason: Throwable) = {
     Some(handleFailure(IrrecoverableError(reason)))
   }
@@ -303,9 +303,9 @@ with ServerConnectionHandler {
   protected def processRequest(request: I): Callback[O]
 
   //DO NOT CALL THIS METHOD INTERNALLY, use handleFailure!!
- 
+
   protected def processFailure(error: ProcessingFailure[I]): O
-  
+
 }
 
 sealed trait ProcessingFailure[C] {

--- a/colossus/src/main/scala/colossus/service/TagDecorator.scala
+++ b/colossus/src/main/scala/colossus/service/TagDecorator.scala
@@ -12,7 +12,7 @@ class DefaultTagDecorator[I,O] extends TagDecorator[I,O] {
 }
 
 object TagDecorator {
-  
+
   def default[I, O] = new DefaultTagDecorator[I,O]
 }
 

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -97,7 +97,7 @@ trait Zero[T] {
  *
  * === Overview ===
  *
- * A `Parser[T]` is an object that consumes a stream of bytes to produce a result of type `T`.  
+ * A `Parser[T]` is an object that consumes a stream of bytes to produce a result of type `T`.
  *
  * A Combinator is a "higher-order" parser that takes one or more parsers to produce a new parser
  *
@@ -165,7 +165,7 @@ object Combinators {
           parse(data) //need to give b a chance
         } else {
           None
-        }                
+        }
       } else {
         doneb = second.parse(data)
         if (doneb.isDefined) {
@@ -227,7 +227,7 @@ object Combinators {
     def |>[B](f: T => Parser[B]): Parser[B] = new FlatMapParser(this, f)
 
     def flatMap[B](f: T => Parser[B]): Parser[B] = |>(f)
-        
+
 
   }
 
@@ -252,7 +252,7 @@ object Combinators {
     def parse(data: DataBuffer) = {
       while(data.hasNext && index < lit.size) {
         if (data.next != arr(index)) {
-          throw new ParseException(s"Parsed byte string does not match expected literal")    
+          throw new ParseException(s"Parsed byte string does not match expected literal")
         }
         index += 1
       }
@@ -264,7 +264,7 @@ object Combinators {
       }
     }
   }
-  
+
   /**
    * Creates a parser that wraps another parser and will throw an exception if
    * more than `size` data is required to parse a single object.  See the
@@ -296,7 +296,7 @@ object Combinators {
   def bytes(num: Int, maxSize: DataSize, maxInitBufferSize: DataSize): Parser[Array[Byte]] = new Parser[Array[Byte]] {
     if (num < 0 || num > maxSize.bytes.value) {
       throw new ParseException(s"Invalid number $num for bytes parser")
-    } 
+    }
 
     val builder = new FastArrayBuilder(math.min(num, maxInitBufferSize.bytes.value.toInt), false)
 
@@ -390,7 +390,7 @@ object Combinators {
       }
     }
   }
-        
+
 
 
   /** Parse a string until a designated byte is encountered
@@ -492,10 +492,10 @@ object Combinators {
       }
     }
   }
-      
+
 
   /** Parse a pattern multiple times based on a numeric prefix
-   * 
+   *
    * This is useful for any situation where the repeated pattern is prefixed by
    * the number of repetitions, for example `num:[obj1][obj2][obj3]`.  In
    * situations where the pattern doesn't immediately follow the number, you'll
@@ -517,7 +517,7 @@ object Combinators {
         } else {
           None
         }
-      } else if (parsedTimes.get > 0) {          
+      } else if (parsedTimes.get > 0) {
         parser.parse(data).foreach{res =>
           build = build :+ res
         }
@@ -611,7 +611,7 @@ object Combinators {
    /*
     NOTE - this is commented out because right now in all cases we need to know
     how much data was peeked, so instead we're using peek on the databuffer and
-    regular parsers inside of the peek, 
+    regular parsers inside of the peek,
   def peek[T](p: Parser[T]): Parser[T] = new Parser[(T] {
     def parse(data: DataBuffer): Option[T] = data.peek{buf => p.parse(data)}
   }
@@ -663,7 +663,7 @@ object Combinators {
    */
   def repeatUntilEOS[T](parser: Parser[T]): Parser[Seq[T]] = new Parser[Seq[T]] {
     var build = collection.mutable.ArrayBuffer[T]()
-    def parse(data: DataBuffer) = { 
+    def parse(data: DataBuffer) = {
       while (data.hasNext) {
         parser.parse(data).foreach{t =>
           build += t
@@ -720,7 +720,7 @@ object Combinators {
   }
 
   class FoldZeroParser[T, U](parser: Parser[T], init: => U)(folder: (T, U) => U)(implicit zero: Zero[T]) extends Parser[U] {
-    
+
     var current: U = init
 
     def parse(data: DataBuffer): Option[U] = {
@@ -754,10 +754,10 @@ object Combinators {
    * replace this with any out-of-the-box Java/Scala class.  This is faster.
    */
   trait FastArrayBuilding {
-    
+
     def initSize: Int
     def shrinkOnComplete: Boolean
-    
+
     //TODO : This class is somewhat similar to the DynamicOutBuffer, maybe
     //there's a way to avoid duplicated logic
 
@@ -796,8 +796,8 @@ object Combinators {
       System.arraycopy(bytes, 0, build, writePos, bytes.length)
       writePos += bytes.length
     }
-      
-      
+
+
 
     def complete(): Array[Byte] = {
       val res = new Array[Byte](writePos)
@@ -840,7 +840,7 @@ object Combinators {
         if (includeNewline) {
           write(CR)
           write(LF)
-        } 
+        }
         scanByte = CR
         constructor(complete())
       } else {
@@ -884,4 +884,4 @@ object Combinators {
   case class ~[+A,+B](a: A, b: B)
 
 }
-    
+

--- a/colossus/src/main/scala/colossus/util/Task.scala
+++ b/colossus/src/main/scala/colossus/util/Task.scala
@@ -14,7 +14,7 @@ import akka.actor._
 
 abstract class Task(context: Context) extends WorkerItem(context) with ProxyActor {
 
-  override def onBind() {  
+  override def onBind() {
     super.onBind()
     run()
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -23,10 +23,10 @@ object ColossusBuild extends Build {
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>
       val default = List(
-        "-feature", 
-        "-language:implicitConversions", 
-        "-language:postfixOps", 
-        "-unchecked", 
+        "-feature",
+        "-language:implicitConversions",
+        "-language:postfixOps",
+        "-unchecked",
         "-deprecation"
       )
       if (v.startsWith("2.10.")) default else "-Ywarn-unused-import" :: default
@@ -45,17 +45,17 @@ object ColossusBuild extends Build {
   ) ++ Defaults.itSettings
 
   val ColossusSettings = GeneralSettings ++ Publish.settings
-  
+
   val noPubSettings = GeneralSettings ++ Seq(
     publishArtifact := false,
-    publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo"))) 
+    publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
     )
 
   val testkitDependencies = libraryDependencies ++= Seq(
     "org.scalatest"     %% "scalatest" % SCALATEST_VERSION
   )
 
-  val MetricSettings = ColossusSettings 
+  val MetricSettings = ColossusSettings
 
   val ExamplesSettings = Seq (
     libraryDependencies ++= Seq(
@@ -94,7 +94,7 @@ object ColossusBuild extends Build {
       .dependsOn(ColossusProject)
 
   lazy val ColossusTestsProject = Project(
-    id="colossus-tests", 
+    id="colossus-tests",
     base = file("colossus-tests"),
     dependencies = Seq(ColossusTestkitProject % "compile;test->test")
   ).settings(noPubSettings:_*).configs(IntegrationTest)

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -14,7 +14,7 @@ object Publish {
 
   lazy val settings: Seq[Setting[_]] = Seq(
     publishMavenStyle := true,
-    
+
     publishTo := (if(isSnapshot.value) snapshots else releases),
 
     publishArtifact in Test := false,


### PR DESCRIPTION
There are a lot of files with trailing whitespace. This commit removes them from Scala files via:

```shell
$ find . -name '*.scala' -type f -print0 | xargs -0 sed -i '' -E "s/[[:space:]]*$//"
```