### PR TITLE
Fixed wrong Scaladoc parameters.

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/MetricSystem.scala
@@ -98,9 +98,7 @@ case class SystemMetricsConfig(enabled: Boolean, namespace: MetricAddress)
  *
  * @param enabled true to enable all functionality.  Setting to false will effectively create a dummy system that does nothing
  * @param name The name of the metric system.  Name is not used in the root path of a metric system.
- * @param collectionIntervals The intervals that the system should use to periodicaly collect metrics.  Multiple intervals can be specified to allow the collection of, for example, both per second and per minute metrics.
- * @param collectSystemMetrics whether to collect system metrics like GC usage
- * @param systemMetricsNamespace an optional namespace for system metrics, defaults to "/name" where name is the name of the metric system
+ * @param systemMetrics a typesafe config object containing configurations for the metric system.
  * @param collectorConfigs a typesafe config object containing configurations for individual collectors
  */
 case class MetricSystemConfig(


### PR DESCRIPTION
Just delete old parameters that were still in the comments.