### PR TITLE
fixing histogram values to not be higher than max

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -302,7 +302,7 @@ private[metrics] class BaseHistogram(val bucketList: BucketList = Histogram.defa
             p(num + mBuckets(index).get.toInt, index + 1, build, remain)
           } else {
             val weightedValue = if (index < ranges.size - 1) {
-              (ranges(index) + ranges(index + 1)) / 2
+              Math.min((ranges(index) + ranges(index + 1)) / 2, max.toInt)
             } else {
               infinity
             }

--- a/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
@@ -124,5 +124,14 @@ class HistogramSpec extends MetricIntegrationSpec {
       h.percentile(1.second, 0.5) mustBe 0
     }
 
+    "max interval test" in {
+      implicit val col = MetricContext("/", Collection.withReferenceConf(Seq(1.second, 1.minute)))
+      val h = new BaseHistogram()
+      List(120, 100, 100, 100, 100, 100, 100, 100, 100, 100, 100).foreach{
+        h.add
+      }
+      h.percentile(0.999) mustBe 120
+    }
+
   }
 }


### PR DESCRIPTION
@benblack86 @DanSimon @aliyakamercan 

Since our histogram values are approximations, we occasionally run into times when the approximation calculation is greater than the max value.  Since there's no issue in the underlying approximation calculation (tradeoff between accuracy and data size to keep) I'm setting a hard limit on max values.