### PR TITLE
adding mima

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,9 @@ lazy val RootProject = Project(id = "root", base = file("."))
 
 lazy val ColossusProject: Project = Project(id = "colossus", base = file("colossus"))
   .settings(ColossusSettings: _*)
+  .settings{
+    mimaPreviousArtifacts := Set("com.tumblr" % "colossus_2.11" % "0.9.1")
+  }
   .configs(IntegrationTest)
   .aggregate(ColossusTestsProject)
   .dependsOn(ColossusMetricsProject)
@@ -111,11 +114,17 @@ lazy val ColossusExamplesProject = Project(id = "colossus-examples", base = file
 
 lazy val ColossusMetricsProject = Project(id = "colossus-metrics", base = file("colossus-metrics"))
   .settings(MetricSettings: _*)
+  .settings{
+    mimaPreviousArtifacts := Set("com.tumblr" % "colossus-metrics_2.11" % "0.9.1")
+  }
   .configs(IntegrationTest)
 
 lazy val ColossusTestkitProject = Project(id = "colossus-testkit", base = file("colossus-testkit"))
   .settings(ColossusSettings: _*)
   .settings(testkitDependencies)
+  .settings{
+    mimaPreviousArtifacts := Set("com.tumblr" % "colossus-testkit_2.11" % "0.9.1")
+  }
   .configs(IntegrationTest)
   .dependsOn(ColossusProject)
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,11 @@ import sbt._
 import Keys._
 import com.lightbend.paradox.sbt.ParadoxPlugin
 import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport._
+import ProjectImplicits._
 
 val AKKA_VERSION      = "2.5.4"
 val SCALATEST_VERSION = "3.0.1"
+val MIMA_PREVIOUS_VERSIONS = Seq("0.9.1")
 
 lazy val testAll = TaskKey[Unit]("test-all")
 
@@ -99,9 +101,7 @@ lazy val RootProject = Project(id = "root", base = file("."))
 
 lazy val ColossusProject: Project = Project(id = "colossus", base = file("colossus"))
   .settings(ColossusSettings: _*)
-  .settings{
-    mimaPreviousArtifacts := Set("com.tumblr" % "colossus_2.11" % "0.9.1")
-  }
+  .withMima(MIMA_PREVIOUS_VERSIONS : _*)
   .configs(IntegrationTest)
   .aggregate(ColossusTestsProject)
   .dependsOn(ColossusMetricsProject)
@@ -114,17 +114,13 @@ lazy val ColossusExamplesProject = Project(id = "colossus-examples", base = file
 
 lazy val ColossusMetricsProject = Project(id = "colossus-metrics", base = file("colossus-metrics"))
   .settings(MetricSettings: _*)
-  .settings{
-    mimaPreviousArtifacts := Set("com.tumblr" % "colossus-metrics_2.11" % "0.9.1")
-  }
+  .withMima(MIMA_PREVIOUS_VERSIONS : _*)
   .configs(IntegrationTest)
 
 lazy val ColossusTestkitProject = Project(id = "colossus-testkit", base = file("colossus-testkit"))
   .settings(ColossusSettings: _*)
   .settings(testkitDependencies)
-  .settings{
-    mimaPreviousArtifacts := Set("com.tumblr" % "colossus-testkit_2.11" % "0.9.1")
-  }
+  .withMima(MIMA_PREVIOUS_VERSIONS : _*)
   .configs(IntegrationTest)
   .dependsOn(ColossusProject)
 

--- a/project/ProjectImplicits.scala
+++ b/project/ProjectImplicits.scala
@@ -1,0 +1,23 @@
+import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport.mimaPreviousArtifacts
+import sbt.Project
+
+object ProjectImplicits{
+
+  implicit class ProjectExtras(project : Project){
+    import sbt._
+    import Keys._
+
+    def withMima(versions : String*) : Project = {
+      project.settings{
+        mimaPreviousArtifacts := (if(scalaBinaryVersion.value == "2.11") {
+          versions.map{ v =>
+            organization.value %% s"${moduleName.value}" % v
+          }.toSet
+        }else{
+          Set.empty
+        })
+      }
+    }
+  }
+}
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,4 +14,6 @@ addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.2.13")
 
 addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.10")
 
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
+
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"


### PR DESCRIPTION
This is a no frills mima integration.

I wanted to do something a bit more fancy then just copy/pasting and changing the dep for the mima setting, but wasn't sure if it was super necessary.  I was going to use an implicit class on project that exposed a new function `withMima(...)` which would allow each project to opt into mima, and that function could generate the setting.  This is probably good for now, but if we want to start tracking more than just one pervious version, we might want that function at some point.