### PR TITLE
Merging DSLService into ServiceServer and RequestHandler

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
@@ -35,6 +35,10 @@ object StreamServiceExample {
           )
         }
       }
+
+      def unhandledError = {
+        case err => StreamingHttpResponse(HttpResponse.error(s"error: $err"))
+      }
     })
 
   }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -60,7 +60,7 @@ class ServiceDSLSpec extends ColossusSpec {
     */
 
 
-    "receive connection messages" taggedAs(org.scalatest.Tag("test")) in {
+    "receive connection messages" in {
       val probe = TestProbe()
       withIOSystem{ implicit system =>
         val server = RawServer.basic("test", TEST_PORT, new RequestHandler(_) with ProxyActor {

--- a/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceDSLSpec.scala
@@ -60,7 +60,7 @@ class ServiceDSLSpec extends ColossusSpec {
     */
 
 
-    "receive connection messages" in {
+    "receive connection messages" taggedAs(org.scalatest.Tag("test")) in {
       val probe = TestProbe()
       withIOSystem{ implicit system =>
         val server = RawServer.basic("test", TEST_PORT, new RequestHandler(_) with ProxyActor {

--- a/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
@@ -8,20 +8,8 @@ import controller._
 import service._
 
 protected[server] class HttpServiceHandler(rh: RequestHandler) 
-extends DSLService[Http](rh) {
+extends ServiceServer[Http](rh) {
 
-  val defaults = new Http.ServerDefaults
-
-  override def tagDecorator = new ReturnCodeTagDecorator
-
-  override def processRequest(input: Http#Request): Callback[Http#Response] = {
-    val response = super.processRequest(input)
-    if(!input.head.persistConnection) connection.disconnect()
-    response
-  }
-  def unhandledError = {
-    case error => defaults.errorResponse(error)
-  }
 
 }
 
@@ -51,6 +39,19 @@ abstract class Initializer(ctx: InitContext) extends Generator(ctx) with Service
  */
 abstract class RequestHandler(config: ServiceConfig, ctx: ServerContext) extends GenRequestHandler[Http](config, ctx) {
   def this(ctx: ServerContext) = this(ServiceConfig.load(ctx.name), ctx)
+
+  val defaults = new Http.ServerDefaults
+
+  override def tagDecorator = new ReturnCodeTagDecorator
+
+  override def handleRequest(input: Http#Request): Callback[Http#Response] = {
+    val response = super.handleRequest(input)
+    if(!input.head.persistConnection) connection.disconnect()
+    response
+  }
+  def unhandledError = {
+    case error => defaults.errorResponse(error)
+  }
 }
 
 /**

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -177,11 +177,7 @@ with UpstreamEventHandler[ControllerUpstream[GenEncoding[HttpStream, E]]] {
 
 
 class StreamingHttpServiceHandler(rh: GenRequestHandler[StreamingHttp]) 
-extends DSLService[StreamingHttp](rh) {
-
-  def unhandledError = {
-    case error => ???//defaults.errorResponse(error)
-  }
+extends ServiceServer[StreamingHttp](rh) {
 
 }
 

--- a/colossus/src/main/scala/colossus/service/RequestHandler.scala
+++ b/colossus/src/main/scala/colossus/service/RequestHandler.scala
@@ -1,0 +1,68 @@
+package colossus.service
+
+import colossus.core._
+
+class UnhandledRequestException(message: String) extends Exception(message)
+class ReceiveException(message: String) extends Exception(message)
+class RequestHandlerException(message: String) extends Exception(message)
+
+object GenRequestHandler {
+
+  type PartialHandler[C <: Protocol] = PartialFunction[C#Request, Callback[C#Response]]
+
+  type Receive = PartialFunction[Any, Unit]
+
+  type ErrorHandler[C <: Protocol] = PartialFunction[ProcessingFailure[C#Request], C#Response]
+
+  type ParseErrorHandler[C <: Protocol] = PartialFunction[Throwable, C#Response]
+}
+import GenRequestHandler._
+
+abstract class GenRequestHandler[P <: Protocol](val config: ServiceConfig, val serverContext: ServerContext) 
+extends DownstreamEvents with HandlerTail with UpstreamEventHandler[ServiceUpstream[P]] {
+
+  type Request = P#Request
+  type Response = P#Response
+
+  def this(context: ServerContext) = this(ServiceConfig.load(context.name), context)
+
+  protected val server = serverContext.server
+  def context = serverContext.context
+  implicit val worker = context.worker
+
+  private var _connectionManager: Option[ConnectionManager] = None
+
+  protected def connection = _connectionManager.getOrElse {
+    throw new RequestHandlerException("Cannot access connection before request handler is bound")
+  }
+
+  def setConnection(connection: ConnectionManager) {
+    _connectionManager = Some(connection)
+  }
+
+  implicit val executor   = context.worker.callbackExecutor
+
+  protected def handle: PartialHandler[P]
+  protected def unhandledError: ErrorHandler[P] 
+
+  protected def onError: ErrorHandler[P] = Map()
+
+  private lazy val fullHandler: PartialHandler[P] = handle orElse {
+    case req => Callback.failed(new UnhandledRequestException(s"Unhandled Request $req"))
+  }
+
+  def handleRequest(request: Request): Callback[Response] = fullHandler(request)
+  private lazy val errorHandler: ErrorHandler[P] = onError orElse unhandledError
+
+  def handleFailure(error: ProcessingFailure[Request]): Response = errorHandler(error)
+
+  def tagDecorator: TagDecorator[P] = TagDecorator.default[P]
+  def requestLogFormat : Option[RequestFormatter[Request]] = None
+
+
+
+  protected def disconnect() {
+    connection.disconnect()
+  }
+
+}

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -112,10 +112,11 @@ trait ServiceUpstream[P <: Protocol] extends UpstreamEvents
  * in the order that they are received.
  *
  */
-abstract class ServiceServer[P <: Protocol](val requestHandler: GenRequestHandler[P])
+class ServiceServer[P <: Protocol](val requestHandler: GenRequestHandler[P])
 extends ControllerDownstream[Encoding.Server[P]] 
 with ServiceUpstream[P] 
 with UpstreamEventHandler[ControllerUpstream[Encoding.Server[P]]] 
+with DownstreamEventHandler[GenRequestHandler[P]]
 {
   import ServiceServer._
 
@@ -128,7 +129,6 @@ with UpstreamEventHandler[ControllerUpstream[Encoding.Server[P]]]
   val incoming = new BufferedPipe[Request](50)
 
   def config = requestHandler.config
-  def context = requestHandler.serverContext.context
   implicit val namespace = requestHandler.serverContext.server.namespace
   def name = requestHandler.serverContext.server.config.name
 


### PR DESCRIPTION
This fixes #478 .  Basically `DSLService` was a thin layer on top of `ServiceServer`that is no longer needed.  Now `ServiceServer` directly takes a `GenRequestHandler[I]` as input.  A few other things like `tagDecorator` and `requestLogFormat` have also been moved into `GenRequestHandler` which means it will now be just as easy for the user to override those as it was in 0.8.x