### PR TITLE
Include the host header in HTTP requests

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -44,7 +44,7 @@ object RawProtocol {
 
   implicit object RawClientLifter extends ClientLifter[Raw, RawClient] {
     
-    def lift[M[_]](client: Sender[Raw,M], clientConfig: ClientConfig)(implicit async: Async[M]) = {
+    def lift[M[_]](client: Sender[Raw,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) = {
       new BasicLiftedClient(client, clientConfig) with RawClient[M]
     }
   }

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -44,7 +44,9 @@ object RawProtocol {
 
   implicit object RawClientLifter extends ClientLifter[Raw, RawClient] {
     
-    def lift[M[_]](client: Sender[Raw,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with RawClient[M]
+    def lift[M[_]](client: Sender[Raw,M], clientConfig: ClientConfig)(implicit async: Async[M]) = {
+      new BasicLiftedClient(client, clientConfig) with RawClient[M]
+    }
   }
 
   object Raw extends ClientFactories[Raw, RawClient]{

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpClientSpec.scala
@@ -1,0 +1,50 @@
+package colossus
+package protocols.http
+
+import java.net.InetSocketAddress
+
+import colossus.metrics.MetricAddress
+import colossus.service.{ClientConfig, Sender}
+import colossus.testkit.ColossusSpec
+import org.scalamock.scalatest.MockFactory
+
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+
+class HttpClientSpec extends ColossusSpec with MockFactory {
+
+  "Http Client" must {
+
+    val clientConfig = ClientConfig(
+      address = new InetSocketAddress("localhost", 80),
+      requestTimeout = Duration.Inf,
+      name = MetricAddress.Root / "testMetric"
+    )
+
+    "include the Host header into a request if it's missing" in {
+      withIOSystem { implicit io =>
+        val request = HttpRequest.get("/")
+
+        val sender = mock[Sender[Http, Future]]
+
+        val expectedRequest = request.withHeader("host", "localhost")
+        (sender.send _).expects(expectedRequest)
+
+        val httpClient = Http.futureClient(sender, clientConfig)
+        httpClient.send(request)
+      }
+    }
+
+    "not modify the existing Host header" in {
+      withIOSystem { implicit io =>
+        val request = HttpRequest.get("/").withHeader("host", "some.host")
+
+        val sender = mock[Sender[Http, Future]]
+        (sender.send _).expects(request)
+
+        val httpClient = Http.futureClient(sender, clientConfig)
+        httpClient.send(request)
+      }
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -127,7 +127,7 @@ class ServiceDSLSpec extends ColossusSpec {
         import Http.defaults._
 
         val s = FutureClient[Http]("localhost", TEST_PORT, 1.second)
-        val t = Http.futureClient(s)
+        val t = Http.futureClient(s, s.clientConfig)
         val q : HttpClient[Future] = t
       }
     }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -127,7 +127,7 @@ class ServiceDSLSpec extends ColossusSpec {
         import Http.defaults._
 
         val s = FutureClient[Http]("localhost", TEST_PORT, 1.second)
-        val t = Http.futureClient(s, s.clientConfig)
+        val t = Http.futureClient(s)
         val q : HttpClient[Future] = t
       }
     }

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -262,6 +262,7 @@ object HttpHeaders {
   val ContentLength     = "content-length"
   val ContentType       = "content-type"
   val CookieHeader      = "cookie"
+  val Host              = "host"
   val SetCookie         = "set-cookie"
   val TransferEncoding  = "transfer-encoding"
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -7,11 +7,18 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait HttpClient[M[_]]  extends LiftedClient[Http, M] with HttpRequestBuilder[M[HttpResponse]]{ //self: LiftedClient[Http, M] => 
 
-  protected def build(req: HttpRequest) = client.send(req)
+  protected def build(req: HttpRequest) = send(req)
 
   val base = HttpRequest.base
 
-
+  override def send(input: HttpRequest): M[HttpResponse] = {
+    val headers = input.head.headers
+    val decoratedRequest = headers.firstValue(HttpHeaders.Host) match {
+      case Some(_) => input // Host header is already present.
+      case None => input.withHeader(HttpHeaders.Host, clientConfig.address.getHostName)
+    }
+    super.send(decoratedRequest)
+  }
 }
 
 
@@ -20,7 +27,9 @@ object HttpClient {
 
   implicit object HttpClientLifter extends ClientLifter[Http, HttpClient] {
     
-    def lift[M[_]](client: Sender[Http,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with HttpClient[M]
+    def lift[M[_]](client: Sender[Http,M], clientConfig: ClientConfig)(implicit async: Async[M]) = {
+      new BasicLiftedClient(client, clientConfig) with HttpClient[M]
+    }
   }
 
 }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -7,6 +7,10 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait HttpClient[M[_]]  extends LiftedClient[Http, M] with HttpRequestBuilder[M[HttpResponse]]{ //self: LiftedClient[Http, M] => 
 
+  private lazy val hostHeader = clientConfig.map(config => {
+    HttpHeader(HttpHeaders.Host, config.address.getHostName)
+  })
+
   protected def build(req: HttpRequest) = send(req)
 
   val base = HttpRequest.base
@@ -15,7 +19,7 @@ trait HttpClient[M[_]]  extends LiftedClient[Http, M] with HttpRequestBuilder[M[
     val headers = input.head.headers
     val decoratedRequest = headers.firstValue(HttpHeaders.Host) match {
       case Some(_) => input // Host header is already present.
-      case None => input.withHeader(HttpHeaders.Host, clientConfig.address.getHostName)
+      case None => hostHeader.map(header => input.withHeader(header)).getOrElse(input)
     }
     super.send(decoratedRequest)
   }
@@ -27,7 +31,7 @@ object HttpClient {
 
   implicit object HttpClientLifter extends ClientLifter[Http, HttpClient] {
     
-    def lift[M[_]](client: Sender[Http,M], clientConfig: ClientConfig)(implicit async: Async[M]) = {
+    def lift[M[_]](client: Sender[Http,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) = {
       new BasicLiftedClient(client, clientConfig) with HttpClient[M]
     }
   }

--- a/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
@@ -118,7 +118,7 @@ import scala.language.higherKinds
   
     implicit object MemcacheClientLifter extends ClientLifter[Memcache, MemcacheClient] {
       
-      def lift[M[_]](client: Sender[Memcache,M], clientConfig: ClientConfig)(implicit async: Async[M]) = {
+      def lift[M[_]](client: Sender[Memcache,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) = {
         new BasicLiftedClient(client, clientConfig) with MemcacheClient[M]
       }
     }

--- a/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
@@ -118,7 +118,9 @@ import scala.language.higherKinds
   
     implicit object MemcacheClientLifter extends ClientLifter[Memcache, MemcacheClient] {
       
-      def lift[M[_]](client: Sender[Memcache,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with MemcacheClient[M]
+      def lift[M[_]](client: Sender[Memcache,M], clientConfig: ClientConfig)(implicit async: Async[M]) = {
+        new BasicLiftedClient(client, clientConfig) with MemcacheClient[M]
+      }
     }
 
   }

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
@@ -499,7 +499,7 @@ object RedisClient {
 
   implicit object RedisClientLifter extends ClientLifter[Redis, RedisClient] {
     
-    def lift[M[_]](client: Sender[Redis,M], clientConfig: ClientConfig)(implicit async: Async[M]) = {
+    def lift[M[_]](client: Sender[Redis,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) = {
       new BasicLiftedClient(client, clientConfig) with RedisClient[M]
     }
   }

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
@@ -499,7 +499,9 @@ object RedisClient {
 
   implicit object RedisClientLifter extends ClientLifter[Redis, RedisClient] {
     
-    def lift[M[_]](client: Sender[Redis,M])(implicit async: Async[M]) = new BasicLiftedClient(client) with RedisClient[M]
+    def lift[M[_]](client: Sender[Redis,M], clientConfig: ClientConfig)(implicit async: Async[M]) = {
+      new BasicLiftedClient(client, clientConfig) with RedisClient[M]
+    }
   }
 
 }

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -144,7 +144,7 @@ object Service {
  */
 trait ClientLifter[C <: Protocol, T[M[_]] <: Sender[C,M]] {
 
-  def lift[M[_]](baseClient: Sender[C, M], clientConfig: ClientConfig)(implicit async: Async[M]) : T[M]
+  def lift[M[_]](baseClient: Sender[C, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) : T[M]
 
 }
 
@@ -220,9 +220,12 @@ extends ClientFactory[C,M,T[M],E] {
   }
 
   def apply(sender: Sender[C,M], clientConfig: ClientConfig)(implicit env: E): T[M] = {
-    lifter.lift(sender, clientConfig)(builder.build(env))
+    lifter.lift(sender, Some(clientConfig))(builder.build(env))
   }
 
+  def apply(sender: Sender[C,M])(implicit env: E): T[M] = {
+    lifter.lift(sender, None)(builder.build(env))
+  }
 }
 
 /**
@@ -238,7 +241,7 @@ class ClientFactories[C <: Protocol, T[M[_]] <: Sender[C, M]](implicit lifter: C
 
 trait LiftedClient[C <: Protocol, M[_] ] extends Sender[C,M] {
 
-  def clientConfig: ClientConfig
+  def clientConfig: Option[ClientConfig]
   def client: Sender[C,M]
   implicit val async: Async[M]
 
@@ -252,7 +255,7 @@ trait LiftedClient[C <: Protocol, M[_] ] extends Sender[C,M] {
 
 }
 
-class BasicLiftedClient[C <: Protocol, M[_] ](val client: Sender[C,M], val clientConfig: ClientConfig)
+class BasicLiftedClient[C <: Protocol, M[_] ](val client: Sender[C,M], val clientConfig: Option[ClientConfig])
                                              (implicit val async: Async[M]) extends LiftedClient[C,M] {
 
 }

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -144,7 +144,7 @@ object Service {
  */
 trait ClientLifter[C <: Protocol, T[M[_]] <: Sender[C,M]] {
 
-  def lift[M[_]](baseClient: Sender[C, M])(implicit async: Async[M]) : T[M]
+  def lift[M[_]](baseClient: Sender[C, M], clientConfig: ClientConfig)(implicit async: Async[M]) : T[M]
 
 }
 
@@ -216,10 +216,12 @@ class CodecClientFactory[C <: Protocol, M[_], B <: Sender[C, M], T[M[_]] <: Send
 extends ClientFactory[C,M,T[M],E] {
 
   def apply(config: ClientConfig)(implicit provider: ClientCodecProvider[C], env: E): T[M] =  {
-    apply(baseFactory(config))
+    apply(baseFactory(config), config)
   }
 
-  def apply(sender: Sender[C,M])(implicit env: E): T[M] = lifter.lift(sender)(builder.build(env))
+  def apply(sender: Sender[C,M], clientConfig: ClientConfig)(implicit env: E): T[M] = {
+    lifter.lift(sender, clientConfig)(builder.build(env))
+  }
 
 }
 
@@ -236,6 +238,7 @@ class ClientFactories[C <: Protocol, T[M[_]] <: Sender[C, M]](implicit lifter: C
 
 trait LiftedClient[C <: Protocol, M[_] ] extends Sender[C,M] {
 
+  def clientConfig: ClientConfig
   def client: Sender[C,M]
   implicit val async: Async[M]
 
@@ -249,6 +252,7 @@ trait LiftedClient[C <: Protocol, M[_] ] extends Sender[C,M] {
 
 }
 
-class BasicLiftedClient[C <: Protocol, M[_] ](val client: Sender[C,M])(implicit val async: Async[M]) extends LiftedClient[C,M] {
+class BasicLiftedClient[C <: Protocol, M[_] ](val client: Sender[C,M], val clientConfig: ClientConfig)
+                                             (implicit val async: Async[M]) extends LiftedClient[C,M] {
 
 }


### PR DESCRIPTION
This is a proposed fix for the Host header issue (https://github.com/tumblr/colossus/issues/466). It was a little bit tricky to forward the destination address information from the lower level (`ServiceClient`) to a protocol-specific implementation. That's why I had to update the `ClientLifter` and `LiftedClient` interfaces. I'm pretty sure this update can potentially be useful for other implementations in future. So far I tested it manually, but if my updates make sense I can also introduce some unit tests. The only detail that bothers me here is [apply](https://github.com/izeigerman/colossus/blob/96f1643b08282d5461169070dd567f9865d4ad69/colossus/src/main/scala/colossus/service/ServiceDSL.scala#L222-L224) method. It's definition allows user to specify a client configuration that differs from the sender's one. I'm not sure how to fix this properly (perhaps declare it `private[colossus]` since it's only used internally).