### PR TITLE
fixing bug that caused clients to fail connection completion on Windows

### DIFF
--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -89,7 +89,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
       }
     }
 
-    "automatically unbind on manual disconnect" in {
+    "automatically unbind on manual disconnect"  in {
       val probe = TestProbe()
       class MyHandler(context: Context) extends BasicSyncHandler(context) with ClientConnectionHandler{
         override def onUnbind() {
@@ -110,7 +110,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
       }
     }
 
-    "automatically unbind on disrupted connection" taggedAs(org.scalatest.Tag("test")) in {
+    "automatically unbind on disrupted connection" in {
       val probe = TestProbe()
       withIOSystem{ implicit io =>
         val server = Service.basic[Raw]("test", TEST_PORT){case x => x}
@@ -127,14 +127,14 @@ class ConnectionHandlerSpec extends ColossusSpec {
 
     }
 
-    "automatically unbind on failure to connect" in {
+    "automatically unbind on failure to connect" taggedAs(org.scalatest.Tag("test")) in {
       val probe = TestProbe()
       withIOSystem{ implicit io =>
         io ! IOCommand.BindAndConnectWorkerItem(
           new InetSocketAddress("localhost", TEST_PORT), c => new MyHandler(c, probe.ref, true, true)
         )
         probe.expectMsg(250.milliseconds, "BOUND")
-        probe.expectMsg(250.milliseconds, "UNBOUND")
+        probe.expectMsg(10.seconds, "UNBOUND")
       }
     }
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -476,7 +476,7 @@ class ServiceClientSpec extends ColossusSpec with MockFactory {
         //beware, a java TimeoutException is NOT what we want, that is simply
         //the future timing out, which it shouldn't here
         intercept[RequestTimeoutException] {
-          Await.result(f, 100.milliseconds)
+          Await.result(f, 10.seconds)
         }
       }
     }

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -324,7 +324,13 @@ private[colossus] class Worker(config: WorkerConfig) extends Actor with ActorLog
       case _ =>{}
     }
     try {
-      newChannel.connect(address)
+      if (newChannel.connect(address)) {
+        //if this returns true it means the connection is already connected (can
+        //happen on Windows and maybe other OS's when connecting to localhost),
+        //so finish the connect process immediately.  The connection will
+        //properly set the key interest ops
+        connection.handleConnected()
+      }
     } catch {
       case t: Throwable => {
         log.error(t, s"Failed to establish connection to $address: $t")


### PR DESCRIPTION
Yeah you read that right.  I've been messing around with the windows subsystem for Linux and ran into this issue pretty quickly.  Apparently this whole time client connections (probably only to localhost) have not worked on Windows because we weren't properly handling the result of `SocketChannel.connect()`.  

At least on Linux and MacOs, connecting to localhost is asynchronous, so `SocketChannel.connect()` returns false and we must subscribe the selection key to `OP_CONNECT`.  However on windows it appears that the method returns true and the connection is immediately established.  This meant not only were we never calling `Connection.handleConnected()`, but because the `OP_CONNECT` interest is apparently the same as `OP_WRITE`, it would cause the worker to go nuts constantly selecting the connection over and over with nothing to do, pegging the CPU.

Best I can tell this totally fixes the issue.  All tests pass locally and I can run all the examples.  I also had to tweak timeouts on a few tests, as it appears there is a delay when a connection on windows to localhost is refused.