### PR TITLE
Refactor

### DIFF
--- a/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/FakeIOSystem.scala
@@ -53,7 +53,6 @@ object FakeIOSystem {
    * Returns a ServerRef representing a server in the Bound state
    */
   def fakeServerRef(implicit system: ActorSystem): (TestProbe, ServerRef) = {
-    import system.dispatcher
     val probe = TestProbe()
     val config = ServerConfig(
       "/foo",

--- a/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus-testkit/ServiceSpec.scala
@@ -11,10 +11,10 @@ import core.ServerRef
 import service._
 import scala.reflect.ClassTag
 
-abstract class ServiceSpec[C <: Protocol](implicit clientFactory: GenFutureClientFactory[C]) extends ColossusSpec {
+abstract class ServiceSpec[P <: Protocol](implicit clientFactory: GenFutureClientFactory[P]) extends ColossusSpec {
   
-  type Request = C#Request
-  type Response = C#Response
+  type Request = P#Request
+  type Response = P#Response
 
   implicit val sys = IOSystem("test-system", Some(2), MetricSystem.deadSystem)
 
@@ -37,7 +37,7 @@ abstract class ServiceSpec[C <: Protocol](implicit clientFactory: GenFutureClien
 
   def client(timeout: FiniteDuration = requestTimeout) = clientFactory(clientConfig(timeout))
 
-  def withClient(f: FutureClient[C] => Unit) {
+  def withClient(f: FutureClient[P] => Unit) {
     val c = client()
     f(c)
     c.disconnect()

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -98,7 +98,7 @@ object RawProtocol {
 
   implicit object RawClientLifter extends ClientLifter[Raw, RawClient] {
     
-    def lift[M[_]](client: Sender[Raw,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) = {
+    override def lift[M[_]](client: Sender[Raw, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): RawClient[M] = {
       new BasicLiftedClient(client, clientConfig) with RawClient[M]
     }
   }

--- a/colossus-tests/src/test/scala/colossus/core/WorkerManagerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerManagerSpec.scala
@@ -2,7 +2,7 @@ package colossus.core
 
 import java.util.concurrent.atomic.AtomicReference
 
-import akka.actor.{ActorContext, ActorRef, Props}
+import akka.actor.{ActorContext, ActorRef}
 import akka.testkit.TestProbe
 import colossus.IOSystem
 import colossus.testkit.ColossusSpec

--- a/colossus/src/main/scala/colossus/core/server/Server.scala
+++ b/colossus/src/main/scala/colossus/core/server/Server.scala
@@ -20,7 +20,7 @@ import scala.concurrent.duration._
  *  and the name and settings by the user.
  *
  * @param name Name of the Server, all reported metrics are prefixed using this name
- * @param initializerFactory Factory to generate [[colossus.core.Initializer]]s for each Worker
+ * @param initializerFactory Factory to generate [[colossus.core.server.Initializer]]s for each Worker
  * @param settings lower-level server configuration settings
  */
 case class ServerConfig(
@@ -361,11 +361,12 @@ object Server extends ServerDSL {
    * @return ServerRef which encapsulates the created Server
    */
   def apply(serverConfig: ServerConfig)(implicit io: IOSystem): ServerRef = {
-    import io.actorSystem.dispatcher
-    import ServerStatus._
-    val serverStateAgent = new AtomicReference(ServerState(ConnectionVolumeState.Normal, Initializing))
+
+    val serverStateAgent = new AtomicReference(ServerState(ConnectionVolumeState.Normal, ServerStatus.Initializing))
+
     val actor = io.actorSystem.actorOf(Props(classOf[Server], io, serverConfig, serverStateAgent)
                               .withDispatcher("server-dispatcher"), name = s"server-${serverConfig.name.idString}")
+
     ServerRef(serverConfig, actor, io, serverStateAgent)
   }
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -43,7 +43,7 @@ object HttpClient {
 
   implicit object HttpClientLifter extends ClientLifter[Http, HttpClient] {
     
-    def lift[M[_]](client: Sender[Http,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) = {
+    override def lift[M[_]](client: Sender[Http, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): HttpClient[M] = {
       new BasicLiftedClient(client, clientConfig) with HttpClient[M]
     }
   }

--- a/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
@@ -113,12 +113,12 @@ import scala.language.higherKinds
       }
     }
   }
-  object MemcacheClient {
 
+  object MemcacheClient {
   
     implicit object MemcacheClientLifter extends ClientLifter[Memcache, MemcacheClient] {
       
-      def lift[M[_]](client: Sender[Memcache,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) = {
+      override def lift[M[_]](client: Sender[Memcache,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): MemcacheClient[M] = {
         new BasicLiftedClient(client, clientConfig) with MemcacheClient[M]
       }
     }

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
@@ -498,8 +498,8 @@ trait RedisClient[M[_]] extends LiftedClient[Redis, M] {
 object RedisClient {
 
   implicit object RedisClientLifter extends ClientLifter[Redis, RedisClient] {
-    
-    def lift[M[_]](client: Sender[Redis,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]) = {
+
+    override def lift[M[_]](client: Sender[Redis, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): RedisClient[M] = {
       new BasicLiftedClient(client, clientConfig) with RedisClient[M]
     }
   }

--- a/colossus/src/main/scala/colossus/service/Async.scala
+++ b/colossus/src/main/scala/colossus/service/Async.scala
@@ -10,9 +10,9 @@ import colossus.core.WorkerRef
  * A Sender is anything that is able to asynchronously send a request and
  * receive a corresponding response
  */
-trait Sender[C <: Protocol, M[_]] {
+trait Sender[P <: Protocol, M[_]] {
 
-  def send(input: C#Request): M[C#Response]
+  def send(input: P#Request): M[P#Response]
 
   def disconnect()
 

--- a/colossus/src/main/scala/colossus/service/RequestHandler.scala
+++ b/colossus/src/main/scala/colossus/service/RequestHandler.scala
@@ -8,13 +8,13 @@ class RequestHandlerException(message: String) extends Exception(message)
 
 object GenRequestHandler {
 
-  type PartialHandler[C <: Protocol] = PartialFunction[C#Request, Callback[C#Response]]
+  type PartialHandler[P <: Protocol] = PartialFunction[P#Request, Callback[P#Response]]
 
   type Receive = PartialFunction[Any, Unit]
 
-  type ErrorHandler[C <: Protocol] = PartialFunction[ProcessingFailure[C#Request], C#Response]
+  type ErrorHandler[P <: Protocol] = PartialFunction[ProcessingFailure[P#Request], P#Response]
 
-  type ParseErrorHandler[C <: Protocol] = PartialFunction[Throwable, C#Response]
+  type ParseErrorHandler[P <: Protocol] = PartialFunction[Throwable, P#Response]
 }
 import GenRequestHandler._
 


### PR DESCRIPTION
Hopefully a minor PR.

+ I noticed that some protocol types used the letter `C`, whilst other places used `P`. I refactor so `P` is consistently used.
+ Removed some unused imports
+ Made the `lift` implementations more explicit
