### PR TITLE
Fixing a bug with handling unexpected exceptions in Controller

### DIFF
--- a/colossus-tests/src/test/scala/colossus/controller/Common.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/Common.scala
@@ -27,9 +27,9 @@ trait ControllerMocks extends MockFactory {self: org.scalamock.scalatest.MockFac
 
     def namespace = colossus.metrics.MetricSystem.deadSystem
 
-    override def onFatalError(reason: Throwable): Option[E#Output] = {
+    override def onFatalError(reason: Throwable) = {
       println(s"FATAL : $reason")
-      None
+      FatalErrorAction.Terminate
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/controller/InputControllerSpec.scala
@@ -26,7 +26,7 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers with Contro
       val config = ControllerConfig(4, 2.bytes)
       val (u, con, d) = get(config)
       con.receivedData(DataBuffer(input))
-      (u.disconnect _).verify()
+      (u.kill _).verify(*)
     }
 
     "properly copy and buffer data when input buffer fills" in {
@@ -46,7 +46,7 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers with Contro
       con.receivedData(input)
       d.pipe.pull() mustBe PullResult.Item(ByteString("a"))
       d.pipe.pull() mustBe a[PullResult.Empty]
-      (u.disconnect _).verify()
+      (u.kill _).verify(*)
     }
 
     "properly handle parse failure with buffeerd data" in {
@@ -58,21 +58,21 @@ class InputControllerSpec extends ColossusSpec with CallbackMatchers with Contro
         d.pipe.pull() mustBe PullResult.Item(ByteString(i.toString))
       }
       d.pipe.pull() mustBe a[PullResult.Empty]
-      (u.disconnect _).verify()
+      (u.kill _).verify(*)
     }
 
     "react to closed downstream input buffer" in {
       val (u, con, d) = get(new SimpleCodec, defaultConfig)
       d.incoming.complete()
       con.receivedData(DataBuffer(ByteString("5;hello6;world!")))
-      (u.disconnect _).verify()
+      (u.kill _).verify(*)
     }
 
     "react to terminated downstream input buffer" in {
       val (u, con, d) = get(new SimpleCodec, defaultConfig)
       d.incoming.terminate(new Exception("ASDF"))
       con.receivedData(DataBuffer(ByteString("5;hello6;world!")))
-      (u.disconnect _).verify()
+      (u.kill _).verify(*)
 
     }
 

--- a/colossus-tests/src/test/scala/colossus/streaming/StreamTranscoderSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/streaming/StreamTranscoderSpec.scala
@@ -28,7 +28,9 @@ class StreamServiceSpec extends ColossusSpec with MockFactory with ControllerMoc
         def transcodeOutput(source: colossus.streaming.Source[Int]): colossus.streaming.Source[Int] = source.map{_ * 10}
       }
 
-      val controller = new StreamTranscodingController(downstream, transcoder)
+      val controller = new StreamTranscodingController(downstream, transcoder) {
+        def onFatalError(reason: Throwable) = FatalErrorAction.Terminate
+      }
       controller.setUpstream(upstream)
       controller.connected()
       controller.incoming.push(3) mustBe PushResult.Ok

--- a/colossus/src/main/scala/colossus/protocols/http/streaming/StreamService.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/streaming/StreamService.scala
@@ -94,7 +94,7 @@ class HttpClientTranscoder extends HttpTranscoder[Encoding.Client[StreamHeader],
 }
 
 
-class HttpStreamController[
+abstract class HttpStreamController[
   E <: HeadEncoding, 
   A <: ExEncoding[HttpStream, E], 
   B <: GenEncoding[StreamingHttpMessage, E]
@@ -102,10 +102,17 @@ class HttpStreamController[
 
 
 class HttpStreamServerController(ds: ControllerDownstream[Encoding.Server[StreamingHttp]])
-extends HttpStreamController[Encoding.Server[StreamHeader], Encoding.Server[StreamHttp], Encoding.Server[StreamingHttp]](ds, new HttpServerTranscoder)
+extends HttpStreamController[Encoding.Server[StreamHeader], Encoding.Server[StreamHttp], Encoding.Server[StreamingHttp]](ds, new HttpServerTranscoder) {
+
+  def onFatalError(reason: Throwable) = FatalErrorAction.Disconnect(None)
+}
 
 class HttpStreamClientController(ds: ControllerDownstream[Encoding.Client[StreamingHttp]])
-extends HttpStreamController[Encoding.Client[StreamHeader], Encoding.Client[StreamHttp], Encoding.Client[StreamingHttp]](ds, new HttpClientTranscoder)
+extends HttpStreamController[Encoding.Client[StreamHeader], Encoding.Client[StreamHttp], Encoding.Client[StreamingHttp]](ds, new HttpClientTranscoder) {
+  
+  def onFatalError(reason: Throwable) = FatalErrorAction.Terminate
+
+}
 
 
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -214,6 +214,8 @@ with UpstreamEventHandler[ControllerUpstream[WebsocketEncoding]] {
     upstream.outgoing.push(frame)
   }
 
+  def onFatalError(reason: Throwable) = FatalErrorAction.Terminate
+
   def send(message: E#Output) {
     send(frameCodec.encode(message))
   }

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -392,12 +392,8 @@ extends ControllerDownstream[Encoding.Client[P]] with HasUpstream[ControllerUpst
     }
   }
 
-  override def onFatalError(reason: Throwable) = {
-    worker ! Kill(id, DisconnectCause.Error(reason))
-    None
-  }
-
-
+  override def onFatalError(reason: Throwable) = FatalErrorAction.Terminate
+  
   override protected def onIdleCheck(period: FiniteDuration) {
     val now = System.currentTimeMillis
     if (sentBuffer.length > 0 && sentBuffer.head.isTimedOut(now)) {

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -276,11 +276,7 @@ with DownstreamEventHandler[GenRequestHandler[P]]
     )
   }
   
-  def processBadRequest(reason: Throwable) = {
-    Some(handleFailure(IrrecoverableError(reason)))
-  }
-
-  override def onFatalError(reason: Throwable) = processBadRequest(reason)
+  override def onFatalError(reason: Throwable) = FatalErrorAction.Disconnect(Some(handleFailure(IrrecoverableError(reason))))
 
   private def handleFailure(error: ProcessingFailure[Request]): Response = {
     addError(error)

--- a/colossus/src/main/scala/colossus/streaming/StreamTranscoder.scala
+++ b/colossus/src/main/scala/colossus/streaming/StreamTranscoder.scala
@@ -29,7 +29,7 @@ trait Transcoder[U <: Encoding, D <: Encoding] {
  * This controller interface can be used to transcode from one encoding to
  * another in a connection handler pipeline
  */
-class StreamTranscodingController[
+abstract class StreamTranscodingController[
   U <: Encoding,
   D <: Encoding
 ] (


### PR DESCRIPTION
This fixes a bug uncovered by another bug that will be in a separate PR against master.  Basically when `ServiceClient` threw an exception, it got caught by `InputController` as an unexpected error resulting in killing the connection (which it should do).  The problem was that it was calling `disconnect` instead of `kill`, which meant `ServiceClient` would not handle the disconnect as an error and would _not_ try to reconnect.

The solution was a little more involved because in the case of server connections, calling `disconnect()` is actually what we want to do, because when pipelining responses we want the server connection to be able to send back any responses for successfully processed requests before closing the connection.

So the solution is to basically punt the decision of which function to call to the downstream handler, aka `ServiceServer` or `ServiceClient`.  So now the `onFatalError` event handler method is required to return a `FatalErrorAction` which instructs the controller how to behave.