### PR TITLE
Initialize metrics collection map

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -65,18 +65,18 @@ private[metrics] class CollectionMap[T] {
     Option(map.get(tags)) match {
       case Some(got) => op(got)(num)
       case None => {
-        Option(map.putIfAbsent(tags, new AtomicLong(num))).foreach{got => op(got)(num)}          
+        Option(map.putIfAbsent(tags, new AtomicLong(num))).foreach { got => op(got)(num) }
       }
     }
 
   }
 
   def increment(tags: T, num: Long = 1) {
-    update(tags, num, _.addAndGet _)
+    update(tags, num, al => l => al.addAndGet(l))
   }
 
   def set(tags: T, num: Long) {
-    update(tags, num, _.set _)
+    update(tags, num, al => l => al.set(l))
   }
 
   def get(tags: T): Option[Long] = Option(map.get(tags)).map{_.get}

--- a/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/Collection.scala
@@ -72,11 +72,11 @@ private[metrics] class CollectionMap[T] {
   }
 
   def increment(tags: T, num: Long = 1) {
-    update(tags, num, al => l => al.addAndGet(l))
+    update(tags, num, (atomicLong: AtomicLong) => (long: Long) => atomicLong.addAndGet(long))
   }
 
   def set(tags: T, num: Long) {
-    update(tags, num, al => l => al.set(l))
+    update(tags, num, (atomicLong: AtomicLong) => (long: Long) => atomicLong.set(long))
   }
 
   def get(tags: T): Option[Long] = Option(map.get(tags)).map{_.get}

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Counter.scala
@@ -47,6 +47,8 @@ private[metrics] class DefaultCounter private[metrics](val address: MetricAddres
 
   private val counters = new CollectionMap[TagMap]
 
+  set(value = 0L)
+
   def increment(tags: TagMap = TagMap.Empty, amount: Long = 1) {
     counters.increment(tags, amount)
   }

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Histogram.scala
@@ -324,7 +324,7 @@ private[metrics] class BaseHistogram(val bucketList: BucketList = Histogram.defa
             p(num, index, build :+ weightedValue, remain.tail, newLastNonZeroIndex)
           } else {
             p(num + bucketCount, index + 1, build, remain, newLastNonZeroIndex)
-          } 
+          }
         }
       }
     }
@@ -356,9 +356,9 @@ class DefaultHistogram private[metrics](
   val pruneEmpty: Boolean = false,
   val buckets : BucketList = Histogram.defaultBucketRanges,
   intervals : Seq[FiniteDuration]
-)extends Histogram {
+) extends Histogram {
 
-  val tagHists: Map[FiniteDuration, ConcurrentHashMap[TagMap, BaseHistogram]] = intervals.map{i =>
+  val tagHists: Map[FiniteDuration, ConcurrentHashMap[TagMap, BaseHistogram]] = intervals.map { i =>
     val m = new ConcurrentHashMap[TagMap, BaseHistogram]
     (i -> m)
   }.toMap

--- a/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/collectors/Rate.scala
@@ -47,15 +47,19 @@ trait Rate extends Collector{
 //working implementation of a Rate
 private[metrics] class DefaultRate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean, intervals : Seq[FiniteDuration])extends Rate {
 
-  private val maps: Map[FiniteDuration, CollectionMap[TagMap]] = intervals.map{ i => (i, new CollectionMap[TagMap])}.toMap
+  private val maps: Map[FiniteDuration, CollectionMap[TagMap]] = intervals.map { i =>
+    val collectionMap = new CollectionMap[TagMap]
+    collectionMap.set(TagMap.Empty, 0L)
+    (i, collectionMap)
+  }.toMap
 
   //note - the totals are shared amongst all intervals, and we use the smallest
   //interval to update them
   private val totals = new CollectionMap[TagMap]
-  private val minInterval = if (intervals.size > 0) intervals.min else Duration.Inf
+  private val minInterval = if (intervals.nonEmpty) intervals.min else Duration.Inf
 
   def hit(tags: TagMap = TagMap.Empty, amount: Long = 1) {
-    maps.foreach{ case (_, map) => map.increment(tags, amount) }
+    maps.foreach { case (_, map) => map.increment(tags, amount) }
   }
 
   def tick(interval: FiniteDuration): MetricMap  = {
@@ -82,7 +86,7 @@ private[metrics] class DefaultRate private[metrics](val address: MetricAddress, 
 }
 
 //Dummy implementation of a Rate, used when "enabled=false" is specified at creation
-private[metrics] class NopRate private[metrics](val address : MetricAddress, val pruneEmpty : Boolean)extends Rate {
+private[metrics] class NopRate private[metrics](val address: MetricAddress, val pruneEmpty: Boolean) extends Rate {
 
   private val empty : MetricMap = Map()
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/CollectionSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CollectionSpec.scala
@@ -47,10 +47,10 @@ class CollectionSpec extends WordSpec with MustMatchers{
       val bar = MetricAddress("baz")
       val rate = Rate(bar, false, true)(subNamespace)
       rate.hit()
-      collection.tick(1.minute) mustBe Map(
-        MetricAddress("/foo/baz") -> Map(Map("a" -> "b") -> 1),
-        MetricAddress("/foo/baz/count") -> Map()
-      )
+      val ticked = collection.tick(1.minute)
+      // Due to initializing with zero, the MetricMap will include empty maps from previous tests/MetricAddresses, which we don't care about.
+      ticked(MetricAddress("/foo/baz")) mustBe Map(Map("a" -> "b") -> 1)
+      ticked(MetricAddress("/foo/baz/count")) mustBe Map()
     }
   }
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/CounterSpec.scala
@@ -38,8 +38,9 @@ class CounterSpec extends MetricIntegrationSpec {
       c.get(Map("a" -> "b")) must equal(2)
     }
 
-    "return no metrics when not used yet" in {
-      counter.tick(1.second) must equal(Map())
+    "return empty metrics set to zero when not used yet" in {
+      val ticked = counter.tick(1.second)
+      ticked(counter.address) must equal(Map(Map() -> 0L))
     }
 
     "have correct address" in {

--- a/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/RateSpec.scala
@@ -73,8 +73,10 @@ class RateSpec extends MetricIntegrationSpec {
       r.tick(1.second)("/foo/count")(Map()) must equal(2)
     }
 
-    "not return any metrics when never hit" in {
-      rate().tick(1.second) must equal(Map())
+    "return empty metrics when never hit" in {
+      val ticked = rate().tick(1.second)
+      ticked("/foo") must equal(Map(Map() -> 0))
+      ticked("/foo/count") must equal(Map(Map() -> 0))
     }
 
     "prune empty values" in {


### PR DESCRIPTION
Assign 0 to the empty `TagMap`. Wish I could do this in the `CollectionMap` constructor, but it only accepts params of type `T`.

https://github.com/tumblr/colossus/issues/449
@DanSimon @benblack86 @jlbelmonte @aliyakamercan @amotamed 