### PR TITLE
Fixing Histogram race condition

### DIFF
--- a/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
@@ -15,7 +15,7 @@ class HistogramSpec extends MetricIntegrationSpec {
   }
 
   "BaseHistogram" must {
-    "simple collection" taggedAs(org.scalatest.Tag("test")) in {
+    "simple collection" in {
       val address = MetricAddress.Root / "latency"
       val tags = Map("route" -> "home")
       val h = new BaseHistogram(Histogram.generateBucketRanges(10, 10))
@@ -100,7 +100,6 @@ class HistogramSpec extends MetricIntegrationSpec {
       val adding = h.bucketList.buckets(30)
       h.add(adding)
       val p = h.percentile(0.5) 
-      println(s"Added $adding, got $p")
       p mustBe adding
     }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/HistogramSpec.scala
@@ -1,5 +1,7 @@
 package colossus.metrics
 
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class HistogramSpec extends MetricIntegrationSpec {
@@ -13,7 +15,7 @@ class HistogramSpec extends MetricIntegrationSpec {
   }
 
   "BaseHistogram" must {
-    "simple collection" in {
+    "simple collection" taggedAs(org.scalatest.Tag("test")) in {
       val address = MetricAddress.Root / "latency"
       val tags = Map("route" -> "home")
       val h = new BaseHistogram(Histogram.generateBucketRanges(10, 10))
@@ -22,7 +24,7 @@ class HistogramSpec extends MetricIntegrationSpec {
       h.max must equal (10)
       h.count must equal (11)
       val percentiles = Seq(0.0, 0.25, 0.5, 0.75, 0.99, 1.0)
-      h.percentiles(percentiles) must equal (percentiles.zip(Seq(0, 3, 6, 9, 10, 10)).toMap)
+      h.percentiles(percentiles) must equal (percentiles.zip(Seq(0, 2, 5, 7, 10, 10)).toMap)
 
       val metrics = Map(
         address / "count" -> Map(tags -> 11),
@@ -31,15 +33,78 @@ class HistogramSpec extends MetricIntegrationSpec {
           tags + ("label" -> "max") -> 10,
           tags + ("label" -> "mean") -> 5,
           tags + ("label" -> "0.0") -> 0,
-          tags + ("label" -> "0.25") -> 3,
-          tags + ("label" -> "0.5") -> 6,
-          tags + ("label" -> "0.75") -> 9,
+          tags + ("label" -> "0.25") -> 2,
+          tags + ("label" -> "0.5") -> 5,
+          tags + ("label" -> "0.75") -> 7,
           tags + ("label" -> "0.99") -> 10,
           tags + ("label" -> "1.0") -> 10
         )
       )
       h.metrics(address, tags, percentiles) must equal (metrics)
     }
+
+    "another simple collection" in {
+      val h = new BaseHistogram(Histogram.generateBucketRanges(4, 4))
+      h.add(0)
+      h.add(1)
+      h.add(2)
+      h.add(3)
+      h.percentile(0.25) mustBe 0
+      h.percentile(0.5) mustBe 1
+      h.percentile(0.75) mustBe 2
+      h.percentile(0.99) mustBe 3
+      //adding the same number of each value a whole bunch shouldn't change the
+      //percentiles
+      (0 to 3).foreach{i =>
+        (0 to 100).foreach{j =>
+          h.add(i)
+        }
+      }
+      h.percentile(0.25) mustBe 0
+      h.percentile(0.5) mustBe 1
+      h.percentile(0.75) mustBe 2
+      h.percentile(0.99) mustBe 3
+    }
+
+    "third collection" in {
+      val h = new BaseHistogram
+      h.add(3)
+      h.add(6)
+      h.add(7)
+      h.add(10)
+      h.add(23409)
+      h.percentile(0.25) mustBe 3
+      h.percentile(0.50) mustBe 7
+      h.percentile(0.75) mustBe 10
+      h.percentile(0.99) mustBe 21970
+    }
+
+    "fourth collection" in {
+      val h = new BaseHistogram
+      (0 to 99).foreach{_ => h.add(5)}
+      h.add(7830)
+      h.percentile(0.25) mustBe 5
+      h.percentile(0.50) mustBe 5
+      h.percentile(0.75) mustBe 5
+      h.percentile(0.99) mustBe 5
+      h.percentile(0.999) mustBe 7503
+      h.percentile(1.0) mustBe 7830
+    }
+
+    "tail percentiles should not exceed max" in {
+      val h = new BaseHistogram
+      //since when calculating a percentile, we use the average of the current
+      //bucket and the next bucket values, we can verify this works by adding a
+      //value equal to one of the larger bucket value, which will result in a
+      //calculated percentile larger than the value added.
+      val adding = h.bucketList.buckets(30)
+      h.add(adding)
+      val p = h.percentile(0.5) 
+      println(s"Added $adding, got $p")
+      p mustBe adding
+    }
+
+      
 
     "bucketFor" in {
       val h = new BaseHistogram
@@ -65,6 +130,25 @@ class HistogramSpec extends MetricIntegrationSpec {
       h.mean mustBe 0
       h.percentile(.99) mustBe 0
     }
+
+    "handle tick race condition" in {
+      //this race condition can occur when a value is added while the histogram
+      //is being ticked.  It resulted in some tail percentiles getting
+      //calculated as Int.MaxValue
+      val h = new BaseHistogram
+      Future {
+        (0 to 10000).foreach{i =>
+          h.add(i % 100)
+        }
+      }
+      Thread.sleep(1)
+      (0 to 5).foreach{i => 
+        h.tick()
+        h.percentile(0.999)  must be < 500
+      }
+
+    }
+
 
 
 
@@ -116,7 +200,7 @@ class HistogramSpec extends MetricIntegrationSpec {
       h.add(10)
       h.add(50)
       h.count(1.second) mustBe 2
-      h.percentile(1.second, 0.5) mustBe 12
+      h.percentile(1.second, 0.5) mustBe 10
       h.count(1.minute) mustBe 2
       h.tick(1.second)
       h.count(1.second) mustBe 0


### PR DESCRIPTION
### What's the Bug?

Very rarely, a race condition can occur that will cause calculated tail percentiles of a histogram (> 99th percentile) to report `Int.MaxValue`.

The bug is due to a race condition that can happen when a value is added to the histogram at the same time the percentiles are being calculated in another thread.  What ends up happening is that the calculated number of added values is 1 higher than the actual number of added values in the histogram's buckets.  At high percentiles, it ends up searching through all the buckets for the missing value, and stops at the end, resulting in the "infinity" value of `Int.MaxValue`.

### How did I fix it?

The percentile calculation function will now keep track of the last bucket with a non-zero count, and use that bucket instead of the last one when such a situation occurs.  This also ends up slightly changing how percentiles are calculated, but this change is only apparent when relatively few values have been added to the histogram.

This does not resolve the fact that the `count` is still one off from the actual total count, but generally that will have little to no effect, especially when hundreds to thousands of values are added per second.  Fixing that race condition would require doing some kind of atomic locking, which is probably not worth it.

### How is it tested?

I added test that successfully and consistently reproduced the race condition.  

Before merging, I am going to do a bit more testing to make sure that calculated percentiles are not significantly changed.