### PR TITLE
Remove unmapped callback

### DIFF
--- a/colossus-testkit/src/test/scala/colossus.testkit/CallbackMatchersSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus.testkit/CallbackMatchersSpec.scala
@@ -2,7 +2,7 @@ package colossus.testkit
 
 import java.awt.datatransfer.UnsupportedFlavorException
 
-import colossus.service.{UnmappedCallback, Callback}
+import colossus.service.{MappedCallback, Callback}
 import scala.concurrent.duration._
 
 import scala.util.Try
@@ -21,7 +21,7 @@ class CallbackMatchersSpec extends ColossusSpec {
 
       def cbFunc(f: Try[Int] => Unit) {}
 
-      val unmapped = UnmappedCallback(cbFunc)
+      val unmapped = MappedCallback(cbFunc, identity[Try[Int]])
 
       var execd  = false
       val result = new CallbackEvaluateTo[Int](duration, a => execd = true).apply(unmapped)

--- a/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
@@ -43,7 +43,7 @@ class CallbackSpec extends ColossusSpec {
       def sfunc(s: String): Callback[String] = Callback { f: (Try[String] => Unit) =>
         f(Success("hey " + s))
       }
-      val cb1 = UnmappedCallback(func)
+      val cb1 = MappedCallback(func, identity[Try[Int]])
       val cb2 = cb1.flatMap { i: Int =>
         sfunc((i + 1).toString)
       }

--- a/colossus/src/main/scala/colossus/service/Callback.scala
+++ b/colossus/src/main/scala/colossus/service/Callback.scala
@@ -136,7 +136,7 @@ case class MappedCallback[I, O](trigger: (Try[I] => Unit) => Unit, handler: Try[
           }
           case Failure(err) => cb(Failure(err))
       })
-    UnmappedCallback(newTrigger)
+    MappedCallback(newTrigger, identity[Try[U]])
   }
   def map[U](f: O => U): Callback[U] =
     MappedCallback(trigger, { i: Try[I] =>
@@ -182,73 +182,7 @@ case class MappedCallback[I, O](trigger: (Try[I] => Unit) => Unit, handler: Try[
               case t: Throwable => cb(Failure(t))
             }
       })
-    UnmappedCallback(newtrigger)
-  }
-
-}
-
-/**
-  * A Callback that has not been mapped.  See the docs for [[Callback]] for more information
-  */
-case class UnmappedCallback[I](trigger: (Try[I] => Unit) => Unit) extends Callback[I] {
-  def map[O](f: I => O): Callback[O] = MappedCallback(trigger, (i: Try[I]) => i.map(f))
-  def flatMap[O](f: I => Callback[O]): Callback[O] = {
-    val newTrigger: (Try[O] => Unit) => Unit = cb =>
-      trigger {
-        case Success(value) => {
-          Try(f(value)) match {
-            case Success(callback) => callback.execute(cb)
-            case Failure(err)      => cb(Failure(err))
-          }
-        }
-        case Failure(err) => cb(Failure(err))
-    }
-    UnmappedCallback(newTrigger)
-  }
-
-  def mapTry[O](f: Try[I] => Try[O]): Callback[O] =
-    MappedCallback(trigger, (i: Try[I]) => try { f(i) } catch { case t: Throwable => Failure(t) })
-
-  def execute(onComplete: Try[I] => Unit = _ => ()) {
-    try {
-      trigger({ i =>
-        onComplete(i)
-      })
-    } catch {
-      case err: Throwable => throw new CallbackExecutionException(err)
-    }
-  }
-
-  def recover[U >: I](p: PartialFunction[Throwable, U]): Callback[U] =
-    MappedCallback(
-      trigger,
-      (i: Try[I]) =>
-        i match {
-          case Success(o) => Success(o)
-          case Failure(err) =>
-            try {
-              p.andThen(s => Success(s))
-                .applyOrElse(err, { e: Throwable =>
-                  Failure[U](e)
-                })
-            } catch {
-              case t: Throwable => Failure(t)
-            }
-      }
-    )
-
-  def recoverWith[U >: I](p: PartialFunction[Throwable, Callback[U]]): Callback[U] = {
-    val newTrigger: (Try[U] => Unit) => Unit = cb =>
-      trigger {
-        case Success(o) => cb(Success(o))
-        case Failure(err) =>
-          try {
-            p.applyOrElse(err, (e: Throwable) => Callback.failed(e)).execute(cb)
-          } catch {
-            case t: Throwable => cb(Failure(t))
-          }
-    }
-    UnmappedCallback(newTrigger)
+    MappedCallback(newtrigger, identity[Try[U]])
   }
 
 }
@@ -358,14 +292,14 @@ object Callback {
     * continuation that will be the fully built mappings on the result
     * `Callback`.
     */
-  def apply[I](f: (Try[I] => Unit) => Unit): Callback[I] = UnmappedCallback(f)
+  def apply[I](f: (Try[I] => Unit) => Unit): Callback[I] = MappedCallback(f, identity[Try[I]])
 
   /**
     * Zip two [[Callback Callbacks]] together into a single `Callback` containing
     * a tuple of the results.
     */
   def zip[A, B](a: Callback[A], b: Callback[B]): Callback[(A, B)] = {
-    UnmappedCallback((f: Try[(A, B)] => Unit) => new TupledCallback[A, B](a, b, f).execute())
+    MappedCallback((f: Try[(A, B)] => Unit) => new TupledCallback[A, B](a, b, f).execute(), identity[Try[(A, B)]])
   }
 
   /**
@@ -374,7 +308,7 @@ object Callback {
     * that the success/failure of each individual `Callback` can be determined.
     */
   def sequence[A: ClassTag](callbacks: Seq[Callback[A]]): Callback[Seq[Try[A]]] = {
-    UnmappedCallback((f: Function1[Try[Seq[Try[A]]], Unit]) => new SequencedCallback(f, callbacks).execute())
+    MappedCallback((f: Function1[Try[Seq[Try[A]]], Unit]) => new SequencedCallback(f, callbacks).execute(), identity[Try[Seq[Try[A]]]])
   }
 
   /** Create a callback that immediately returns the value
@@ -416,7 +350,7 @@ object Callback {
       future.onComplete { res =>
         executor.executor ! CallbackExec(() => cb(res))
     }
-    UnmappedCallback(trigger)
+    MappedCallback(trigger, identity[Try[I]])
   }
 
   /**
@@ -431,7 +365,7 @@ object Callback {
   def schedule[I](in: FiniteDuration)(cb: Callback[I])(implicit executor: CallbackExecutor): Callback[I] = {
     implicit val ex                       = executor.context
     val trigger: (Try[I] => Unit) => Unit = x => executor.executor ! CallbackExec(() => cb.execute(x), Some(in))
-    UnmappedCallback(trigger)
+    MappedCallback(trigger, identity[Try[I]])
   }
 
   object Implicits {
@@ -457,14 +391,14 @@ class CallbackPromise[T] {
   private var value: Option[Try[T]]              = None
   private var completion: Option[Try[T] => Unit] = None
 
-  val callback: Callback[T] = UnmappedCallback(trigger => {
+  val callback: Callback[T] = MappedCallback[T, T](trigger  => {
     value match {
       case Some(v) => trigger(v)
       case None => {
         completion = Some(trigger)
       }
     }
-  })
+  }, identity[Try[T]])
 
   def success(t: T) {
     complete(Success(t))

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -289,7 +289,7 @@ class ServiceClient[P <: Protocol](
     * Create a callback for sending a request.  this allows you to do something like
     * service.send("request"){response => "YAY"}.map{str => println(str)}.execute()
     */
-  def send(request: Request): Callback[P#Response] = UnmappedCallback[P#Response](sendNow(request))
+  def send(request: Request): Callback[P#Response] = MappedCallback[P#Response, P#Response](sendNow(request), identity[Try[P#Response]])
 
   def processMessages(): Unit = incoming.pullWhile(
     response => {

--- a/colossus/src/main/scala/colossus/streaming/Source.scala
+++ b/colossus/src/main/scala/colossus/streaming/Source.scala
@@ -1,7 +1,7 @@
 package colossus.streaming
 
-import scala.util.{Try, Success, Failure}
-import colossus.service.{Callback, UnmappedCallback}
+import scala.util.{Failure, Success, Try}
+import colossus.service.{Callback, MappedCallback}
 
 sealed trait PullAction
 
@@ -109,7 +109,7 @@ trait Source[+T] extends Transport {
     done
   }
 
-  def pullCB(): Callback[Option[T]] = UnmappedCallback(pull)
+  def pullCB(): Callback[Option[T]] = MappedCallback(pull, identity[Try[Option[T]]])
 
   def fold[U](init: U)(cb: (T, U) => U): Callback[U] = {
     pullCB().flatMap {


### PR DESCRIPTION
In the name of less code/concepts I thought I'd remove unmapped callback, which is just a mapped callback with the identity function.

I'm guessing the main reason for the unmapped callback is the need for speed? @DanSimon what do you think?

@DanSimon @aliyakamercan @dxuhuang @nsauro 