### PR TITLE
fixing a race condition with hitting a rate from multiple threads

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -65,7 +65,7 @@ private[metrics] class CollectionMap[T] {
     Option(map.get(tags)) match {
       case Some(got) => op(got)(num)
       case None => {
-        map.putIfAbsent(tags, new AtomicLong(num))
+        Option(map.putIfAbsent(tags, new AtomicLong(num))).foreach{got => op(got)(num)}          
       }
     }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -1,6 +1,8 @@
 package colossus.metrics
 
 import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class RateSpec extends MetricIntegrationSpec {
 
@@ -96,6 +98,17 @@ class RateSpec extends MetricIntegrationSpec {
       val r = Rate("/baz")
       r.address must equal(MetricAddress("/foo/bar/baz"))
 
+    }
+
+    "correctly handle hits from multiple threads" taggedAs(org.scalatest.Tag("test")) in {
+      val r = rate()
+      val f = Future.sequence{(1 to 10000).map{_ =>
+        Future { 
+          (1 to 5).foreach(_ => r.hit()) 
+        }
+      }}
+      Await.result(f, 1.second)
+      r.tick(1.second)("/foo")(Map()) must equal(50000)
     }
   }
 }

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -100,7 +100,7 @@ class RateSpec extends MetricIntegrationSpec {
 
     }
 
-    "correctly handle hits from multiple threads" taggedAs(org.scalatest.Tag("test")) in {
+    "correctly handle hits from multiple threads" in {
       val r = rate()
       val f = Future.sequence{(1 to 10000).map{_ =>
         Future { 


### PR DESCRIPTION
Fixes #485 .  This prevents a race condition that can occur when a rate is incremented from multiple threads at the same time, and the rate had never previously been hit before.  Hits from multiple threads afterwards work correctly, so generally at most only 1 hit was lost.
