### PR TITLE
Protect constant callback

### DIFF
--- a/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
@@ -557,7 +557,7 @@ class CallbackSpec extends ColossusSpec {
 
       intercept[CallbackExecutionException] {
         Callback(func).execute {
-          case _ => throw new FoobarException
+          _ => throw new FoobarException
         }
       }
 
@@ -567,12 +567,14 @@ class CallbackSpec extends ColossusSpec {
             Callback(func)
           }
           .execute {
-            case _ => {
-              val e = new FoobarException
-              //e.printStackTrace()
-              throw e
-            }
+            _ => throw new FoobarException
           }
+      }
+
+      intercept[CallbackExecutionException] {
+        Callback.successful(true).execute {
+          _ => throw new FoobarException
+        }
       }
 
     }

--- a/colossus/src/main/scala/colossus/service/Callback.scala
+++ b/colossus/src/main/scala/colossus/service/Callback.scala
@@ -280,7 +280,11 @@ case class ConstantCallback[O](value: Try[O]) extends Callback[O] {
   }
 
   def execute(onComplete: Try[O] => Unit = _ => ()) {
-    onComplete(value)
+    try {
+      onComplete(value)
+    } catch {
+      case err: Throwable => throw new CallbackExecutionException(err)
+    }
   }
 
 }


### PR DESCRIPTION
I was playing around with callback, because I hear they are like the future 🥁 .

The docs say that `CallbackExecutionException` is thrown if there is an uncaught exception in the execution block of a Callback. This is true for unmapped and mapped callback, but not for constant callback. I added a try/catch!

@DanSimon @nsauro @dxuhuang @aliyakamercan  