### PR TITLE
Http service doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,15 @@
 
 ### Editing the docs
 
-You must have installed on your computer:
- * ruby 2.0 or greater
- * jekyll
- * sass (gem install sass)
- * rake
- * bundler
+You must have ruby 2.0+ and bundler installed and then run bundler (`bundler` on the command line) to install the correct gems.
 
-To start a localhost server, simply go to the root folder of this repo and run :
+To start a localhost server:
 
 `jekyll serve --watch --baseurl=''`
 
-the browse to localhost:4000
+Then browse to localhost:4000
 
-### publishing
+### Publishing
 
 When publishing just run :
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ categories: docs
 
 [Workers](workers)
 
+[Services](services)
+
 [Configuration](configuration)
 
 [Testing Servers](testkit)
@@ -17,7 +19,6 @@ categories: docs
 [Metrics](metrics)
 
 [Tasks](tasks)
-
 
 [Colossus API Docs]({{site.baseurl}}/api/index.html#colossus.package) ({{ site.latest_version }})
 

--- a/docs/services.md
+++ b/docs/services.md
@@ -1,0 +1,75 @@
+---
+layout: page
+title:  "Services"
+categories: docs
+---
+
+A service receives requests and returns responses. Colossus has built in support for http, memcache, redis and telnet.
+
+## Http
+
+A http service will take the following form:
+
+{% highlight scala %}
+import colossus.IOSystem
+import colossus.core.{Initializer, Server, ServerRef}
+import colossus.protocols.http.HttpMethod._
+import colossus.protocols.http.UrlParsing._
+import colossus.protocols.http._
+import colossus.service.ServiceConfig
+import colossus.service.Callback.Implicits._
+
+object HttpExample {
+
+  def start(port: Int)(implicit system: IOSystem): ServerRef = {
+    Server.start("http-example", port){implicit worker => new Initializer(worker) {
+
+      def onConnect = context => new HttpService(ServiceConfig.Default, context){
+        def handle = {
+          case request @ Get on Root / "hello" => {
+            request.ok("hello")
+          }
+        }
+      }
+    }}
+  }
+}
+{% endhighlight %}
+
+`ok` is a helper method on `HttpRequest` that returns a `HttpResponse`. The implicit 
+`colossus.service.Callback.Implicits.objectToSuccessfulCallback` then turns the response into a `Callback[HttpResponse]`.
+
+The following helper method are available, which will default the content type to text and return the corresponding 
+http code.
+
++ ok
++ notFound
++ error
++ badRequest
++ unauthorized
++ forbidden
+
+There are several different ways to set headers on the response.
+
+{% highlight scala %}
+request.ok("hello").withHeader("header-name", "header-value")
+request.ok("hello", HttpHeaders(HttpHeader("header-name", "header-value")))
+request.ok("hello", HttpHeaders(HttpHeader(HttpHeaders.CookieHeader, "header-value")))
+{% endhighlight %}
+
+Setting the content type or using a different http code involves a bit more work as the above helper methods can't be 
+used. Instead use the `respond` method.
+
+{% highlight scala %}
+request.respond(HttpCodes.CONFLICT, HttpBody("""{"name":"value"}""").withContentType(ContentType.ApplicationJson))
+{% endhighlight %}
+
+On the incoming request, body and content type are on the `HttpBody` and headers and parameters are on the 
+`HttpHead`.
+
+{% highlight scala %}
+request.body.bytes.utf8String
+request.body.contentType
+request.head.headers
+request.head.parameters.getFirst("key")
+{% endhighlight %}


### PR DESCRIPTION
Adding information on http services. Presumably the "services" section can be extended with info on redis/memcache/telnet one day.

@DanSimon @amotamed @jlbelmonte @dxuhuang @aliyakamercan