### PR TITLE
LoadbalancingClient supports multiple connections to the same host

### DIFF
--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -15,7 +15,7 @@ import java.net.InetSocketAddress
  * This currently doesn't iterate through every possible permutation, but it
  * does evenly distribute 1st and 2nd tries...needs some more work
  */
-class PermutationGenerator[T : ClassTag](val seedlist: List[T]) extends Iterator[List[T]] {
+class PermutationGenerator[T : ClassTag](val seedlist: Seq[T]) extends Iterator[List[T]] {
   private val items:Array[T] = seedlist.toArray
 
   private var swapIndex = 1
@@ -86,40 +86,36 @@ class LoadBalancingClient[P <: Protocol] (
 
   worker.bind(_ => this)
 
-  type Client = Sender[P, Callback]
+  case class Client(address: InetSocketAddress, client: Sender[P, Callback])
 
-  private val clients = collection.mutable.Map[InetSocketAddress, Client]()
+  private val clients = collection.mutable.ArrayBuffer[Client]()
 
-  private var permutations = new PermutationGenerator(clients.values.toList)
+  private var permutations = new PermutationGenerator(clients.map{_.client})
 
   update(initialClients)
 
-  //note, this type must be inner to avoid type erasure craziness
-  case class Send(request: P#Input, promise: Promise[P#Output])
-
-
   private def regeneratePermutations() {
-    permutations = new PermutationGenerator(clients.values.toList)
+    permutations = new PermutationGenerator(clients.map{_.client})
   }
 
-  def currentClients = clients.toList
-
-
-  private def addClient(address: InetSocketAddress, regen: Boolean): Sender[P, Callback] = {
-    val client = generator(address)
-    clients(address) = client
+  private def addClient(address: InetSocketAddress, regen: Boolean): Unit = {
+    val client = Client(address, generator(address))
+    clients append client
     regeneratePermutations()
-    client
   }
 
-  def addClient(address: InetSocketAddress): Sender[P, Callback] = addClient(address, true)
+  def addClient(address: InetSocketAddress): Unit = addClient(address, true)
 
+  private def removeFilter(filter: Client => Boolean) {
+    clients.zipWithIndex.filter{ case (c,i) => filter(c)}.foreach{ case (client, i) =>
+      client.client.disconnect()
+      clients.remove(i)
+    }
+
+  }
+  
   def removeClient(address: InetSocketAddress) {
-    val client = clients.get(address).getOrElse(
-      throw new LoadBalancingClientException(s"Tried to remove non-existant client: $address")
-    )
-    clients -= address
-    client.disconnect()
+    removeFilter{_.address == address}
     regeneratePermutations()
   }
 
@@ -128,18 +124,15 @@ class LoadBalancingClient[P <: Protocol] (
    * existing list and closing connections not in the new list
    */
   def update(addresses: Seq[InetSocketAddress]) {
-    val toRemove = clients.filter{case (i, c) => !addresses.contains(i)}.keys
-    toRemove.foreach(removeClient)
+    removeFilter(c => !addresses.contains(c.address))
     addresses.foreach{address =>
-      if (! (clients contains address)) {
-        addClient(address,false)
-      }
+      addClient(address,false)
     }
     regeneratePermutations()
   }
 
   def disconnect() {
-    clients.foreach{case (i,c) => c.disconnect()}
+    clients.foreach{_.client.disconnect()}
     clients.clear()
   }
 
@@ -160,9 +153,6 @@ class LoadBalancingClient[P <: Protocol] (
   }
 
   override def receivedMessage(message: Any, sender: ActorRef) {
-    message match {
-      case Send(request, promise) => send(request).execute(promise.complete)
-    }
   }
 
 }

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -107,15 +107,21 @@ class LoadBalancingClient[P <: Protocol] (
   def addClient(address: InetSocketAddress): Unit = addClient(address, true)
 
   private def removeFilter(filter: Client => Boolean) {
-    clients.zipWithIndex.filter{ case (c,i) => filter(c)}.foreach{ case (client, i) =>
-      client.client.disconnect()
-      clients.remove(i)
+    var i = 0
+    while (i < clients.length) {
+      if (filter(clients(i))) {
+        clients(i).client.disconnect()
+        clients.remove(i)
+      } else {
+        i += 1
+      }
     }
-
   }
   
   def removeClient(address: InetSocketAddress) {
-    removeFilter{_.address == address}
+    removeFilter{c =>
+      c.address == address
+    }
     regeneratePermutations()
   }
 

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -92,7 +92,7 @@ class LoadBalancingClient[P <: Protocol] (
 
   private var permutations = new PermutationGenerator(clients.map{_.client})
 
-  update(initialClients)
+  update(initialClients, true)
 
   private def regeneratePermutations() {
     permutations = new PermutationGenerator(clients.map{_.client})
@@ -129,10 +129,12 @@ class LoadBalancingClient[P <: Protocol] (
    * Updates the client list, creating connections for new addresses not in the
    * existing list and closing connections not in the new list
    */
-  def update(addresses: Seq[InetSocketAddress]) {
+  def update(addresses: Seq[InetSocketAddress], allowDuplicates: Boolean = false) {
     removeFilter(c => !addresses.contains(c.address))
     addresses.foreach{address =>
-      addClient(address,false)
+      if (! clients.exists{_.address == address} || allowDuplicates) {
+        addClient(address,false)
+      }
     }
     regeneratePermutations()
   }


### PR DESCRIPTION
Previously a `LoadBalancingClient` could only have one open connection per host, due to the fact that it was backed by a hash map using the address as the key.  This could be a problem, for example, if you're trying to load balance requests across multiple connections through a proxy.  This has now been changed to use an `ArrayBuffer` instead.

This is not a perfect solution, since although new connections to a host can be added one at a time, they can only be removed all at once.  This ensures backwards compatibility and does solve the use-case of creating a load-balancer with multiple connections to a single host, but further work will probably be needed down the road to support other use cases.