### PR TITLE
Stream cleanup

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
@@ -3,9 +3,8 @@ package colossus.examples
 import colossus._
 
 import protocols.http._
-import protocols.http.streaming._
 import stream._
-import core.ServerContext
+import core.DataBlock
 import service._
 import colossus.streaming._
 

--- a/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
@@ -3,12 +3,12 @@ package colossus.examples
 import colossus._
 
 import protocols.http._
+import protocols.http.streaming._
 import stream._
-import core.{DataBlock, ServerContext}
+import core.ServerContext
 import service._
-import streaming._
+import colossus.streaming._
 
-import scala.util.{Failure, Success, Try}
 
 object StreamServiceExample {
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpHeadSpec.scala
@@ -5,9 +5,10 @@ import org.scalatest._
 import java.util.Date
 import java.text.SimpleDateFormat
 import scala.util.{Try, Success, Failure}
+import colossus.core.DynamicOutBuffer
 
 
-class HttpRequestHeadSuite extends WordSpec with MustMatchers{
+class HttpHeadSpec extends WordSpec with MustMatchers{
 
   import HttpHeader.Conversions._
 
@@ -114,6 +115,15 @@ class HttpRequestHeadSuite extends WordSpec with MustMatchers{
       req.head.parameters.getFirstAs[Int]("a") mustBe a[Failure[Int]]
       req.head.parameters.getFirstAs[Int]("c") mustBe a[Failure[Int]]
 
+    }
+  }
+
+  "ParsedHttpHeaders" must {
+    "encode separate headers" in {
+      val p = new ParsedHttpHeaders(HttpHeaders(HttpHeader("foo", "bar")), Some(TransferEncoding.Chunked), None, Some(Connection.KeepAlive))
+      val b = new DynamicOutBuffer(500)
+      p.encode(b)
+      b.data.asByteString.utf8String mustBe "Transfer-Encoding: chunked\r\nConnection: keep-alive\r\nfoo: bar\r\n"
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/StreamServiceSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/StreamServiceSpec.scala
@@ -38,7 +38,7 @@ class StreamServiceSpec extends ColossusSpec with MockFactory with ControllerMoc
 
   def create(): (Con, TestUpstream[Encoding.Server[StreamHttp]])  = {
     val controllerstub = new TestUpstream[Encoding.Server[StreamHttp]]
-    val handler = new StreamServiceController[Encoding.Server[StreamHeader]](stub[ControllerDownstream[Encoding.Server[StreamingHttp]]], StreamRequestBuilder)
+    val handler = new StreamServiceController[Encoding.Server[StreamHeader]](stub[ControllerDownstream[Encoding.Server[StreamingHttp]]], StreamingHttpRequest)
     handler.setUpstream(controllerstub)
     (handler, controllerstub)
   }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -80,12 +80,14 @@ class ServiceClientSpec extends ColossusSpec with MockFactory {
 
   }
 
+  implicit val executor = FakeIOSystem.testExecutor
+
 
   "Service Client" must {
 
     "connect" in {
       val (endpoint, client, probe) = newClient()
-      client.connectionStatus must equal (ConnectionStatus.Connected)
+      CallbackAwait.result(client.connectionStatus, 1.second) must equal (ConnectionStatus.Connected)
     }
 
     "send a command" in {

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -1,9 +1,7 @@
 package colossus
 package service
 
-import java.net.InetSocketAddress
 
-import akka.actor.ActorRef
 import akka.util.ByteString
 import colossus.RawProtocol._
 import colossus.core._
@@ -12,9 +10,7 @@ import colossus.parsing.DataSize._
 import colossus.testkit._
 import streaming._
 
-import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
 import org.scalamock.scalatest.MockFactory
 
 class ServiceServerSpec extends ColossusSpec with MockFactory with ControllerMocks {

--- a/colossus-tests/src/test/scala/colossus/streaming/PipeSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/PipeSpec.scala
@@ -365,6 +365,16 @@ class PipeSpec extends ColossusSpec {
     }
   }
 
+  "Pipe.filterMap" must {
+    "filter and map correctly" in {
+      val p = new BufferedPipe[Int](10).filterMap{i => if (i > 3) Some(i.toString) else None}
+      p.push(4)
+      p.push(2)
+      p.pull() mustBe PullResult.Item("4")
+      p.pull() mustBe a[PullResult.Empty]
+    }
+  }
+
 
 
   "channel" must {

--- a/colossus-tests/src/test/scala/colossus/streaming/SourceSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/SourceSpec.scala
@@ -144,8 +144,7 @@ class SourceSpec extends ColossusSpec {
       s.pullWhile(
         i => {
           sum += i
-          s.terminate(new Exception("BYE"))
-          PullAction.PullContinue
+          PullAction.Terminate(new Exception("BYE"))
         },
         _ => ()
       )

--- a/colossus/src/main/scala/colossus/controller/Controller.scala
+++ b/colossus/src/main/scala/colossus/controller/Controller.scala
@@ -39,7 +39,7 @@ trait ControllerDownstream[E <: Encoding] extends HasUpstream[ControllerUpstream
 }
 
 //these are the method that a controller layer itself must implement for its downstream neighbor
-trait ControllerUpstream[E <: Encoding] extends UpstreamEvents {
+trait ControllerUpstream[-E <: Encoding] extends UpstreamEvents {
   def connection: ConnectionManager
   def outgoing: Sink[E#Output]
 }

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -199,6 +199,15 @@ class ParsedHttpHeaders(
 
   override def transferEncoding = if (transferEncodingOpt.isDefined) transferEncodingOpt.get else TransferEncoding.Identity
 
+  override def encode(buffer: core.DataOutBuffer) {
+    transferEncodingOpt.foreach{_.header.encode(buffer)}
+    connection.foreach{_.header.encode(buffer)}
+    contentLength.foreach{c => 
+      HttpHeader.encodeContentLength(buffer, c)
+    }
+    super.encode(buffer)
+  }
+
 }
 
 
@@ -318,6 +327,8 @@ object Cookie {
 
 sealed trait TransferEncoding {
   def value : String
+
+  lazy val header: HttpHeader = HttpHeader("Transfer-Encoding", value)
 }
 
 object TransferEncoding {
@@ -366,6 +377,8 @@ object ContentEncoding {
 
 sealed trait Connection {
   def value: String
+
+  lazy val header: HttpHeader = HttpHeader("Connection", value)
 }
 object Connection {
   case object KeepAlive extends Connection {

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -4,33 +4,39 @@ import scala.language.higherKinds
 
 import service._
 import scala.concurrent.{ExecutionContext, Future}
+import colossus.streaming.Source
 
 trait BaseHttpClient[M[_], B, P <: BaseHttp[B]] extends LiftedClient[P, M] {
+
+  def ops: MessageOps[HttpRequestHead, B, P#Request]// = implicitly[MessageOps[HttpRequestHead, B, P#Request]]
 
   protected lazy val hostHeader = clientConfig.map(config => {
     HttpHeader(HttpHeaders.Host, config.address.getHostName)
   })
+
+  override def send(input: P#Request): M[P#Response] = {
+    val headers = input.head.headers
+    val decoratedRequest = headers.firstValue(HttpHeaders.Host) match {
+      case Some(_) => input // Host header is already present.
+      case None => hostHeader.map(header => ops.withHeader(input,header)).getOrElse(input)
+    }
+    super.send(decoratedRequest)
+  }
+
 
 
 }
 
 trait HttpClient[M[_]]  extends LiftedClient[Http, M] with BaseHttpClient[M, HttpBody, Http] with HttpRequestBuilder[M[HttpResponse]]{ 
 
+  val ops = HttpRequestOps
 
   protected def build(req: HttpRequest) = send(req)
 
   val base = HttpRequest.base
 
-  override def send(input: HttpRequest): M[HttpResponse] = {
-    val headers = input.head.headers
-    val decoratedRequest = headers.firstValue(HttpHeaders.Host) match {
-      case Some(_) => input // Host header is already present.
-      case None => hostHeader.map(header => input.withHeader(header)).getOrElse(input)
-    }
-    super.send(decoratedRequest)
-  }
-
 }
+
 
 
 
@@ -45,12 +51,3 @@ object HttpClient {
   }
 
 }
-
-//trait StreamingHttpClient extends LiftedClient[StreamingHttp, Callback] with BaseClient[Callback, Source[Data]]
-
-/*
-object StreamingHttpClient {
-    
-  implicit object StreamingHttpClientLifter extends ClientLifter[
-}
-*/

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -7,29 +7,28 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait BaseHttpClient[M[_], B, P <: BaseHttp[B]] extends LiftedClient[P, M] {
 
-  private lazy val hostHeader = clientConfig.map(config => {
+  protected lazy val hostHeader = clientConfig.map(config => {
     HttpHeader(HttpHeaders.Host, config.address.getHostName)
   })
 
-  def ops: MessageOps[HttpRequestHead, B, P#Request]
-
-  override def send(input: P#Request): M[P#Response] = {
-    val headers = input.head.headers
-    val decoratedRequest: P#Request = headers.firstValue(HttpHeaders.Host) match {
-      case Some(_) => input // Host header is already present.
-      case None => hostHeader.map(header => ops.withHeader(input, header)).getOrElse(input)
-    }
-    super.send(decoratedRequest)
-  }
 
 }
 
-trait HttpClient[M[_]]  extends LiftedClient[Http, M] with BaseHttpClient[M, HttpBody] with HttpRequestBuilder[M[HttpResponse]]{ 
+trait HttpClient[M[_]]  extends LiftedClient[Http, M] with BaseHttpClient[M, HttpBody, Http] with HttpRequestBuilder[M[HttpResponse]]{ 
 
 
   protected def build(req: HttpRequest) = send(req)
 
   val base = HttpRequest.base
+
+  override def send(input: HttpRequest): M[HttpResponse] = {
+    val headers = input.head.headers
+    val decoratedRequest = headers.firstValue(HttpHeaders.Host) match {
+      case Some(_) => input // Host header is already present.
+      case None => hostHeader.map(header => input.withHeader(header)).getOrElse(input)
+    }
+    super.send(decoratedRequest)
+  }
 
 }
 
@@ -47,7 +46,7 @@ object HttpClient {
 
 }
 
-trait StreamingHttpClient extends LiftedClient[StreamingHttp, Callback] with BaseClient[Callback, Source[Data]]
+//trait StreamingHttpClient extends LiftedClient[StreamingHttp, Callback] with BaseClient[Callback, Source[Data]]
 
 /*
 object StreamingHttpClient {

--- a/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/StreamService.scala
@@ -11,10 +11,7 @@ import service._
 import scala.language.higherKinds
 import scala.util.{Try, Success, Failure}
 
-trait StreamingHttpMessage[T <: HttpMessageHead] {
-
-  def head: T
-  def body: Source[Data]
+trait StreamingHttpMessage[T <: HttpMessageHead] extends BaseHttpMessage[T, Source[Data]] {
 
   def collapse: Source[HttpStream[T]] = Source.one[HttpStream[T]](Head(head)) ++ body ++ Source.one[HttpStream[T]](End)
 }

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -15,12 +15,12 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
     def body: B
   }
 
-  type BaseHttp[B] = Protocol {
+  trait BaseHttp[B] extends Protocol {
     type Request <: BaseHttpMessage[HttpRequestHead, B]
     type Response <: BaseHttpMessage[HttpResponseHead, B]
   }
 
-  trait Http extends Protocol {
+  trait Http extends BaseHttp[HttpBody] {
     type Request = HttpRequest
     type Response = HttpResponse
   }
@@ -56,7 +56,7 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
 
   trait HttpMessage[H <: HttpMessageHead] extends BaseHttpMessage[H, HttpBody]
 
-  class MessageOps[H <: HttpMessageHead : HeadOps, B, M <: BaseHttpMessage[H,B]] {
+  abstract class MessageOps[H <: HttpMessageHead : HeadOps, B, M <: BaseHttpMessage[H,B]] {
     def build(head: H, body: B): M
 
     def withHeader(message: M, header: HttpHeader): M = build(implicitly[HeadOps[H]].withHeader(message.head, header), message.body)

--- a/colossus/src/main/scala/colossus/protocols/http/streaming/StreamingHttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/streaming/StreamingHttpClient.scala
@@ -1,0 +1,36 @@
+package colossus
+package protocols.http
+package streaming
+
+import stream._
+import controller._
+import core.{WorkerCommand, WorkerRef}
+
+import service._
+import colossus.streaming.Source
+
+trait StreamingHttpClient extends LiftedClient[StreamingHttp, Callback] with BaseHttpClient[Callback, Source[Data], StreamingHttp] {
+  
+  val ops = StreamingHttpRequestOps
+}
+
+object StreamingHttpClient {
+    
+  val client = new ClientFactory[StreamingHttp, Callback, StreamingHttpClient, WorkerRef] {
+    def defaultName = "streaming-http-client"
+
+    def apply(config: ClientConfig)(implicit worker: WorkerRef): StreamingHttpClient = {
+      val client = new ServiceClient[StreamingHttp](config, worker.generateContext())
+      val handler = new UnbindHandler(
+        new Controller[Encoding.Client[StreamHttp]](
+          new HttpStreamClientController(client),
+          new StreamHttpClientCodec
+        ), 
+        client
+      )
+      worker.worker ! WorkerCommand.Bind(handler)
+      new BasicLiftedClient(client, Some(config))(implicitly[AsyncBuilder[Callback, WorkerRef]].build(worker)) with StreamingHttpClient
+    }
+  }
+
+}

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -75,7 +75,8 @@ class AsyncHandlerGenerator[C <: Protocol](config: ClientConfig, base: FutureCli
         client.send(request).execute(promise.complete)
       }
       case FutureClient.GetConnectionStatus(promise) => {
-        promise.success(client.connectionStatus)
+        import scala.concurrent.ExecutionContext.Implicits.global
+        promise.completeWith(client.connectionStatus.toFuture)
       }
 
     }

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -39,11 +39,13 @@ object FutureClient {
 
   sealed trait ClientCommand
 
+  type BaseFactory[P <: Protocol] = ClientFactory[P, Callback, Client[P,Callback], WorkerRef]
+
   case class GetConnectionStatus(promise: Promise[ConnectionStatus] = Promise()) extends ClientCommand
 
-  def apply[C <: Protocol](config: ClientConfig)(implicit io: IOSystem, base: ServiceClientFactory[C]): FutureClient[C] = create(config)(io, base)
+  def apply[C <: Protocol](config: ClientConfig)(implicit io: IOSystem, base: BaseFactory[C]): FutureClient[C] = create(config)(io, base)
 
-  def create[C <: Protocol](config: ClientConfig)(implicit io: IOSystem, base: ServiceClientFactory[C]): FutureClient[C] = {
+  def create[C <: Protocol](config: ClientConfig)(implicit io: IOSystem, base: BaseFactory[C]): FutureClient[C] = {
     val gen = new AsyncHandlerGenerator(config, base)
     gen.client
   }
@@ -57,7 +59,7 @@ object FutureClient {
  * without using reflection.  We can do that with some nifty path-dependant
  * types
  */
-class AsyncHandlerGenerator[C <: Protocol](config: ClientConfig, base: ServiceClientFactory[C])(implicit sys: IOSystem) {
+class AsyncHandlerGenerator[C <: Protocol](config: ClientConfig, base: FutureClient.BaseFactory[C])(implicit sys: IOSystem) {
 
   type I = C#Request
   type O = C#Response

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -227,11 +227,11 @@ extends ControllerDownstream[Encoding.Client[P]] with HasUpstream[ControllerUpst
   //TODO way too application specific
   private val hpTags: TagMap = Map("client_host" -> address.getHostName, "client_port" -> address.getPort.toString)
 
-  def connectionStatus: ConnectionStatus = clientState match {
+  def connectionStatus: Callback[ConnectionStatus] = Callback.successful(clientState match {
     case ClientState.Connected => ConnectionStatus.Connected
     case ClientState.Initializing | ClientState.Connecting => ConnectionStatus.Connecting
     case _ => ConnectionStatus.NotConnected
-  }
+  })
 
   /**
    * returns true if the client is potentially able to send.  This does not

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -158,7 +158,7 @@ class ServiceClient[P <: Protocol](
   val config: ClientConfig,
   val context: Context
 )(implicit tagDecorator: TagDecorator[P] = TagDecorator.default[P])
-extends ControllerDownstream[Encoding.Client[P]] with HasUpstream[ControllerUpstream[Encoding.Client[P]]] with Sender[P, Callback] with HandlerTail {
+extends ControllerDownstream[Encoding.Client[P]] with HasUpstream[ControllerUpstream[Encoding.Client[P]]] with Client[P, Callback] with HandlerTail {
 
   type Request = Encoding.Client[P]#Output
   type Response = Encoding.Client[P]#Input

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -173,6 +173,9 @@ trait ServiceClientFactory[P <: Protocol] extends ClientFactory[P, Callback, Ser
   def codecProvider: Codec.Client[P]
 
   def apply(config: ClientConfig)(implicit worker: WorkerRef): ServiceClient[P] = {
+    //TODO : binding a client needs to be split up from creating the connection handler
+    // we should make a method called "create" the abstract method, and have
+    // this apply call it, then move this to a more generic parent type
     val base = new ServiceClient[P](config, worker.generateContext())
     val handler = connectionHandler(base, codecProvider)
     worker.worker ! WorkerCommand.Bind(handler)
@@ -226,7 +229,7 @@ extends ClientFactory[C,M,T[M],E] {
  */
 abstract class ClientFactories[C <: Protocol, T[M[_]] <: Sender[C, M]](implicit lifter: ClientLifter[C,T]) {
 
-  implicit def clientFactory: ServiceClientFactory[C]
+  implicit def clientFactory: FutureClient.BaseFactory[C]
 
   implicit val futureFactory = new FutureClientFactory[C](clientFactory)
 

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -110,13 +110,13 @@ trait BasicServiceDSL[P <: Protocol] {
  *
  * For example this is how we go from ServiceClient[HttpRequest, HttpResponse] to HttpClient[Callback]
  */
-trait ClientLifter[M[_], C <: Protocol, T[_[_]] <: Sender[C,M]] {
+trait ClientLifter[C <: Protocol, T[M[_]] <: Sender[C,M]] {
 
-  def lift(baseClient: Sender[C, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) : T[M]
+  def lift[M[_]](baseClient: Sender[C, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) : T[M]
 
 }
 
-trait ClientFactory[C <: Protocol, M[_], T <: Sender[C,M], E] {
+trait ClientFactory[C <: Protocol, M[_], +T <: Sender[C,M], E] {
 
   def defaultName: String
 
@@ -228,7 +228,7 @@ abstract class ClientFactories[C <: Protocol, T[M[_]] <: Sender[C, M]](implicit 
 
   implicit def clientFactory: ServiceClientFactory[C]
 
-  implicit val futureFactory = new FutureClientFactory(clientFactory)
+  implicit val futureFactory = new FutureClientFactory[C](clientFactory)
 
   val client = new CodecClientFactory[C, Callback, T, WorkerRef]
 

--- a/colossus/src/main/scala/colossus/streaming/Sink.scala
+++ b/colossus/src/main/scala/colossus/streaming/Sink.scala
@@ -8,7 +8,7 @@ import scala.util.{Try, Success, Failure}
  * the pipe is full, the Sink will return a mutable Trigger and you can
  * attach a callback to for when the pipe can receive more items
  */
-trait Sink[T] extends Transport {
+trait Sink[-T] extends Transport {
   def push(item: T): PushResult
 
   def pushPeek: PushResult

--- a/colossus/src/main/scala/colossus/streaming/Source.scala
+++ b/colossus/src/main/scala/colossus/streaming/Source.scala
@@ -156,7 +156,7 @@ trait Source[+T] extends Transport {
    * @param linkClosed if true, the linked sink will be closed when this source is closed
    * @param linkTerminated if true, the linked sink will be terminated when this source is terminated
    */
-  def into[U >: T] (sink: Sink[U], linkClosed: Boolean, linkTerminated: Boolean)(onComplete: NonOpenTransportState => Any) {
+  def into[X >: T] (sink: Sink[X], linkClosed: Boolean, linkTerminated: Boolean)(onComplete: NonOpenTransportState => Any) {
     pullWhile (
       i => sink.push(i) match {
         case PushResult.Ok                  => PullAction.PullContinue
@@ -181,7 +181,7 @@ trait Source[+T] extends Transport {
   }
 
 
-  def into[U >: T] (sink: Sink[U]) {
+  def into[X >: T] (sink: Sink[X]) {
     into(sink, true, true)( _ => ())
   }
 

--- a/colossus/src/main/scala/colossus/streaming/Source.scala
+++ b/colossus/src/main/scala/colossus/streaming/Source.scala
@@ -194,7 +194,6 @@ object Source {
     def pullWhile(fn: T => PullAction, onComplete: TerminalPullResult => Any){
       import PullAction._
       var continue = true
-      println(this)
       while (continue) {
         continue = peek match {
           case PullResult.Empty(trig) => {
@@ -295,7 +294,9 @@ object Source {
               signal.notify(pullWhile(fn, onComplete))
               continue = false
             }
-            case _ => {}
+            case _ => {
+              continue = false
+            }
           }
         } else {
           onComplete(PullResult.Closed)

--- a/colossus/src/main/scala/colossus/streaming/StreamTranscoder.scala
+++ b/colossus/src/main/scala/colossus/streaming/StreamTranscoder.scala
@@ -55,7 +55,6 @@ with UpstreamEventHandler[ControllerUpstream[U]] {
 
   val outgoing = new PipeCircuitBreaker[DO, UO]
 
-
   def inputStream : Pipe[UI, DI] = {
     val p = new BufferedPipe[UI](100)
     new Channel(p, transcoder.transcodeInput(p))

--- a/colossus/src/main/scala/colossus/streaming/StreamTranscoder.scala
+++ b/colossus/src/main/scala/colossus/streaming/StreamTranscoder.scala
@@ -1,0 +1,89 @@
+package colossus
+package streaming
+
+import controller._
+import core._
+
+
+/**
+ * A Transcoder is used to convert streams of one encoding to streams of
+ * another.  The two streams are intended to be part of a duplex pipeline, so
+ * input is transcoded from A to B, and output is transcoded the other way B to
+ * A
+ */
+trait Transcoder[U <: Encoding, D <: Encoding] {
+
+  // this seems to be a bug in the compiler, but these type aliases are mandatory
+  // to make this code compile
+  type UI = U#Input
+  type UO = U#Output
+  type DI = D#Input
+  type DO = D#Output
+
+  def transcodeInput(source: Source[UI]): Source[DI]
+  def transcodeOutput(source: Source[DO]): Source[UO]
+}
+
+
+/**
+ * This controller interface can be used to transcode from one encoding to
+ * another in a connection handler pipeline
+ */
+class StreamTranscodingController[
+  U <: Encoding,
+  D <: Encoding
+] (
+  val downstream: ControllerDownstream[D],
+  transcoder: Transcoder[U,D]
+)
+extends ControllerDownstream[U] 
+with DownstreamEventHandler[ControllerDownstream[D]] 
+with ControllerUpstream[D]
+with UpstreamEventHandler[ControllerUpstream[U]] {
+
+  downstream.setUpstream(this)
+
+  type UI = U#Input
+  type UO = U#Output
+  type DI = D#Input
+  type DO = D#Output
+
+  def outputStream: Pipe[DO, UO] = {
+    val p = new BufferedPipe[DO](100)
+    new Channel[DO, UO](p, transcoder.transcodeOutput(p))
+  }
+
+  val outgoing = new PipeCircuitBreaker[DO, UO]
+
+
+  def inputStream : Pipe[UI, DI] = {
+    val p = new BufferedPipe[UI](100)
+    new Channel(p, transcoder.transcodeInput(p))
+  }
+
+  val incoming = new PipeCircuitBreaker[UI, DI]
+
+  override def onConnected() {
+    
+    outgoing.set(outputStream)
+    outgoing.into(upstream.outgoing, true, true){e => fatal(e.toString)}
+
+    incoming.set(inputStream)
+    incoming.into(downstream.incoming, true, true){e => fatal(e.toString)}
+  }
+
+  override def onConnectionTerminated(reason: DisconnectCause) {
+    outgoing.unset()
+    incoming.unset()
+  }
+
+  protected def fatal(message: String) {
+    println(s"FATAL ERROR: $message")
+    upstream.connection.forceDisconnect()
+  }
+
+  def controllerConfig: colossus.controller.ControllerConfig = downstream.controllerConfig
+
+  def connection: colossus.core.ConnectionManager = upstream.connection
+
+}

--- a/colossus/src/main/scala/colossus/streaming/package.scala
+++ b/colossus/src/main/scala/colossus/streaming/package.scala
@@ -28,6 +28,40 @@ package object streaming {
 
   }
 
+  implicit object SourceFilterMapper {
+    
+    def filterMap[A,B](source: Source[A], fn: A => Option[B]): Source[B] = new Source[B] {
+      def pull(): PullResult[B] = source.pull().map(fn) match {
+        case PullResult.Item(Some(item)) => PullResult.Item(item)
+        case PullResult.Item(None)       => pull()
+        case other                       => other.asInstanceOf[PullResult[B]]
+      }
+
+      def peek = source.peek.map(fn) match {
+        case PullResult.Item(Some(item)) => PullResult.Item(item)
+        case PullResult.Item(None)       => {
+          source.pull()
+          peek
+        }
+        case other                       => other.asInstanceOf[PullResult[B]]
+      }
+      def outputState = source.outputState
+      def terminate(err: Throwable) {
+        source.terminate(err)
+      }
+      override def pullWhile(whilefn: B => PullAction, onc: TerminalPullResult => Any) {
+        source.pullWhile(x => fn(x) match {
+          case Some(item) => whilefn(item)
+          case None => PullAction.PullContinue
+        }, onc)
+      }
+    }
+  }
+
+  implicit class SourceOps[A](val source: Source[A]) extends AnyVal {
+    def filterMap[B](f: A => Option[B]): Source[B] = SourceFilterMapper.filterMap(source, f)
+  }
+
   //note - sadly trying to unify this with a HKT like Functor doesn't seem to
   //work since type inferrence fails on the type-lambda needed to squash
   //Pipe[_,_] down to M[_].  See: https://issues.scala-lang.org/browse/SI-6895
@@ -35,6 +69,11 @@ package object streaming {
   implicit class PipeOps[A,B](val pipe: Pipe[A,B]) extends AnyVal {
     def map[C](fn: B => C): Pipe[A,C] = {
       val mappedsource = SourceMapper.map(pipe, fn)
+      new Channel(pipe, mappedsource)
+    }
+
+    def filterMap[C](fn: B => Option[C]) : Pipe[A,C] = {
+      val mappedsource = SourceFilterMapper.filterMap(pipe, fn)
       new Channel(pipe, mappedsource)
     }
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,8 +17,8 @@ object ColossusBuild extends Build {
     compile <<= (compile in Compile) dependsOn (compile in Test) dependsOn (compile in IntegrationTest),
     (testAll) <<= (test in Test) dependsOn (test in IntegrationTest),
     organization := "com.tumblr",
-    scalaVersion  := "2.11.7",
-    crossScalaVersions := Seq("2.10.6", "2.11.7"),
+    scalaVersion  := "2.11.8",
+    crossScalaVersions := Seq("2.10.6", "2.11.8"),
     version                   := "0.9.0-SNAPSHOT",
     parallelExecution in Test := false,
     scalacOptions <<= scalaVersion map { v: String =>


### PR DESCRIPTION
There are several significant changes in this PR focused on cleaning up and generalizing some of the http streaming code:

* Began moving some streaming-related files into a new streaming sub-folder.  I will have another PR that moves some other files containing unchanged code.
* The `StreamServiceController` has been generalized into `StreamTranscodingController`.  Not only can this class now be used with streaming protocols besides http, but it can work for both server and client connections.  This definitely took a little type trickery to get all the parameters to behave with http, but it is all hidden from end-users.  This should also work as the multiplexing layer for http2
* New `StreamingHttpClient`.  Unlike other clients, there will be no `Future` version of this client, since at least for now streams are not thread-safe.
* A new `BaseHttpMessage[H,B]` type that can serve as a base trait for all http protocols, including (eventually) http2.  This opens the door for being able to do write more generic types and operations on http, http-stream, and streaming-http messages.
* A new `filterMap` typeclass operation on sources, used by streaming http as part of the decoding process.
* Few small bug fixes encountered along the way

All existing tests pass.  I may add a few more if test coverage is too low.