### PR TITLE
Fix scala 2.12 warnings

### DIFF
--- a/colossus-metrics/src/main/scala/colossus/metrics/ConfigHelper.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/ConfigHelper.scala
@@ -6,12 +6,12 @@ import com.typesafe.config.{Config, ConfigFactory}
 import scala.concurrent.duration._
 import scala.util.Try
 
+import scala.collection.JavaConverters._
+
 //has to be a better way
 object ConfigHelpers {
 
   implicit class ConfigExtractors(config: Config) {
-
-    import scala.collection.JavaConversions._
 
     def getStringOption(path: String): Option[String] = getOption(path, config.getString)
 
@@ -30,7 +30,7 @@ object ConfigHelpers {
     }
 
     def getFiniteDurations(path: String): Seq[FiniteDuration] =
-      config.getStringList(path).map(finiteDurationOnly(_, path))
+      config.getStringList(path).asScala.map(finiteDurationOnly(_, path))
 
     def getFiniteDuration(path: String): FiniteDuration = finiteDurationOnly(config.getString(path), path)
 

--- a/colossus-metrics/src/test/scala/colossus/metrics/MetricNamespaceSpec.scala
+++ b/colossus-metrics/src/test/scala/colossus/metrics/MetricNamespaceSpec.scala
@@ -3,6 +3,7 @@ package colossus.metrics
 import colossus.metrics.collectors.{Counter, Rate}
 import org.scalatest.{MustMatchers, WordSpec}
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 class MetricNamespaceSpec extends WordSpec with MustMatchers {
@@ -10,7 +11,6 @@ class MetricNamespaceSpec extends WordSpec with MustMatchers {
   "MetricNamespace" must {
     "allow for subspaces to create Metrics with the same name" in {
 
-      import scala.collection.JavaConversions._
       //not using implicits here, just to illustrate the point.
       val namespace = MetricContext("/", Collection.withReferenceConf(Seq(1.minute, 1.second)))
       val subName   = namespace / "bar"
@@ -35,7 +35,7 @@ class MetricNamespaceSpec extends WordSpec with MustMatchers {
       val barBar = MetricAddress("/bar/bar")
 
       val expected = Set(bar, baz, barBaz, barBar)
-      namespace.collection.collectors.keySet().toSet mustBe expected
+      namespace.collection.collectors.keySet().asScala.toSet mustBe expected
 
       //paranoid much?
       namespace.collection.collectors.get(bar).collector mustBe a[Rate]

--- a/colossus-tests/src/it/scala/colossus/BaseRedisITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/BaseRedisITSpec.scala
@@ -3,7 +3,7 @@ package colossus
 import java.net.InetSocketAddress
 
 import akka.util.ByteString
-import colossus.metrics.{MetricReporterConfig, MetricSystem}
+import colossus.metrics.MetricSystem
 import colossus.protocols.redis._
 import colossus.service.ClientConfig
 import colossus.testkit.ColossusSpec
@@ -11,34 +11,32 @@ import org.scalatest.concurrent.{ScalaFutures, ScaledTimeSpans}
 import org.scalatest.time.Span
 import org.scalatest.time._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
 abstract class BaseRedisITSpec extends ColossusSpec with ScalaFutures with ScaledTimeSpans {
+
   val metricSystem =  MetricSystem("test-system")
 
-  implicit val sys = IOSystem("test-system", Some(2), metricSystem)
-
-  implicit val ec = system.dispatcher
+  implicit val sys: IOSystem        = IOSystem("test-system", Some(2), metricSystem)
+  implicit val ec: ExecutionContext = system.dispatcher
+  implicit val pc: PatienceConfig   = PatienceConfig(Span(1, Minutes))
 
   protected var nextId : Integer = 1
 
-  implicit val defaultPatience = PatienceConfig(Span(1, Minutes))
-
   def keyPrefix : String
-
 
   val client = Redis.futureClient(ClientConfig(new InetSocketAddress("localhost", 6379), 1.second, "redis"))
 
-  val usedKeys = scala.collection.mutable.HashSet[ByteString]()
+  val usedKeys = scala.collection.mutable.HashSet.empty[ByteString]
 
   override def afterAll() {
     val f: Future[Long] = client.del(usedKeys.toSeq : _*)
-    val b  = f.futureValue
+    f.futureValue
     super.afterAll()
   }
 
-  //this defaults to the keyPrefix, and the only reason this takes a parameter is so
+  // this defaults to the keyPrefix, and the only reason this takes a parameter is so
   // that i can override it in each test(look at the 'keys' command test in RedisITSpec
   def getKey(prefix : String = keyPrefix) : ByteString = {
     nextId += 1

--- a/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/client/HttpResponseParserSpec.scala
@@ -4,14 +4,15 @@ import colossus.core.{DataBuffer, DynamicOutBuffer}
 import akka.util.ByteString
 import org.scalatest.{MustMatchers, WordSpec}
 import colossus.parsing.DataSize._
-import colossus.protocols.http.{HttpBody, HttpCodes, HttpHeader, HttpHeaders, HttpResponse, HttpResponseHead, HttpResponseParser, HttpVersion, StaticHttpClientCodec, StaticHttpServerCodec}
+import colossus.protocols.http.{HttpBody, HttpCodes, HttpHeaders, HttpResponse, HttpResponseHead, HttpResponseParser, HttpVersion, StaticHttpClientCodec}
 
 //NOTICE - all expected headers names must lowercase, otherwise these tests will fail equality testing
 
 class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
   import colossus.protocols.http.HttpHeader.Conversions._
-  val maxRequestSize = 10.MB
+
+  private val maxRequestSize = 10.MB
 
   "HttpResponseParser" must {
 
@@ -48,7 +49,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
       val body = "hello world"
       val res =
-        s"HTTP/1.1 200 OK\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nAuthorization: Basic XXX\r\nAccept-Encoding: gzip, deflate\r\n\r\n${body}"
+        s"HTTP/1.1 200 OK\r\nHost: api.foo.bar:444\r\nAccept: */*\r\nAuthorization: Basic XXX\r\nAccept-Encoding: gzip, deflate\r\n\r\n$body"
       val parser = HttpResponseParser.static()
 
       val expected = HttpResponse(
@@ -70,7 +71,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
     "parse a response with a body" in {
       val content = "{some : json}"
-      val size    = content.getBytes.size
+      val size    = content.getBytes.length
       val res = s"HTTP/1.1 200 OK" +
         s"\r\nHost: api.foo.bar:444" +
         s"\r\nAccept: */*" +
@@ -113,7 +114,6 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
       val expected = Some(sent.withHeader("content-length", "0"))
 
-      val serverProtocol = new StaticHttpServerCodec(HttpHeaders.Empty, maxRequestSize)
       val clientProtocol = new StaticHttpClientCodec
 
       val buf = new DynamicOutBuffer(100)
@@ -127,7 +127,7 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
     "decode a response that was encoded by colossus with a body" in {
       val content = "{some : json}"
-      val size    = content.getBytes.size
+      val size    = content.getBytes.length
 
       val sent = HttpResponse(
         HttpVersion.`1.1`,
@@ -141,7 +141,6 @@ class HttpResponseParserSpec extends WordSpec with MustMatchers {
 
       val expected = Some(sent.withHeader("content-length", size.toString))
 
-      val serverProtocol = new StaticHttpServerCodec(HttpHeaders.Empty, maxRequestSize)
       val clientProtocol = new StaticHttpClientCodec
 
       val buf = new DynamicOutBuffer(100)

--- a/colossus/src/main/scala/colossus/core/server/Server.scala
+++ b/colossus/src/main/scala/colossus/core/server/Server.scala
@@ -11,7 +11,7 @@ import colossus.metrics.MetricAddress
 import colossus.metrics.collectors.{Counter, Rate}
 import colossus.metrics.logging.ColossusLogging
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
 /** Configuration used to specify a Server's application-level behavior
@@ -280,7 +280,7 @@ private[colossus] class Server(io: IOSystem, serverConfig: ServerConfig, stateRe
 
   override def postStop() {
     //cleanup
-    selector.keys.foreach { _.channel.close }
+    selector.keys.asScala.foreach { _.channel.close }
     selector.close()
     ss.close()
     info("SERVER PEACE OUT")


### PR DESCRIPTION
Fixed scala 2.12 warnings, which were mainly about JavaConversions being deprecated. I then fixed some warnings from intellij. Fixes #576

@DanSimon @aliyakamercan @dxuhuang @nsauro 