### PR TITLE
Minor code cleanup

### DIFF
--- a/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus-examples/StreamServiceExample.scala
@@ -20,7 +20,7 @@ object StreamServiceExample {
       requestMetrics = false
     )
 
-    StreamingHttpServer.basic("stream-service", port, new GenRequestHandler[StreamingHttp](config, _) {
+    StreamingHttpServer.basic("stream-service", port, new GenRequestHandler[StreamingHttp](_, config) {
 
       def handle = {
         case StreamingHttpRequest(head, source) if (head.url == "/plaintext") => source.collected.map{_ =>

--- a/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ColossusSpec.scala
@@ -3,6 +3,7 @@ package testkit
 
 import colossus.metrics.MetricSystem
 import core._
+import server._
 
 import org.scalatest._
 

--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -2,6 +2,7 @@ package colossus
 package testkit
 
 import core.{InitContext, _}
+import core.server._
 import metrics._
 import service._
 import akka.agent.Agent

--- a/colossus-testkit/src/main/scala/colossus-testkit/MockClientFactory.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/MockClientFactory.scala
@@ -1,0 +1,30 @@
+package colossus.testkit
+
+import scala.language.higherKinds
+import colossus.IOSystem
+import colossus.core.WorkerRef
+import colossus.service._
+import scala.concurrent.Future
+
+object MockSender {
+
+  def apply[P <: Protocol, M[_] ](responder: P#Request => M[P#Response]): Sender[P,M] = new Sender[P, M] {
+    def send(request: P#Request): M[P#Response] = responder(request)
+
+    def disconnect(){}
+  }
+}
+
+object MockClientFactory {
+
+  def apply[P <: Protocol, M[_]  , E](responder: P#Request => M[P#Response]): ClientFactory[P, M, Sender[P,M], E]  = new ClientFactory[P,M,Sender[P,M], E] {
+
+    def apply(config: ClientConfig)(implicit env: E) = MockSender[P,M](responder)
+
+    def defaultName = "mock-client"
+  }
+
+  def client[P <: Protocol](responder: P#Request => Callback[P#Response]): ClientFactory[P, Callback, Sender[P, Callback], WorkerRef] = apply(responder)
+
+  def futureClient[P <: Protocol](responder: P#Request => Future[P#Response]): ClientFactory[P, Future, Sender[P, Future], IOSystem] = apply(responder)
+}

--- a/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
@@ -11,7 +11,7 @@ import core.ServerRef
 import service._
 import scala.reflect.ClassTag
 
-abstract class ServiceSpec[C <: Protocol](implicit clientFactory: FutureClientFactory[C]) extends ColossusSpec {
+abstract class ServiceSpec[C <: Protocol](implicit clientFactory: GenFutureClientFactory[C]) extends ColossusSpec {
   
   type Request = C#Request
   type Response = C#Response

--- a/colossus-testkit/src/test/scala/colossus/MockClientSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus/MockClientSpec.scala
@@ -1,0 +1,38 @@
+package colossus.testkit
+
+import colossus.service._
+import colossus.protocols.http._
+import java.net.InetSocketAddress
+import scala.concurrent.duration._
+
+class MockClientSpec extends ColossusSpec {
+
+  implicit val ex = FakeIOSystem.testExecutor
+
+  "MockClient" must {
+    "work" in {
+      implicit val worker = FakeIOSystem.fakeWorker.worker
+      val c: HttpClient[Callback] = Http.client(MockSender[Http, Callback](( request: HttpRequest) => Callback.successful(request.ok("hi"))))
+
+      CallbackAwait.result(c.send(HttpRequest.get("foo")), 1.second).body.asDataBlock.utf8String mustBe "hi"
+    }
+  }
+
+
+  "MockClientFactory" must {
+    "work with LoadBalancingClient" in {
+      implicit val worker = FakeIOSystem.fakeWorker.worker
+      val l: LoadBalancingClient[Http] = new LoadBalancingClient(
+        List(new InetSocketAddress("1.1.1.1", 34)),
+        ClientConfig(address = new InetSocketAddress("0.0.0.0", 1), name = "/foo", requestTimeout = 1.second),
+        MockClientFactory.client[Http]((x: HttpRequest) => Callback.successful(x.ok("test"))),
+        4
+      )
+
+      CallbackAwait.result(l.send(HttpRequest.get("foo")), 1.second).body.asDataBlock.utf8String mustBe "test"
+    }
+  }
+        
+
+}
+

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -4,6 +4,7 @@ import java.net.InetSocketAddress
 
 import akka.util.{ByteString, Timeout}
 import colossus.core._
+import server._
 import controller.{Codec, Encoding}
 import colossus.service.{FutureClient, ClientConfig, Protocol}
 

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -1,4 +1,5 @@
 package colossus.core
+package server
 
 import colossus.EchoHandler
 import colossus.metrics.MetricAddress

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -1,5 +1,6 @@
 package colossus
 package core
+package server
 
 import colossus.metrics.MetricSystem
 import testkit._

--- a/colossus-tests/src/test/scala/colossus/service/LoadBalancingClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/LoadBalancingClientSpec.scala
@@ -164,6 +164,18 @@ class LoadBalancingClientSpec extends ColossusSpec with MockFactory{
       (removed.disconnect _).verify()
 
     }
+
+    "work with client factories" in {
+      //if this compiles then the test passes
+      import protocols.http.Http
+      implicit val w = FakeIOSystem.fakeWorker.worker
+      val l = new LoadBalancingClient[Http](
+        List(new InetSocketAddress("127.0.0.1", 1)),
+        ClientConfig(address = new InetSocketAddress("0.0.0.0", 1), name = "/foo", requestTimeout = 1.second),
+        Http.client,
+        4
+      )
+    }
       
   }
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -20,7 +20,7 @@ class ServiceServerSpec extends ColossusSpec with MockFactory with ControllerMoc
     maxRequestSize = 300.bytes
   )
 
-  class FakeHandler(handler: ByteString => Callback[ByteString] = x => Callback.successful(x), context: ServerContext) extends GenRequestHandler[Raw](config, context) {
+  class FakeHandler(handler: ByteString => Callback[ByteString] = x => Callback.successful(x), context: ServerContext) extends GenRequestHandler[Raw](context, config) {
 
     def handle = { case req => handler(req) }
     def unhandledError = {case _ => ByteString("ERROR")}

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -4,6 +4,7 @@ package core
 import scala.concurrent.duration._
 import java.nio.channels.{SelectionKey, SocketChannel}
 import java.net.InetSocketAddress
+import server._
 
 /**
  * Represent the connection state.  NotConnected, Connected or Connecting.

--- a/colossus/src/main/scala/colossus/core/Context.scala
+++ b/colossus/src/main/scala/colossus/core/Context.scala
@@ -1,0 +1,42 @@
+package colossus
+package core
+
+import akka.actor.{ActorRef, Props}
+
+/**
+ * Represents the binding of an item to a worker
+ *
+ * @param id the id used to reference the worker item
+ * @param worker the worker the item is bound to
+ */
+class Context(val id: Long, val worker: WorkerRef) {
+
+  def !(message: Any)(implicit sender: ActorRef) {
+    worker.worker ! WorkerCommand.Message(id, message)
+  }
+
+  def unbind() {
+    worker.worker ! WorkerCommand.UnbindWorkerItem(id)
+  }
+
+  private[colossus] lazy val proxy : ActorRef = {
+    _proxyExists = true
+    worker.system.actorSystem.actorOf(Props(classOf[WorkerItemProxy], id, worker))
+  }
+
+  private var _proxyExists = false
+  private[colossus] def proxyExists = _proxyExists
+}
+
+
+/**
+ * An instance of this is handed to every new server connection handler
+ */
+case class ServerContext(server: ServerRef, context: Context) {
+  def name: String = server.name.idString
+}
+
+/**
+ * An instance of this is handed to every new initializer for a server
+ */
+case class InitContext(server: ServerRef, worker: WorkerRef)

--- a/colossus/src/main/scala/colossus/core/ServerRef.scala
+++ b/colossus/src/main/scala/colossus/core/ServerRef.scala
@@ -1,0 +1,80 @@
+package colossus
+package core
+
+import akka.actor.{ActorRef, PoisonPill}
+import akka.agent.Agent
+import akka.pattern.ask
+import akka.util.Timeout
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+import metrics._
+
+import server._
+
+/**
+ * A `ServerRef` is a handle to a created server.  It can be used to get basic
+ * information about the state of the server as well as send operational
+ * commands to it.
+ *
+ * @param config The ServerConfig used to create this Server
+ * @param server The ActorRef of the Server
+ * @param system The IOSystem to which this Server belongs
+ * @param serverStateAgent The current state of the Server.
+ */
+case class ServerRef private[colossus] (config: ServerConfig, server: ActorRef, system: IOSystem, private val serverStateAgent : Agent[ServerState]) {
+  def name = config.name
+
+  def serverState = serverStateAgent.get()
+
+  val namespace : MetricNamespace = system.namespace / name
+
+  def maxIdleTime = {
+    if(serverStateAgent().connectionVolumeState == ConnectionVolumeState.HighWater) {
+      config.settings.highWaterMaxIdleTime
+    } else {
+      config.settings.maxIdleTime
+    }
+  }
+
+  def info(): Future[Server.ServerInfo] = {
+    implicit val timeout = Timeout(1.second)
+    (server ? Server.GetInfo).mapTo[Server.ServerInfo]
+  }
+
+  /**
+   * Broadcast a message to a all of the [[Initializer]]s of this server.
+   *
+   * @param message
+   * @param sender
+   * @return
+   */
+  @deprecated("function has been deprecated, please use `initializerBroadcast` instead", "0.9.0")
+  def delegatorBroadcast(message: Any)(implicit sender: ActorRef = ActorRef.noSender) {
+    initializerBroadcast(message)
+  }
+
+  def initializerBroadcast(message: Any)(implicit sender: ActorRef = ActorRef.noSender) {
+    server.!(Server.InitializerBroadcast(message))(sender)
+  }
+
+  /**
+   * Gracefully shutdown this server.  This will cause the server to
+   * immediately begin refusing connections, but attempt to allow existing
+   * connections to close on their own.  The `shutdownRequest` method will be
+   * called on every `ServerConnectionHandler` associated with this server.
+   * `shutdownTimeout` in `ServerSettings` controls how long the server will
+   * wait before it force-closes all connections and shuts down.  The server
+   * actor will remain alive until it is fully shutdown.
+   */
+  def shutdown() {
+    server ! Server.Shutdown
+  }
+
+  /**
+   * Immediately kill the server and all corresponding open connections.
+   */
+  def die() {
+    server ! PoisonPill
+  }
+}

--- a/colossus/src/main/scala/colossus/core/ServerSettings.scala
+++ b/colossus/src/main/scala/colossus/core/ServerSettings.scala
@@ -1,0 +1,95 @@
+package colossus
+package core
+
+import com.typesafe.config.{Config, ConfigFactory}
+import scala.concurrent.duration._
+
+/** Contains values for configuring how a Server operates
+ *
+ * These are all lower-level configuration settings that are for the most part
+ * not concerned with a server's application behavior
+ *
+ * The low/high watermark percentages are used to help mitigate connection
+ * overload.  When a server hits the high watermark percentage of live
+ * connections, it will change the idle timeout from `maxIdleTime` to
+ * `highWaterMaxIdleTime` in an attempt to more aggressively close idle
+ * connections.  This will continue until the percentage drops below
+ * `lowWatermarkPercentage`.  This can be totally disabled by just setting both
+ * watermarks to 1.
+ *
+ * @param port Port on which this Server will accept connections
+ * @param maxConnections Max number of simultaneous live connections
+ * @param lowWatermarkPercentage Percentage of live/max connections which represent a normal state
+ * @param highWatermarkPercentage Percentage of live/max connections which represent a high water state.
+ * @param maxIdleTime Maximum idle time for connections when in non high water conditions
+ * @param highWaterMaxIdleTime Max idle time for connections when in high water conditions.
+ * @param tcpBacklogSize Set the max number of simultaneous connections awaiting accepting, or None for NIO default
+ *
+ * @param bindingRetry A [[colossus.core.RetryPolicy]] describing how to retry
+ * binding to the port if the first attempt fails.  By default it will keep
+ * retrying forever.
+ *
+ * @param delegatorCreationPolicy A [[colossus.core.WaitPolicy]] describing how
+ * to handle delegator startup.  Since a Server waits for a signal from the
+ * [[colossus.IOSystem]] that every worker has properly initialized a
+ * [[colossus.core.Initializer]], this determines how long to wait before the
+ * initialization is considered a failure and whether to retry the
+ * initialization.
+ *
+ * @param shutdownTimeout Once a Server begins to shutdown, it will signal a
+ * request to every open connection.  This determines how long it will wait for
+ * every connection to self-terminate before it forcibly closes them and
+ * completes the shutdown.
+ */
+case class ServerSettings(
+  port: Int,
+  slowStart: ConnectionLimiterConfig = ConnectionLimiterConfig.NoLimiting,
+  maxConnections: Int = 1000,
+  maxIdleTime: Duration = Duration.Inf,
+  lowWatermarkPercentage: Double = 0.75,
+  highWatermarkPercentage: Double = 0.85,
+  highWaterMaxIdleTime : FiniteDuration = 100.milliseconds,
+  tcpBacklogSize: Option[Int] = None,
+  bindingRetry : RetryPolicy = BackoffPolicy(100.milliseconds, BackoffMultiplier.Exponential(1.second)),
+  delegatorCreationPolicy : WaitPolicy = WaitPolicy(500.milliseconds, BackoffPolicy(50.milliseconds, BackoffMultiplier.Constant)),
+  shutdownTimeout: FiniteDuration = 100.milliseconds
+) {
+  def lowWatermark = lowWatermarkPercentage * maxConnections
+  def highWatermark = highWatermarkPercentage * maxConnections
+}
+
+object ServerSettings {
+  val ConfigRoot = "colossus.server"
+
+  def extract(config : Config) : ServerSettings = {
+    import colossus.metrics.ConfigHelpers._
+
+    val bindingRetry = RetryPolicy.fromConfig(config.getConfig("binding-retry"))
+    val delegatorCreationPolicy = WaitPolicy.fromConfig(config.getConfig("delegator-creation-policy"))
+
+    ServerSettings (
+      port                    = config.getInt("port"),
+      maxConnections          = config.getInt("max-connections"),
+      slowStart               = ConnectionLimiterConfig.fromConfig(config.getConfig("slow-start")),
+      maxIdleTime             = config.getScalaDuration("max-idle-time"),
+      lowWatermarkPercentage  = config.getDouble("low-watermark-percentage"),
+      highWatermarkPercentage = config.getDouble("high-watermark-percentage"),
+      highWaterMaxIdleTime    = config.getFiniteDuration("highwater-max-idle-time"),
+      tcpBacklogSize          = config.getIntOption("tcp-backlog-size"),
+      bindingRetry            = bindingRetry,
+      delegatorCreationPolicy = delegatorCreationPolicy,
+      shutdownTimeout         = config.getFiniteDuration("shutdown-timeout")
+    )
+  }
+
+  def load(name: String, config: Config = ConfigFactory.load()): ServerSettings = {
+    val nameRoot = ConfigRoot + "." + name
+    val resolved = if (config.hasPath(nameRoot)) {
+      config.getConfig(nameRoot).withFallback(config.getConfig(ConfigRoot))
+    } else {
+      config.getConfig(ConfigRoot)
+    }
+    extract(resolved)
+
+  }
+}

--- a/colossus/src/main/scala/colossus/core/Worker.scala
+++ b/colossus/src/main/scala/colossus/core/Worker.scala
@@ -1,6 +1,8 @@
 package colossus
 package core
 
+import server._
+
 import akka.actor._
 import akka.event.LoggingAdapter
 import metrics._

--- a/colossus/src/main/scala/colossus/core/WorkerItem.scala
+++ b/colossus/src/main/scala/colossus/core/WorkerItem.scala
@@ -7,30 +7,6 @@ import scala.concurrent.duration.FiniteDuration
 
 class WorkerItemException(message: String) extends Exception(message)
 
-/**
- * Represents the binding of an item to a worker
- *
- * @param id the id used to reference the worker item
- * @param worker the worker the item is bound to
- */
-class Context(val id: Long, val worker: WorkerRef) {
-
-  def !(message: Any)(implicit sender: ActorRef) {
-    worker.worker ! WorkerCommand.Message(id, message)
-  }
-
-  def unbind() {
-    worker.worker ! WorkerCommand.UnbindWorkerItem(id)
-  }
-
-  private[colossus] lazy val proxy : ActorRef = {
-    _proxyExists = true
-    worker.system.actorSystem.actorOf(Props(classOf[WorkerItemProxy], id, worker))
-  }
-
-  private var _proxyExists = false
-  private[colossus] def proxyExists = _proxyExists
-}
 
 /**
  * This trait contains event handler methods for when a worker item is

--- a/colossus/src/main/scala/colossus/core/server/Server.scala
+++ b/colossus/src/main/scala/colossus/core/server/Server.scala
@@ -1,111 +1,15 @@
 package colossus
 package core
+package server
 
 import akka.actor._
 import akka.agent.Agent
-import akka.pattern.ask
-import akka.util.Timeout
-import com.typesafe.config.{Config, ConfigFactory}
 import java.net.{InetSocketAddress, ServerSocket}
 import java.nio.channels.{SelectionKey, Selector, ServerSocketChannel, SocketChannel}
 import metrics._
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._
-import scala.concurrent.Future
 
-
-
-
-
-/** Contains values for configuring how a Server operates
- *
- * These are all lower-level configuration settings that are for the most part
- * not concerned with a server's application behavior
- *
- * The low/high watermark percentages are used to help mitigate connection
- * overload.  When a server hits the high watermark percentage of live
- * connections, it will change the idle timeout from `maxIdleTime` to
- * `highWaterMaxIdleTime` in an attempt to more aggressively close idle
- * connections.  This will continue until the percentage drops below
- * `lowWatermarkPercentage`.  This can be totally disabled by just setting both
- * watermarks to 1.
- *
- * @param port Port on which this Server will accept connections
- * @param maxConnections Max number of simultaneous live connections
- * @param lowWatermarkPercentage Percentage of live/max connections which represent a normal state
- * @param highWatermarkPercentage Percentage of live/max connections which represent a high water state.
- * @param maxIdleTime Maximum idle time for connections when in non high water conditions
- * @param highWaterMaxIdleTime Max idle time for connections when in high water conditions.
- * @param tcpBacklogSize Set the max number of simultaneous connections awaiting accepting, or None for NIO default
- *
- * @param bindingRetry A [[colossus.core.RetryPolicy]] describing how to retry
- * binding to the port if the first attempt fails.  By default it will keep
- * retrying forever.
- *
- * @param delegatorCreationPolicy A [[colossus.core.WaitPolicy]] describing how
- * to handle delegator startup.  Since a Server waits for a signal from the
- * [[colossus.IOSystem]] that every worker has properly initialized a
- * [[colossus.core.Initializer]], this determines how long to wait before the
- * initialization is considered a failure and whether to retry the
- * initialization.
- *
- * @param shutdownTimeout Once a Server begins to shutdown, it will signal a
- * request to every open connection.  This determines how long it will wait for
- * every connection to self-terminate before it forcibly closes them and
- * completes the shutdown.
- */
-case class ServerSettings(
-  port: Int,
-  slowStart: ConnectionLimiterConfig = ConnectionLimiterConfig.NoLimiting,
-  maxConnections: Int = 1000,
-  maxIdleTime: Duration = Duration.Inf,
-  lowWatermarkPercentage: Double = 0.75,
-  highWatermarkPercentage: Double = 0.85,
-  highWaterMaxIdleTime : FiniteDuration = 100.milliseconds,
-  tcpBacklogSize: Option[Int] = None,
-  bindingRetry : RetryPolicy = BackoffPolicy(100.milliseconds, BackoffMultiplier.Exponential(1.second)),
-  delegatorCreationPolicy : WaitPolicy = WaitPolicy(500.milliseconds, BackoffPolicy(50.milliseconds, BackoffMultiplier.Constant)),
-  shutdownTimeout: FiniteDuration = 100.milliseconds
-) {
-  def lowWatermark = lowWatermarkPercentage * maxConnections
-  def highWatermark = highWatermarkPercentage * maxConnections
-}
-
-object ServerSettings {
-  val ConfigRoot = "colossus.server"
-
-  def extract(config : Config) : ServerSettings = {
-    import colossus.metrics.ConfigHelpers._
-
-    val bindingRetry = RetryPolicy.fromConfig(config.getConfig("binding-retry"))
-    val delegatorCreationPolicy = WaitPolicy.fromConfig(config.getConfig("delegator-creation-policy"))
-
-    ServerSettings (
-      port                    = config.getInt("port"),
-      maxConnections          = config.getInt("max-connections"),
-      slowStart               = ConnectionLimiterConfig.fromConfig(config.getConfig("slow-start")),
-      maxIdleTime             = config.getScalaDuration("max-idle-time"),
-      lowWatermarkPercentage  = config.getDouble("low-watermark-percentage"),
-      highWatermarkPercentage = config.getDouble("high-watermark-percentage"),
-      highWaterMaxIdleTime    = config.getFiniteDuration("highwater-max-idle-time"),
-      tcpBacklogSize          = config.getIntOption("tcp-backlog-size"),
-      bindingRetry            = bindingRetry,
-      delegatorCreationPolicy = delegatorCreationPolicy,
-      shutdownTimeout         = config.getFiniteDuration("shutdown-timeout")
-    )
-  }
-
-  def load(name: String, config: Config = ConfigFactory.load()): ServerSettings = {
-    val nameRoot = ConfigRoot + "." + name
-    val resolved = if (config.hasPath(nameRoot)) {
-      config.getConfig(nameRoot).withFallback(config.getConfig(ConfigRoot))
-    } else {
-      config.getConfig(ConfigRoot)
-    }
-    extract(resolved)
-
-  }
-}
 
 /** Configuration used to specify a Server's application-level behavior
  *
@@ -125,72 +29,6 @@ case class ServerConfig(
   settings : ServerSettings
 )
 
-/**
- * A `ServerRef` is a handle to a created server.  It can be used to get basic
- * information about the state of the server as well as send operational
- * commands to it.
- *
- * @param config The ServerConfig used to create this Server
- * @param server The ActorRef of the Server
- * @param system The IOSystem to which this Server belongs
- * @param serverStateAgent The current state of the Server.
- */
-case class ServerRef private[colossus] (config: ServerConfig, server: ActorRef, system: IOSystem, private val serverStateAgent : Agent[ServerState]) {
-  def name = config.name
-
-  def serverState = serverStateAgent.get()
-
-  val namespace : MetricNamespace = system.namespace / name
-
-  def maxIdleTime = {
-    if(serverStateAgent().connectionVolumeState == ConnectionVolumeState.HighWater) {
-      config.settings.highWaterMaxIdleTime
-    } else {
-      config.settings.maxIdleTime
-    }
-  }
-
-  def info(): Future[Server.ServerInfo] = {
-    implicit val timeout = Timeout(1.second)
-    (server ? Server.GetInfo).mapTo[Server.ServerInfo]
-  }
-
-  /**
-   * Broadcast a message to a all of the [[Initializer]]s of this server.
-   *
-   * @param message
-   * @param sender
-   * @return
-   */
-  @deprecated("function has been deprecated, please use `initializerBroadcast` instead", "0.9.0")
-  def delegatorBroadcast(message: Any)(implicit sender: ActorRef = ActorRef.noSender) {
-    initializerBroadcast(message)
-  }
-
-  def initializerBroadcast(message: Any)(implicit sender: ActorRef = ActorRef.noSender) {
-    server.!(Server.InitializerBroadcast(message))(sender)
-  }
-
-  /**
-   * Gracefully shutdown this server.  This will cause the server to
-   * immediately begin refusing connections, but attempt to allow existing
-   * connections to close on their own.  The `shutdownRequest` method will be
-   * called on every `ServerConnectionHandler` associated with this server.
-   * `shutdownTimeout` in `ServerSettings` controls how long the server will
-   * wait before it force-closes all connections and shuts down.  The server
-   * actor will remain alive until it is fully shutdown.
-   */
-  def shutdown() {
-    server ! Server.Shutdown
-  }
-
-  /**
-   * Immediately kill the server and all corresponding open connections.
-   */
-  def die() {
-    server ! PoisonPill
-  }
-}
 
 /**
  * Represents the current state of a Server.

--- a/colossus/src/main/scala/colossus/core/server/ServerDSL.scala
+++ b/colossus/src/main/scala/colossus/core/server/ServerDSL.scala
@@ -1,5 +1,6 @@
 package colossus
 package core
+package server
 
 object ServerDSL {
   type Receive = PartialFunction[Any, Unit]
@@ -7,17 +8,6 @@ object ServerDSL {
 import ServerDSL._
 import com.typesafe.config.{Config, ConfigFactory}
 
-/**
- * An instance of this is handed to every new server connection handler
- */
-case class ServerContext(server: ServerRef, context: Context) {
-  def name: String = server.name.idString
-}
-
-/**
- * An instance of this is handed to every new initializer for a server
- */
-case class InitContext(server: ServerRef, worker: WorkerRef)
 
 /**
  * An `Initializer` is used to perform any setup/coordination logic for a

--- a/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
@@ -36,8 +36,8 @@ abstract class Initializer(ctx: InitContext) extends Generator(ctx) with Service
 /**
  * A RequestHandler contains the business logic for transforming [[HttpRequest]] into [[HttpResponse]] objects.  
  */
-abstract class RequestHandler(config: ServiceConfig, ctx: ServerContext) extends GenRequestHandler[Http](config, ctx) {
-  def this(ctx: ServerContext) = this(ServiceConfig.load(ctx.name), ctx)
+abstract class RequestHandler(ctx: ServerContext, config: ServiceConfig) extends GenRequestHandler[Http](ctx, config) {
+  def this(ctx: ServerContext) = this(ctx, ServiceConfig.load(ctx.name))
 
   val defaults = new Http.ServerDefaults
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -269,7 +269,7 @@ abstract class WebsocketInitializer[E <: Encoding](val worker: WorkerRef) {
 }
 
 class WebsocketHttpHandler[E <: Encoding](ctx: ServerContext, websocketInit: WebsocketInitializer[E], upgradePath: String)
-extends protocols.http.server.RequestHandler(ServiceConfig.Default, ctx) {
+extends protocols.http.server.RequestHandler(ctx, ServiceConfig.Default) {
   def handle = {
     case request if (request.head.path == upgradePath) => {
       val response = UpgradeRequest.validate(request) match {

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -83,6 +83,15 @@ class LoadBalancingClient[P <: Protocol] (
   initialClients: Seq[InetSocketAddress] = Nil
 ) extends WorkerItem with Sender[P, Callback]  {
 
+  def this(
+    addresses: Seq[InetSocketAddress],
+    baseConfig: ClientConfig,
+    factory: ClientFactory[P, Callback, Sender[P, Callback], WorkerRef], 
+    maxTries: Int
+  )(implicit worker: WorkerRef) = {
+    this(worker, address => factory(baseConfig.copy(address = address)), maxTries, addresses)
+  }
+
   val context = worker.generateContext
 
   worker.bind(_ => this)

--- a/colossus/src/main/scala/colossus/service/RequestHandler.scala
+++ b/colossus/src/main/scala/colossus/service/RequestHandler.scala
@@ -18,13 +18,13 @@ object GenRequestHandler {
 }
 import GenRequestHandler._
 
-abstract class GenRequestHandler[P <: Protocol](val config: ServiceConfig, val serverContext: ServerContext) 
+abstract class GenRequestHandler[P <: Protocol](val serverContext: ServerContext, val config: ServiceConfig) 
 extends DownstreamEvents with HandlerTail with UpstreamEventHandler[ServiceUpstream[P]] {
 
   type Request = P#Request
   type Response = P#Response
 
-  def this(context: ServerContext) = this(ServiceConfig.load(context.name), context)
+  def this(context: ServerContext) = this(context, ServiceConfig.load(context.name))
 
   protected val server = serverContext.server
   def context = serverContext.context


### PR DESCRIPTION
This PR has 2 main cleanup items:

1.  Several internal classes have been moved into a new `colossus.core.server` package, and a few larger files were split up.  This was mainly done to avoid a conflict when importing both `colossus.core` and `colossus.protocols.http.server`, since both have an `Initializer` type.  The one in `core.server` is no longer needed by users.
2.  Constructor parameters were accidentally switched on `RequestHandler`, putting them back in the right order.