### PR TITLE
Remove implicits

### DIFF
--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -96,14 +96,13 @@ object RawProtocol {
     type Response = ByteString
   }
 
-  implicit object RawClientLifter extends ClientLifter[Raw, RawClient] {
-    
+  object RawClientLifter extends ClientLifter[Raw, RawClient] {
     override def lift[M[_]](client: Sender[Raw, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): RawClient[M] = {
       new BasicLiftedClient(client, clientConfig) with RawClient[M]
     }
   }
 
-  object Raw extends ClientFactories[Raw, RawClient]{
+  object Raw extends ClientFactories[Raw, RawClient](RawClientLifter) {
     implicit def clientFactory = ServiceClientFactory.basic("raw", () => RawClientCodec)
     
   }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -34,18 +34,3 @@ trait HttpClient[M[_]]  extends LiftedClient[Http, M] with BaseHttpClient[M, Htt
   val base = HttpRequest.base
 
 }
-
-
-
-
-
-object HttpClient {
-
-  implicit object HttpClientLifter extends ClientLifter[Http, HttpClient] {
-    
-    override def lift[M[_]](client: Sender[Http, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): HttpClient[M] = {
-      new BasicLiftedClient(client, clientConfig) with HttpClient[M]
-    }
-  }
-
-}

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -5,6 +5,7 @@ import colossus.metrics.TagMap
 
 import service._
 
+import scala.language.higherKinds
 
 package object http extends HttpBodyEncoders with HttpBodyDecoders {
 
@@ -25,33 +26,16 @@ package object http extends HttpBodyEncoders with HttpBodyDecoders {
     type Response = HttpResponse
   }
 
-  object Http extends ClientFactories[Http, HttpClient] {
+  object HttpClientLifter extends ClientLifter[Http, HttpClient] {
+    override def lift[M[_]](client: Sender[Http, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): HttpClient[M] = {
+      new BasicLiftedClient(client, clientConfig) with HttpClient[M]
+    }
+  }
+
+  object Http extends ClientFactories[Http, HttpClient](HttpClientLifter) {
 
     implicit lazy val clientFactory = ServiceClientFactory.basic("http", () => new StaticHttpClientCodec)
 
-    class ServerDefaults  {
-      def errorResponse(error: ProcessingFailure[HttpRequest]) = error match {
-        case RecoverableError(request, reason) => reason match {
-          case c: UnhandledRequestException => request.notFound(s"No route for ${request.head.url}")
-          case other => request.error(reason.toString)
-        }
-        case IrrecoverableError(reason) => {
-          HttpResponse(HttpResponseHead(HttpVersion.`1.1`, HttpCodes.BAD_REQUEST,  HttpHeaders.Empty), HttpBody("Bad Request"))
-        }
-      }
-    }
-
-    class ClientDefaults  {
-      def name = "http"
-    }
-
-    object defaults  {
-      
-      implicit val httpServerDefaults = new ServerDefaults
-
-      implicit val httpClientDefaults = new ClientDefaults
-
-    }
   }
 
   trait HttpMessage[H <: HttpMessageHead] extends BaseHttpMessage[H, HttpBody]

--- a/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
@@ -114,15 +114,4 @@ import scala.language.higherKinds
     }
   }
 
-  object MemcacheClient {
-  
-    implicit object MemcacheClientLifter extends ClientLifter[Memcache, MemcacheClient] {
-      
-      override def lift[M[_]](client: Sender[Memcache,M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): MemcacheClient[M] = {
-        new BasicLiftedClient(client, clientConfig) with MemcacheClient[M]
-      }
-    }
-
-  }
-
   case class UnexpectedMemcacheReplyException(message : String) extends Exception

--- a/colossus/src/main/scala/colossus/protocols/memcache/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/package.scala
@@ -3,6 +3,8 @@ package protocols
 
 import service._
 
+import scala.language.higherKinds
+
 package object memcache {
 
   trait Memcache extends Protocol {
@@ -10,13 +12,15 @@ package object memcache {
     type Response = MemcacheReply
   }
 
-  object Memcache extends ClientFactories[Memcache, MemcacheClient] {
+  object MemcacheClientLifter extends ClientLifter[Memcache, MemcacheClient] {
+    override def lift[M[_]](client: Sender[Memcache, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): MemcacheClient[M] = {
+      new BasicLiftedClient(client, clientConfig) with MemcacheClient[M]
+    }
+  }
+
+  object Memcache extends ClientFactories[Memcache, MemcacheClient](MemcacheClientLifter) {
 
     implicit lazy val clientFactory = ServiceClientFactory.basic("memcache", () => new MemcacheClientCodec)
-
-    object defaults {
-      //???
-    }
 
   }
 

--- a/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/redis/RedisOps.scala
@@ -495,17 +495,6 @@ trait RedisClient[M[_]] extends LiftedClient[Redis, M] {
 
 }
 
-object RedisClient {
-
-  implicit object RedisClientLifter extends ClientLifter[Redis, RedisClient] {
-
-    override def lift[M[_]](client: Sender[Redis, M], clientConfig: Option[ClientConfig])(implicit async: Async[M]): RedisClient[M] = {
-      new BasicLiftedClient(client, clientConfig) with RedisClient[M]
-    }
-  }
-
-}
-
 
 case class RedisException(message : String) extends Exception
 

--- a/colossus/src/main/scala/colossus/service/Async.scala
+++ b/colossus/src/main/scala/colossus/service/Async.scala
@@ -81,7 +81,7 @@ class FutureAsync(implicit val environment: IOSystem) extends Async[Future] {
 
   type E = IOSystem
 
-  import environment.actorSystem.dispatcher
+  private implicit val executionContext = environment.actorSystem.dispatcher
 
   def map[T, U](t: Future[T])(f: (T) => U): Future[U] = t.map(f)
 

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -223,13 +223,13 @@ class GenFutureClientFactory[P <: Protocol](base: FutureClient.BaseFactory[P]) e
 
 }
 
-class CodecClientFactory[P <: Protocol, M[_], T[M[_]] <: Sender[P,M], E]
-(implicit baseFactory: ClientFactory[P, M, Sender[P, M], E], lifter: ClientLifter[P, T], builder: AsyncBuilder[M, E])
-extends ClientFactory[P, M, T[M], E] {
+class CodecClientFactory[P <: Protocol, M[_], T[M[_]] <: Sender[P, M], E]
+(baseFactory: ClientFactory[P, M, Sender[P, M], E], lifter: ClientLifter[P, T], builder: AsyncBuilder[M, E])
+  extends ClientFactory[P, M, T[M], E] {
 
   def defaultName = baseFactory.defaultName
 
-  def apply(config: ClientConfig)(implicit env: E): T[M] = {
+  override def apply(config: ClientConfig)(implicit env: E): T[M] = {
     apply(baseFactory(config), config)
   }
 
@@ -245,15 +245,23 @@ extends ClientFactory[P, M, T[M], E] {
 /**
  * Mixed into protocols to provide simple methods for creating clients.
  */
-abstract class ClientFactories[P <: Protocol, T[M[_]] <: Sender[P, M]](implicit lifter: ClientLifter[P, T]) {
+abstract class ClientFactories[P <: Protocol, T[M[_]] <: Sender[P, M]](lifter: ClientLifter[P, T]) {
 
   implicit def clientFactory: FutureClient.BaseFactory[P]
 
+  val client = new CodecClientFactory[P, Callback, T, WorkerRef](
+    clientFactory,
+    lifter,
+    AsyncBuilder.CallbackAsyncBuilder
+  )
+
   implicit val futureFactory = new GenFutureClientFactory[P](clientFactory)
 
-  val client = new CodecClientFactory[P, Callback, T, WorkerRef]
-
-  val futureClient = new CodecClientFactory[P, Future, T, IOSystem]
+  val futureClient = new CodecClientFactory[P, Future, T, IOSystem](
+    futureFactory,
+    lifter,
+    AsyncBuilder.FutureAsyncBuilder
+  )
 
 }
 


### PR DESCRIPTION
I was trying to understand how the client setup logic works and in particular how the `CodecClientFactory` was creating the client. However, I was getting stuck understanding how it was all glued together due to `baseFactory`, `lifter`, and `builder` being implicits. I was like, where are these implicits coming from!?! After a while I realized that some of them there being defined in different files, but under the same namespace so where in scope.

To bring more clarity to the code base, I've turning the implicits for `CodecClientFactory` and `ClientFactories` into explicit parameters. Thumbs up, thumbs down?

I then went crazy and moved the lifter implementations to where they are used and cut out some default objects that weren't being used. In the case of http, I moved the error routing logic to where it is being used. I'm guessing this breaks the rule of no API changes so I should leave those for 0.10?

Thoughts?