### PR TITLE
Use explicit params instead of underscores

### DIFF
--- a/colossus-docs/src/main/scala/CallbackClient.scala
+++ b/colossus-docs/src/main/scala/CallbackClient.scala
@@ -12,12 +12,12 @@ object CallbackClient extends App {
   implicit val actorSystem = ActorSystem()
   implicit val ioSystem    = IOSystem()
 
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
 
       val callbackClient = Http.client("example.org", 80)
 
-      override def onConnect = new RequestHandler(_) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root =>
             val request = HttpRequest.get("/")

--- a/colossus-docs/src/main/scala/Fibonacci2.scala
+++ b/colossus-docs/src/main/scala/Fibonacci2.scala
@@ -21,9 +21,9 @@ object Fibonacci2 extends App {
   implicit val executionContext = actorSystem.dispatcher
   implicit val io               = IOSystem("io-system", workerCount = Some(1), MetricSystem("io-system"))
 
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
-      override def onConnect = new RequestHandler(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
 
           case req @ Get on Root / "hello" =>

--- a/colossus-docs/src/main/scala/Fibonacci3.scala
+++ b/colossus-docs/src/main/scala/Fibonacci3.scala
@@ -24,12 +24,12 @@ object Fibonacci3 extends App {
   implicit val io               = IOSystem("io-system", workerCount = Some(1), MetricSystem("io-system"))
 
   // #fibonacci3
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
 
       val cache = Memcache.client("localhost", 11211)
 
-      override def onConnect = new RequestHandler(_) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
 
           case req @ Get on Root / "hello" =>

--- a/colossus-docs/src/main/scala/GenericClient.scala
+++ b/colossus-docs/src/main/scala/GenericClient.scala
@@ -28,11 +28,11 @@ object GenericClient extends App {
     println(string)
   }
 
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
       val client = Http.client("example.org", 80)
 
-      override def onConnect = new RequestHandler(_) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root =>
             // using callback client

--- a/colossus-docs/src/main/scala/HelloWorld.scala
+++ b/colossus-docs/src/main/scala/HelloWorld.scala
@@ -13,9 +13,9 @@ object HelloWorld extends App {
   implicit val actorSystem = ActorSystem()
   implicit val ioSystem    = IOSystem()
 
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
-      override def onConnect = new RequestHandler(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root => request.ok("Hello world!")
         }

--- a/colossus-docs/src/main/scala/HttpClientExample.scala
+++ b/colossus-docs/src/main/scala/HttpClientExample.scala
@@ -11,12 +11,12 @@ object HttpClientExample extends App {
   implicit val ioSystem    = IOSystem()
 
   // #example
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
 
       val httpClient = Http.client("google.com", 80)
 
-      override def onConnect = new RequestHandler(_) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root =>
             val asyncResult = httpClient.send(HttpRequest.get("/#q=mysearch"))

--- a/colossus-docs/src/main/scala/HttpServiceExample.scala
+++ b/colossus-docs/src/main/scala/HttpServiceExample.scala
@@ -13,9 +13,9 @@ object HttpServiceExample extends App {
   implicit val actorSystem = ActorSystem()
   implicit val ioSystem    = IOSystem()
 
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
-      override def onConnect = new RequestHandler(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root / "hello" =>
             Callback.successful(request.ok("Hello world!"))

--- a/colossus-docs/src/main/scala/MemcacheClient.scala
+++ b/colossus-docs/src/main/scala/MemcacheClient.scala
@@ -13,12 +13,12 @@ object MemcacheClient extends App {
   implicit val ioSystem    = IOSystem()
 
   // #example
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
 
       val memcacheClient = Memcache.client("localhost", 11211)
 
-      override def onConnect = new RequestHandler(_) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root =>
             val asyncResult = memcacheClient.get(ByteString("1"))

--- a/colossus-docs/src/main/scala/MetricTickExample.scala
+++ b/colossus-docs/src/main/scala/MetricTickExample.scala
@@ -22,9 +22,9 @@ object MetricTickExample extends App {
 
   val badUrl = Rate("badurl")
 
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
-      override def onConnect = new RequestHandler(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root / "url" =>
             //bad url, metric tick

--- a/colossus-docs/src/main/scala/MiddlewareAsFunctions.scala
+++ b/colossus-docs/src/main/scala/MiddlewareAsFunctions.scala
@@ -12,9 +12,9 @@ object MiddlewareAsFunctions extends App {
   implicit val actorSystem = ActorSystem()
   implicit val ioSystem    = IOSystem()
 
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
-      override def onConnect = new RequestHandler(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           // #example1
           case request @ Post on Root / "shout" => withBody(request) { body =>

--- a/colossus-docs/src/main/scala/RedisClient.scala
+++ b/colossus-docs/src/main/scala/RedisClient.scala
@@ -21,7 +21,7 @@ object RedisClient extends App {
 
       val redisClient = Redis.client("localhost", 6379)
 
-      override def onConnect = new RequestHandler(_) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
 
           case req @ Get on Root / "get" / key => {

--- a/colossus-docs/src/main/scala/RedisClientExample.scala
+++ b/colossus-docs/src/main/scala/RedisClientExample.scala
@@ -14,12 +14,12 @@ object RedisClientExample extends App {
   implicit val ioSystem    = IOSystem()
 
   // #example
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
 
       val redisClient = Redis.client("localhost", 6379)
 
-      override def onConnect = new RequestHandler(_) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
 
           case request @ Get on Root / "get" / key => {

--- a/colossus-docs/src/main/scala/RedisServiceExample.scala
+++ b/colossus-docs/src/main/scala/RedisServiceExample.scala
@@ -15,9 +15,9 @@ object RedisServiceExample extends App {
 
   val db = new ConcurrentHashMap[String, String]()
 
-  RedisServer.start("example-server", 9000) {
-    new Initializer(_) {
-      override def onConnect = new RequestHandler(_) {
+  RedisServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Redis] = {
           case Command("GET", args) =>
             args match {

--- a/colossus-docs/src/main/scala/ServiceConfigExample.scala
+++ b/colossus-docs/src/main/scala/ServiceConfigExample.scala
@@ -24,10 +24,10 @@ object ServiceConfigExample {
   )
   // #example
 
-  HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
       // #example1
-      override def onConnect = new RequestHandler(_, serviceConfig) {
+      override def onConnect = serverContext => new RequestHandler(serverContext, serviceConfig) {
         // #example1
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root => Callback.successful(request.ok("Hello world!"))

--- a/colossus-docs/src/main/scala/WorkerExample.scala
+++ b/colossus-docs/src/main/scala/WorkerExample.scala
@@ -14,8 +14,8 @@ object WorkerExample extends App {
   // #example
   case class NameChange(name: String)
 
-  val serverRef = HttpServer.start("example-server", 9000) {
-    new Initializer(_) {
+  val serverRef = HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
 
       var currentName = "Jones"
 
@@ -23,7 +23,7 @@ object WorkerExample extends App {
         case NameChange(name) => currentName = name
       }
 
-      override def onConnect = new RequestHandler(_) {
+      override def onConnect = serverContext => new RequestHandler(serverContext) {
         override def handle: PartialHandler[Http] = {
           case request @ Get on Root => Callback.successful(request.ok(s"My name is $currentName"))
         }

--- a/colossus-examples/src/main/scala/colossus.examples/KeyValExample.scala
+++ b/colossus-examples/src/main/scala/colossus.examples/KeyValExample.scala
@@ -35,9 +35,9 @@ object KeyValExample {
 
     val db = io.actorSystem.actorOf(Props[KeyValDB])
 
-    RedisServer.start("key-value-example", port) {
-      new Initializer(_) {
-        def onConnect = new RequestHandler(_) {
+    RedisServer.start("key-value-example", port) { initContext =>
+      new Initializer(initContext) {
+        def onConnect = serverContext => new RequestHandler(serverContext) {
           def handle = {
             case Command("GET", args) => {
               val dbCmd = KeyValDB.Get(args(0))

--- a/colossus-examples/src/main/scala/colossus.examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus.examples/StreamServiceExample.scala
@@ -22,7 +22,7 @@ object StreamServiceExample {
     StreamingHttpServer.basic(
       "stream-service",
       port,
-      new GenRequestHandler[StreamingHttp](_, config) {
+      serverContext => new GenRequestHandler[StreamingHttp](serverContext, config) {
 
         def handle = {
           case StreamingHttpRequest(head, source) if (head.url == "/plaintext") =>


### PR DESCRIPTION
Personally I think examples should focus on clarity and underscores undermine that a little bit.

@DanSimon @benblack86 @aliyakamercan @amotamed @jlbelmonte 