### PR TITLE
Minor changes to publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,17 +30,8 @@ env:
   - secure: EZRC7oP4UQXUVBkTIiviCHPoNRw1ur9rhFFqCV6qVpyNpg7uGtM4l882S598KKXW0C3oemXHEEdrF5t5cGozV2nIRYkuEb9K5Kb+1TIRMPZ3KTKGhKTE/5oObTnuIyggSp0ZQLoB7s5eRUup7O74UGkSYY8oJBqixDDhS5g9mwc=
   - secure: XSIdWCu0lX25akXyl8gRc5C7YhASFwkaYWxk7GImBGoZ1apXou9zUGQtxLuOwWcG1HkRldGmwBZz6OqV135jxOcl6IO+brvd0WGPuWXqPDTWWU63K4GgA5oNh+Pbbd/MxGceYbQKkRAgGxeiB8WhOuoxbfHHsjBordp/tco5hX4=
 
-before_install:
-- if [[ "$TRAVIS_TAG" =~ ^v.+$ || (( "$TRAVIS_BRANCH" = "master" || "$TRAVIS_BRANCH"
-  = "develop" || "$TRAVIS_BRANCH" = "travis-test") && "$TRAVIS_PULL_REQUEST" = "false")  ]]
-  ; then SHOULD_PUBLISH=0; fi
-- if (( $SHOULD_PUBLISH == 0)) ; then openssl aes-256-cbc -K $encrypted_9df8dc1a95a3_key
-  -iv $encrypted_9df8dc1a95a3_iv -in secrets.tar.enc -out secrets.tar -d; tar xvf
-  secrets.tar; fi
-
 after_success:
-- if (( $SHOULD_PUBLISH == 0)) ; then  sbt ++$TRAVIS_SCALA_VERSION publishSigned;
-  fi
 - if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then bash <(curl -s https://codecov.io/bash);
   elif [[ "$TRAVIS_BRANCH" = "master" || "$TRAVIS_BRANCH" = "develop" ]]; then bash
   <(curl -s https://codecov.io/bash); fi
+- ./publish.sh

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val SCALATEST_VERSION = "3.0.1"
 
 lazy val testAll = TaskKey[Unit]("test-all")
 
-val GeneralSettings = Seq[Setting[_]](
+lazy val GeneralSettings = Seq[Setting[_]](
   compile := (compile in Compile).dependsOn(compile in Test).dependsOn(compile in IntegrationTest).value,
   testAll := (test in Test).dependsOn(test in IntegrationTest).value,
   organization := "com.tumblr",
@@ -45,28 +45,25 @@ val GeneralSettings = Seq[Setting[_]](
 
 lazy val publishSettings: Seq[Setting[_]] = Seq(
   publishMavenStyle := true,
-  publishTo := {
-    val nexus = "https://oss.sonatype.org/"
+  publishTo := Some(
     if (isSnapshot.value) {
-      Some("snapshots" at nexus + "content/repositories/snapshots")
+      Opts.resolver.sonatypeSnapshots
     } else {
-      Some("releases" at nexus + "service/local/staging/deploy/maven2")
+      Opts.resolver.sonatypeStaging
     }
-  },
+  ),
   publishArtifact in Test := false,
   pomIncludeRepository := Function.const(false),
-  //credentials could also be just embedded in ~/.sbt/0.13/sonatype.sbt
-  (for {
-    username <- Option(System.getenv("SONATYPE_USERNAME"))
-    password <- Option(System.getenv("SONATYPE_PASSWORD"))
-  } yield credentials += Credentials("Sonatype Nexus Repository Manager", "oss.sonatype.org", username, password))
-    .getOrElse(credentials += Credentials(Path.userHome / ".sonatype_credentials")),
-  Option(System.getenv("PGP_PASSPHRASE")).fold(
-    pgpPassphrase := None
-  )(passPhrase => pgpPassphrase := Some(passPhrase.toCharArray)),
+  credentials += Credentials("Sonatype Nexus Repository Manager",
+    "oss.sonatype.org",
+    sys.env.getOrElse("SONATYPE_USERNAME", ""),
+    sys.env.getOrElse("SONATYPE_PASSWORD", "")
+  ),
+  useGpg := false,
+  pgpPassphrase := sys.env.get("PGP_PASSPHRASE").map(_.toCharArray),
   pgpSecretRing := file("secring.gpg"),
   pgpPublicRing := file("pubring.gpg"),
-  licenses := Seq("Apache License, Version 2.0" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.html")),
+  licenses := Seq("Apache-2.0" -> new URL("http://www.apache.org/licenses/LICENSE-2.0")),
   homepage := Some(url("https://github.com/tumblr/colossus")),
   scmInfo := Some(ScmInfo(url("https://github.com/tumblr/colossus"), "scm:git:git@github.com/tumblr/colossus.git")),
   developers := List(
@@ -74,20 +71,20 @@ lazy val publishSettings: Seq[Setting[_]] = Seq(
   )
 )
 
-val ColossusSettings = GeneralSettings ++ publishSettings
+lazy val ColossusSettings = GeneralSettings ++ publishSettings
 
-val noPubSettings = GeneralSettings ++ Seq(
+lazy val noPubSettings = GeneralSettings ++ Seq(
   publishArtifact := false,
   publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo")))
 )
 
-val testkitDependencies = libraryDependencies ++= Seq(
+lazy val testkitDependencies = libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % SCALATEST_VERSION
 )
 
-val MetricSettings = ColossusSettings
+lazy val MetricSettings = ColossusSettings
 
-val ExamplesSettings = Seq(
+lazy val ExamplesSettings = Seq(
   libraryDependencies ++= Seq(
     "org.json4s" %% "json4s-jackson" % "3.5.3"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,9 @@ addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+if [[ CI != 'true' ]]; then
+    echo "Not running on Travis-ci"
+    exit 0
+fi
+ 
+if [[ $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?$ || ($TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "develop" && $(cat version.sbt) =~ "-SNAPSHOT") ]]; then
+    # decrypt secrets & untar 
+    openssl aes-256-cbc -K $encrypted_9df8dc1a95a3_key -iv $encrypted_9df8dc1a95a3_iv -in secrets.tar.enc -out secrets.tar -d
+    tar xvf secrets.tar
+    # publish, close & release
+    sbt publishSigned sonatypeReleaseAll
+else 
+    echo 'Only publishing on version tags or develop snapshots'
+    exit 0
+fi

--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ CI != 'true' ]]; then
+if [[ $CI != 'true' ]]; then
     echo "Not running on Travis-ci"
     exit 0
 fi

--- a/publish.sh
+++ b/publish.sh
@@ -5,7 +5,7 @@ if [[ $CI != 'true' ]]; then
     exit 0
 fi
  
-if [[ $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+)?$ || ($TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "develop" && $(cat version.sbt) =~ "-SNAPSHOT") ]]; then
+if [[ $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+|-M[0-9]+)?$ || ($TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "develop" && $(cat version.sbt) =~ "-SNAPSHOT") ]]; then
     # decrypt secrets & untar 
     openssl aes-256-cbc -K $encrypted_9df8dc1a95a3_key -iv $encrypted_9df8dc1a95a3_iv -in secrets.tar.enc -out secrets.tar -d
     tar xvf secrets.tar


### PR DESCRIPTION
- Added `sbt-sonatype`, we don't have to manually close and release on Sonatype anymore. 
- Merges to develop will trigger snapshot releases
- Version tag pushes (this used to be any push to master) will trigger releases
- Moved things from `travis.yml` to a publish script
- Minor changes in build.sbt

@benblack86 @DanSimon @amotamed @jlbelmonte @dxuhuang 
