### PR TITLE
Move client Handler creation outside of ServiceClient

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -104,7 +104,7 @@ object RawProtocol {
   }
 
   object Raw extends ClientFactories[Raw, RawClient]{
-    implicit def clientFactory = ServiceClientFactory.staticClient("redis", () => RawClientCodec)
+    implicit def clientFactory = ServiceClientFactory.basic("raw", () => RawClientCodec)
     
   }
 

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -17,7 +17,7 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
 
   object Http extends ClientFactories[Http, HttpClient] {
 
-    implicit lazy val clientFactory = ServiceClientFactory.staticClient("http", () => new StaticHttpClientCodec)
+    implicit lazy val clientFactory = ServiceClientFactory.basic("http", () => new StaticHttpClientCodec)
 
     class ServerDefaults  {
       def errorResponse(error: ProcessingFailure[HttpRequest]) = error match {

--- a/colossus/src/main/scala/colossus/protocols/memcache/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/package.scala
@@ -15,7 +15,7 @@ package object memcache {
 
   object Memcache extends ClientFactories[Memcache, MemcacheClient] {
 
-    implicit lazy val clientFactory = ServiceClientFactory.staticClient("memcache", () => new MemcacheClientCodec)
+    implicit lazy val clientFactory = ServiceClientFactory.basic("memcache", () => new MemcacheClientCodec)
 
     object defaults {
       //???

--- a/colossus/src/main/scala/colossus/protocols/redis/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/package.scala
@@ -14,7 +14,7 @@ package object redis {
 
   object Redis extends ClientFactories[Redis, RedisClient]{
 
-    implicit def clientFactory = ServiceClientFactory.staticClient("redis", () => new RedisClientCodec)
+    implicit def clientFactory = ServiceClientFactory.basic("redis", () => new RedisClientCodec)
     
 
     object defaults {

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -29,7 +29,6 @@ class ProxyWatchdog(proxy: ActorRef, signal: AtomicBoolean) extends Actor {
 trait Client[P <: Protocol, M[_]] extends Sender[P, M] {
   def connectionStatus: M[ConnectionStatus]
   def disconnect()
-  def clientConfig : ClientConfig
 
 }
 

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -155,7 +155,6 @@ class UnbindHandler(ds: CoreDownstream, tail: HandlerTail) extends PipelineHandl
  * TODO: make underlying output controller data size configurable
  */
 class ServiceClient[P <: Protocol](
-  val codec: Codec.Client[P],
   val config: ClientConfig,
   val context: Context
 )(implicit tagDecorator: TagDecorator[P] = TagDecorator.default[P])
@@ -190,16 +189,6 @@ extends ControllerDownstream[Encoding.Client[P]] with HasUpstream[ControllerUpst
 
 
   val controllerConfig = ControllerConfig(config.pendingBufferSize, metricsEnabled = true, inputMaxSize = config.maxResponseSize)
-
-  //TODO: this should be moved somewhere else, maybe constructor parameter,
-  //maybe ServiceClient shouldn't do this at all, especially since users don't
-  //really directly create this anymore
-  protected def fullHandler(me: ServiceClient[P]): ClientConnectionHandler = new UnbindHandler(new Controller[Encoding.Client[P]](me, codec), me)
-
-  def this(codec: Codec.Client[P], config: ClientConfig, worker: WorkerRef) {
-    this(codec, config, worker.generateContext())
-    worker.worker ! WorkerCommand.Bind(fullHandler(this))
-  }
 
   import colossus.core.WorkerCommand._
   import config._


### PR DESCRIPTION
This is a minor refactoring that moves some initialization logic out of `ServiceClient` and into `ServiceClientFactory`.  There will probably be more changes like this, but this one's been sitting unmerged for a couple weeks so I'll get it in now before I forget about it.

The change follows suit with the general ideas that 1) `ServiceClient`is now only one component of a client connection handler vs the whole thing, 2) that the structure of a client handler can change from codec to codec, and 3) that users no longer directly create or interact with `ServiceClient` but rather do so through a codec-specific interface like `HttpClient`.

This also means that `ServiceClient` itself is no longer responsible for binding the full connection handler to a worker.