### PR TITLE
Fixes to Pipe filterScan, CircuitBreaker Error suppression

### DIFF
--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -102,13 +102,13 @@ class RateSpec extends MetricIntegrationSpec {
 
     "correctly handle hits from multiple threads" in {
       val r = rate()
-      val f = Future.sequence{(1 to 10000).map{_ =>
+      val f = Future.sequence{(1 to 1000).map{_ =>
         Future { 
           (1 to 5).foreach(_ => r.hit()) 
         }
       }}
       Await.result(f, 1.second)
-      r.tick(1.second)("/foo")(Map()) must equal(50000)
+      r.tick(1.second)("/foo")(Map()) must equal(5000)
     }
   }
 }

--- a/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/OutputControllerSpec.scala
@@ -47,7 +47,10 @@ class OutputControllerSpec extends ColossusSpec with ControllerMocks {
 
     }
 
-    "react to terminated output buffer" taggedAs(org.scalatest.Tag("test")) in {
+    //IT IS NOW IMPOSSIBLE TO TEST THESE, since closed/terminated no longer leak
+    //outside of circuit-breakers, there is no way to cause this to happen
+
+    "react to terminated output buffer" ignore {
       //the buffer has to be terminated in the middle of the call to
       //readyForData, since otherwise the CircuitBreaker will hide it
       val (u, con, d) = get()
@@ -60,7 +63,7 @@ class OutputControllerSpec extends ColossusSpec with ControllerMocks {
       (con.upstream.kill _).verify(*)
     }
 
-    "react to closed output buffer" in {
+    "react to closed output buffer" ignore {
       val (u, con, d) = get()
       con.connected()
       //this pipe will close when the iterator is finished

--- a/colossus-tests/src/test/scala/colossus/streaming/CircuitBreakerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/CircuitBreakerSpec.scala
@@ -47,7 +47,7 @@ class CircuitBreakerSpec extends ColossusSpec {
       p.push(1) mustBe a [PushResult.Full]
     }
 
-    "termination of inner pipe propagates across linked circuitbreakers" in {
+    "termination of inner pipe is completely contained" in {
       val p = new PipeCircuitBreaker[Int, Int]
       val b = new BufferedPipe[Int](1)
       p.set(b)
@@ -61,14 +61,14 @@ class CircuitBreakerSpec extends ColossusSpec {
       d.pull() mustBe PullResult.Item(1)
 
       b.terminate(new Exception("UH OH"))
-      d.isSet mustBe false
+      d.isSet mustBe true
 
       val n = new BufferedPipe[Int](1)
       p.set(n)
       d.set(new BufferedPipe[Int](1))
       p.push(3) mustBe PushResult.Ok
       //we expect the previous "into" to be broken now
-      d.pull() mustBe a[PullResult.Empty]
+      d.pull() mustBe PullResult.Item(3)
     }
 
     "unsetting a circuitbreaker does not sever link" in {

--- a/colossus-tests/src/test/scala/colossus/streaming/CircuitBreakerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/CircuitBreakerSpec.scala
@@ -152,6 +152,15 @@ class CircuitBreakerSpec extends ColossusSpec {
       sum mustBe 5
     }
 
+    "properly redirect closed on pullUntilNull" in {
+      var error: Option[Throwable] = None
+      val (cb, pipe) = setup(onBreak = err => error = Some(err))
+      var sum = 0
+      pipe.complete()
+      cb.pullUntilNull(_ => true).get mustBe a[PullResult.Empty]
+      cb.isSet mustBe false
+    }
+
   }
 
 }

--- a/colossus/src/main/scala/colossus/streaming/Pipe.scala
+++ b/colossus/src/main/scala/colossus/streaming/Pipe.scala
@@ -186,6 +186,7 @@ class BufferedPipe[T](size: Int) extends Pipe[T, T] {
         i += 1
       }
     }
+    while (!bufferFull && pushTrigger.trigger()) {}
   }
 
 

--- a/colossus/src/main/scala/colossus/streaming/Sink.scala
+++ b/colossus/src/main/scala/colossus/streaming/Sink.scala
@@ -69,8 +69,8 @@ object Sink {
 
     def pushPeek = PushResult.Ok
   }
-
-  def valve[T](sink: Sink[T], valve: Sink[T]): Sink[T] = new Sink[T] {
+  
+  class ValveSink[T](sink: Sink[T], valve: Sink[T]) extends Sink[T] {
     
     def push(item: T): PushResult = pushPeek match {
       case PushResult.Ok => {
@@ -93,4 +93,6 @@ object Sink {
       valve.terminate(reason)
     }
   }
+
+  def valve[T](sink: Sink[T], valve: Sink[T]): Sink[T] = new ValveSink(sink, valve)
 }


### PR DESCRIPTION
So this fixes to main issues:

1.  `Pipe.filterScan` was not correctly triggering push signals.  In a nutshell, when a pipe is full, agents trying to push to the pipe will get a `PushResult.Full` containing a signal that they can map on for when the pipe clears up and is again pushable.  `filterScan` is a method on `BufferedPipe` to traverse buffered items and remove any that don't pass a filter function.  This is used by `ServiceClient`'s pending and sent buffers.  The issue was that when `filterScan` opened up a buffer, the push signals were not triggered.  This lead to a bug where `ServiceClient` would not properly resume sending requests if it disconnected and reconnected while the buffer was full.

2.  `CircuitBreaker` now suppresses all closes/terminations.  This type mutably wraps a Pipe and suppresses its error states.  In particular the goal is for two circuitbreakers to link together, and even if the underlying pipes terminate/close, the link between the circuitbreakers is not severed.  This is used, for example, to connect `ServiceClient` to its underlying `Controller`.  In general this prevents things like disconnects from accidentally severing these links.  However we still need to detect when the underlying Pipe terminates/closes, so a new `onBreak` method has been added to deal with such states.  This is used, for example, in `StreamTranscodingController` to close the connection when a stream hits an error.

Issue 2 is leading me to believe that we need a different interface than pipes to handle the message passing between connection handler layers, something with the same back-pressure semantics but without the notion of termination/closed, which only makes sense for actual streams of data.  For now though these changes will get us the functionality we want.
