### PR TITLE
Remove Content Type from Http Body

### DIFF
--- a/colossus-docs/src/main/paradox/services.md
+++ b/colossus-docs/src/main/paradox/services.md
@@ -25,8 +25,13 @@ There are several different ways to set headers on the response.
 
 @@snip [HttpService2.scala](../scala/HttpService2.scala) { #example1 }
 
-Setting the content type or using a different http code involves a bit more work as the above helper methods can't be 
-used. Instead use the `respond` method.
+The content type header is a little special since it is usually set automatically but can also be set manually.
+It can be set just like any other header.
+
+@@snip [HttpService2.scala](../scala/HttpService2.scala) { #example1a }
+
+You can also use `.withContent()` to set the content type header.
+For a different HTTP status code, the helper methods don't exist; instead just use the `respond` method.
 
 @@snip [HttpService2.scala](../scala/HttpService2.scala) { #example2 }
 

--- a/colossus-docs/src/main/scala/HttpService2.scala
+++ b/colossus-docs/src/main/scala/HttpService2.scala
@@ -23,6 +23,9 @@ object HttpService2 {
             request.ok("hello", HttpHeaders(HttpHeader("header-name", "header-value")))
             request.ok("hello", HttpHeaders(HttpHeader(HttpHeaders.CookieHeader, "header-value")))
           // #example1
+            // #example1a
+            request.ok("hello", HttpHeaders(HttpHeader("Content-Type", "header-value")))
+            // #example1a
 
           case request @ Get on Root =>
             // #example3

--- a/colossus-docs/src/main/scala/HttpService2.scala
+++ b/colossus-docs/src/main/scala/HttpService2.scala
@@ -26,15 +26,17 @@ object HttpService2 {
 
           case request @ Get on Root =>
             // #example3
-            val body: String                    = request.body.bytes.utf8String
-            val contentType: Option[HttpHeader] = request.body.contentType
-            val headers: HttpHeaders            = request.head.headers
-            val parameter: Option[String]       = request.head.parameters.getFirst("key")
+            val body: String                = request.body.bytes.utf8String
+            val contentType: Option[String] = request.head.headers.contentType
+            val headers: HttpHeaders        = request.head.headers
+            val parameter: Option[String]   = request.head.parameters.getFirst("key")
             // #example3
 
             // #example2
-            request.respond(HttpCodes.CONFLICT,
-                            HttpBody("""{"name":"value"}""").withContentType(ContentType.ApplicationJson))
+            request.respond(
+              HttpCodes.CONFLICT,
+              HttpBody("""{"name":"value"}""")
+            ).withContentType(ContentType.ApplicationJson)
           // #example2
         }
       }

--- a/colossus-examples/src/main/scala/colossus.examples/BenchmarkExample.scala
+++ b/colossus-examples/src/main/scala/colossus.examples/BenchmarkExample.scala
@@ -12,8 +12,10 @@ import org.json4s.JsonDSL._
 object BenchmarkService {
 
   implicit object JsonBody extends HttpBodyEncoder[JValue] {
+    val contentType = Some(ContentType.ApplicationJson)
+
     def encode(json: JValue) = {
-      HttpBody(compact(render(json))).withContentType("application/json")
+      HttpBody(compact(render(json)))
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -97,14 +97,13 @@ class HttpParserSuite extends WordSpec with MustMatchers {
             "content-length" -> len.toString
           )
         ),
-        HttpBody(body, "text/plain")
+        HttpBody(body)
       )
 
       val parser = requestParser
       val parsed = parser.parse(DataBuffer(ByteString(req)))
 
       parsed must equal(Some(expected))
-      parsed.get.body.contentType must equal(Some(HttpHeader("Content-Type", "text/plain")))
     }
 
     "handle request with content-length set to 0" in {

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpResponseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpResponseSpec.scala
@@ -21,7 +21,7 @@ class HttpResponseSpec extends ColossusSpec with TryValues with OptionValues wit
       val expected = HttpResponse(HttpVersion.`1.1`, HttpCodes.ACCEPTED, HttpHeaders(), ByteString("test conversion"))
 
       // currently there's no easy way to pass the contentType into HttpResponse.apply()
-      response must equal(expected.copy(body = expected.body.withContentType("text/plain")))
+      response must equal(expected.withContentType("text/plain"))
     }
   }
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpSpec.scala
@@ -24,16 +24,10 @@ class HttpSpec extends WordSpec with MustMatchers {
 
   "http body" must {
 
-    "create with encoder and custom content-type" in {
+    "create with encoder" in {
       val str = "hello, world!™ᴂ無奈朝來寒雨"
-      val b   = HttpBody(str, "foo/bar")
-      b.contentType.get.value must equal("foo/bar")
+      val b   = HttpBody(str)
       b.bytes must equal(ByteString(str))
-    }
-
-    "copy with new content-type" in {
-      val b = HttpBody("hello")
-      b.withContentType("foo/bar").contentType.get.value must equal("foo/bar")
     }
 
     "decode using built-in decoders" in {

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
@@ -65,8 +65,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
       parser.parse(DataBuffer(ByteString(res))) must equal(None)
       val parsed = parser.endOfStream()
       // currently there's no easy way to pass the contentType into HttpResponse.apply()
-      parsed.map(response => response.copy(body = response.body.withContentType("text/plain"))) must equal(
-        Some(expected))
+      parsed must equal(Some(expected))
     }
 
     "parse a response with a body" in {
@@ -96,12 +95,9 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
         ByteString("{some : json}")
       )
       val data   = DataBuffer(ByteString(res))
-      val parsed = parser.parse(data)
-
-      parsed.get.body.contentType must equal(Some(HttpHeader("Content-Type", "application/json")))
+      val parsed: Option[HttpResponse] = parser.parse(data)
       // expected body was constructed with a ByteString so its contentType is None. We will just compare the head and bytes instead.
-      parsed.get.body.bytes must equal(expected.body.bytes)
-      parsed.get.head must equal(expected.head)
+      parsed must equal(Some(expected))
       data.remaining must equal(0)
     }
 

--- a/colossus/src/main/scala/colossus/controller/OutputController.scala
+++ b/colossus/src/main/scala/colossus/controller/OutputController.scala
@@ -88,7 +88,7 @@ trait StaticOutputController[E <: Encoding] extends BaseController[E] {
           false
         }
         case Some(PullResult.Closed) => {
-          fatalError(new PipeStateException("output stream unepectedly closed"), true)
+          fatalError(new PipeStateException("output stream unexpectedly closed"), true)
           false
         }
         case None => true //this would only occur if we returned false due to buffer overflowing

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -260,7 +260,6 @@ class HttpHeaders(private[http] val headers: JList[HttpHeader]) {
     while (it.hasNext) {
       it.next.encode(buffer)
     }
-
   }
 
   /**
@@ -273,8 +272,10 @@ class HttpHeaders(private[http] val headers: JList[HttpHeader]) {
 
   override def equals(that: Any): Boolean = that match {
     case that: HttpHeaders => this.toSeq.toSet == that.toSeq.toSet
-    case other             => false
+    case _                 => false
   }
+
+  override def hashCode(): Int = this.toSeq.toSet.hashCode()
 
   override def toString = "[" + toSeq.map { _.toString }.mkString(" ") + "]"
 

--- a/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpRequestParser.scala
@@ -11,24 +11,19 @@ object HttpRequestParser {
   def apply(maxRequestSize: DataSize) = httpRequest(maxRequestSize)
 
   protected def httpRequest(maxRequestSize: DataSize): Parser[HttpRequest] = httpHead |> { head =>
-    val contentType       = head.headers.contentType
-    val contentTypeHeader = contentType.map(ct => HttpHeader(HttpHeaders.ContentType, ct))
     head.headers.transferEncoding match {
       case TransferEncoding.Identity =>
         head.headers.contentLength match {
           case Some(0) | None => const(HttpRequest(head, HttpBody.NoBody))
           case Some(n) => {
             bytes(n, maxRequestSize, 1.KB) >> { body =>
-              HttpRequest(head, new HttpBody(body, contentTypeHeader))
+              HttpRequest(head, new HttpBody(body))
             }
           }
         }
       case _ =>
         chunkedBody >> { body =>
-          val httpBody = contentTypeHeader.fold(HttpBody(body)) { header =>
-            HttpBody(body, header)
-          }
-          HttpRequest(head, httpBody)
+          HttpRequest(head, HttpBody(body))
         }
     }
   }

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -160,7 +160,6 @@ class ServiceClient[P <: Protocol](
     val context: Context
 )(implicit tagDecorator: TagDecorator[P] = TagDecorator.default[P])
     extends ControllerDownstream[Encoding.Client[P]]
-    with HasUpstream[ControllerUpstream[Encoding.Client[P]]]
     with Client[P, Callback]
     with HandlerTail {
 


### PR DESCRIPTION
@DanSimon  @benblack86  @aliyakamercan  @amotamed  @jlbelmonte 

Second stab at https://github.com/tumblr/colossus/issues/545

So what we'd like to be able to do is set the content-type on the `HttpResponse` without having to bother the internal `HttpBody`. I don't see an inherent reason why the content-type has to be part of `HttpBody` anyway; after all, the only substantial place it's used is in the `encode()` method that writes to the `DynamicOutBuffer`, and the body itself is just a byte array. If we add the content-type `Header` properly, `HttpResponseHead.encode()` will take care of it just the same.

The only issue I see is potential duplicate headers since `HttpHeaders` is just a wrapper around a linked list, but I think that should still be handled in `HttpHeaders` alone. In fact I'm thinking about going a bit further and making `HttpHeaders` wrap a `HashMap[String, HttpHeader]` instead.

Discuss.