### PR TITLE
histogram buckets can be configured through typesafe config

### DIFF
--- a/colossus-metrics/src/main/resources/reference.conf
+++ b/colossus-metrics/src/main/resources/reference.conf
@@ -22,6 +22,11 @@ colossus {
           percentiles: [0.75, 0.9, 0.99, 0.999, 0.9999]
           sample-rate: 1.0
           prune-empty: false
+	  buckets : {
+	    type = "logscale",
+	    num-buckets = 100,
+	    infinity = MAX
+	  }
         }
         counter {
           enabled: true

--- a/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/ConfigLoadingSpec.scala
@@ -130,6 +130,10 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
         |  small-hist {
         |    prune-empty : false
         |    percentiles : [.50, .75]
+        |    buckets : {
+        |     type: manual
+        |     values: [0, 2, 4]
+        |   }
         |  }
         |  off-hist{
         |    enabled : false
@@ -162,6 +166,7 @@ class ConfigLoadingSpec extends MetricIntegrationSpec {
       r.pruneEmpty mustBe false
       r.sampleRate mustBe 1.0
       r.percentiles mustBe Seq(0.5, 0.75)
+      r.buckets mustBe BucketList(Vector(0, 2, 4))
     }
     "load defaults if a defined configuration isn't found" in {
       val r = Histogram(MetricAddress("my-crazy-hist"), "crazy-hist")


### PR DESCRIPTION
This adds a config option for histograms that we missed when moving config to typesafe-config.  Histograms by default use 100 buckets on a log scale.  This works pretty well for latency when the average is around 100ms or lower.  But in many other cases the buckets will not give accurate percentiles, either because something with a non-log distribution is being measured or there are too few buckets to give enough resolution.

So now there are 3 possible ways to configure histogram buckets:
* `manual` - you provide list of bucket lower-bounds yourself
* `linearscale` - you provide `num_buckets` and `infinity` and the range below the infinity value is evenly divided amongst `num` buckets
* `logscale` - same as linear except the natual-log scale is used

the default is set to log-scale with 100 buckets and `Int.MaxValue` as infinity, which matches the existing defaults.