### PR TITLE
Refactor

### DIFF
--- a/colossus-testkit/src/main/scala/colossus.testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus.testkit/ServiceSpec.scala
@@ -8,11 +8,11 @@ import java.net.InetSocketAddress
 
 import colossus.IOSystem
 import colossus.core.ServerRef
-import colossus.service.{ClientConfig, FutureClient, GenFutureClientFactory, Protocol}
+import colossus.service.{ClientConfig, FutureClient, FutureClientFactory, Protocol}
 
 import scala.reflect.ClassTag
 
-abstract class ServiceSpec[P <: Protocol](implicit clientFactory: GenFutureClientFactory[P]) extends ColossusSpec {
+abstract class ServiceSpec[P <: Protocol](implicit clientFactory: FutureClientFactory[P]) extends ColossusSpec {
 
   type Request  = P#Request
   type Response = P#Response

--- a/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/AsyncServiceClient.scala
@@ -27,12 +27,9 @@ class ProxyWatchdog(proxy: ActorRef, signal: AtomicBoolean) extends Actor {
 
 trait Client[P <: Protocol, M[_]] extends Sender[P, M] {
   def connectionStatus: M[ConnectionStatus]
-  def disconnect()
-
 }
 
-trait CallbackClient[P <: Protocol] extends Client[P, Callback]
-trait FutureClient[P <: Protocol]   extends Client[P, Future]
+trait FutureClient[P <: Protocol] extends Client[P, Future]
 
 object FutureClient {
 

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -211,12 +211,8 @@ object ServiceClientFactory {
 
 }
 
-trait CallbackClientFactory[P <: Protocol, T <: Sender[P, Callback]] extends ClientFactory[P, Callback, T, WorkerRef]
-
-trait FutureClientFactory[P <: Protocol, T <: Sender[P, Future]] extends ClientFactory[P, Future, T, IOSystem]
-
-class GenFutureClientFactory[P <: Protocol](base: FutureClient.BaseFactory[P])
-    extends FutureClientFactory[P, FutureClient[P]] {
+class FutureClientFactory[P <: Protocol](base: FutureClient.BaseFactory[P])
+    extends ClientFactory[P, Future, FutureClient[P], IOSystem] {
 
   def defaultName = base.defaultName
 
@@ -252,7 +248,7 @@ abstract class ClientFactories[P <: Protocol, T[M[_]] <: Sender[P, M]](lifter: C
 
   implicit def clientFactory: FutureClient.BaseFactory[P]
 
-  implicit val futureFactory = new GenFutureClientFactory[P](clientFactory)
+  implicit val futureFactory = new FutureClientFactory[P](clientFactory)
 
   val client = new CodecClientFactory[P, Callback, T, WorkerRef](
     clientFactory,


### PR DESCRIPTION
Ali and I were walking through the code and noticed some stuff that was unused and can be deleted. We didn't know what the "Gen" in `GenFutureClientFactory` stood for, so we deleted the "Gen".

@aliyakamercan @dxuhuang @DanSimon @nsauro 