### PR TITLE
Streaming docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,7 @@ lazy val GeneralSettings = Seq[Setting[_]](
   organization := "com.tumblr",
   scalaVersion := "2.12.2",
   crossScalaVersions := Seq("2.11.8", "2.12.2"),
+  apiURL := Some(url("https://www.javadoc.io/doc/")),
   parallelExecution in Test := false,
   scalacOptions := scalaVersion.map { v: String =>
     val default = List(
@@ -124,7 +125,10 @@ lazy val ColossusDocs = Project(id = "colossus-docs", base = file("colossus-docs
   .settings(ExamplesSettings: _*)
   .enablePlugins(ParadoxPlugin)
   .settings(
-    paradoxTheme := Some(builtinParadoxTheme("generic"))
+    paradoxTheme := Some(builtinParadoxTheme("generic")),
+    paradoxProperties in Compile ++= Map(
+      "scaladoc.base_url" -> s"https://static.javadoc.io/${organization.value}/colossus_2.11/${version.value}/index.html#"
+    )
   )
   .configs(IntegrationTest)
   .dependsOn(ColossusProject, ColossusTestkitProject)

--- a/build.sbt
+++ b/build.sbt
@@ -126,8 +126,9 @@ lazy val ColossusDocs = Project(id = "colossus-docs", base = file("colossus-docs
   .enablePlugins(ParadoxPlugin)
   .settings(
     paradoxTheme := Some(builtinParadoxTheme("generic")),
-    paradoxProperties in Compile ++= Map(
-      "scaladoc.base_url" -> s"https://static.javadoc.io/${organization.value}/colossus_2.11/${version.value}/index.html#"
+    paradoxProperties ++= Map(
+      "extref.docs.base_url" -> s"https://static.javadoc.io/${organization.value}/colossus_2.11/${version.value}/index.html#%s",
+      "snip.examples.base_dir" -> "../scala" 
     )
   )
   .configs(IntegrationTest)

--- a/colossus-docs/src/main/paradox/index.md
+++ b/colossus-docs/src/main/paradox/index.md
@@ -8,6 +8,7 @@
 * [Testing Servers](testkit.md)
 * [Metrics](metrics.md)
 * [Tasks](tasks.md)
+* [Streaming](streaming.md)
 * [About](about.md)
 
 @@@

--- a/colossus-docs/src/main/paradox/streaming.md
+++ b/colossus-docs/src/main/paradox/streaming.md
@@ -1,5 +1,11 @@
 # Streams and Streaming Protocols
 
+@@@ note
+
+**Experimental** : This API is under development and subject to breaking changes in future releases.
+
+@@@
+
 Normally when a server receives or a client sends a message, the entire message
 must be in memory and ready to encode/decode all at once.  This is not an issue
 for relatively small messages, but when messages start to get larger, anywhere
@@ -11,7 +17,7 @@ where the messages being sent/received are streamed out/in in chunks.
 
 # The Steaming API
 
-At the heart of streaming is a small set of composoble types for building
+At the heart of streaming is a small set of composable types for building
 reactive streams of objects.  The objects themselves can either be pieces of
 a larger object (such as chunks of an http message), or full messages
 themselves.  You can even have streams of streams.
@@ -85,6 +91,10 @@ supplies the signal with a callback function via the `notify` method.
 
 @@snip [PipeExamples.scala](../scala/PipeExamples.scala) { #full_push }
 
+See the docs for @extref[Sink](docs:colossus.streaming.Sink) for more
+information on how to push to sinks and also some built-in functions to work
+with them.
+
 ### Pulling from Sources
 
 Similar to sinks, calling `pull()` on a Source returns a `PullResult[T]`.  This may
@@ -99,18 +109,15 @@ method which allows you to supply a function that is called whenever an item is
 ready to pull.  It also gives you control over whether to continue using the
 callback function.
 
-See the documentation for @scaladoc[Source](colossus.streaming.Source) for more
+See the documentation for @extref[Source](docs:colossus.streaming.Source) for more
 ways to handle pulling items.
 
-### Composing and Transforming Pipes
+### Transforming and Composing Pipes
 
-A wide variety of methods are available to construct more complex streaming
-workflows.
+There are many methods available to build complex pipes by transforming and piecing together existing pipes.
 
-The simplest way to compose Pipes is with `Source.into` which feeds a
-`Source[T]` into a `Sink[T]`.
+@@snip [PipeExamples.scala](../scala/PipeExamples.scala) { #pipe_compose }
 
-### Pipe Multiplexing
 
 # Streaming HTTP
 
@@ -127,11 +134,5 @@ a high-level API that is more like a standard HTTP service.
 The high-level API is more-or-less a standard HTTP service, except that the
 body of the request/response is a stream of message chunks.
 
-## Streaming Http Messages
-
-The low-level API gives you direct access to the raw stream of HTTP message
-pieces.  Instead of receiving a stream for each message in a typical
-request/response workflow, there is just one incoming stream to read from and
-one outgoing stream to write to.
-
+@@snip [StreamingHttpExample.scala]($examples$/StreamingHttpExample.scala) { #streaming_http }
 

--- a/colossus-docs/src/main/paradox/streaming.md
+++ b/colossus-docs/src/main/paradox/streaming.md
@@ -1,0 +1,137 @@
+# Streams and Streaming Protocols
+
+Normally when a server receives or a client sends a message, the entire message
+must be in memory and ready to encode/decode all at once.  This is not an issue
+for relatively small messages, but when messages start to get larger, anywhere
+from a few MB to multiple GB, the requirement for having the entire message available all
+at once has both memory and performance implications.
+
+Colossus includes a powerful and efficient API for building _streaming protocols_
+where the messages being sent/received are streamed out/in in chunks.  
+
+# The Steaming API
+
+At the heart of streaming is a small set of composoble types for building
+reactive streams of objects.  The objects themselves can either be pieces of
+a larger object (such as chunks of an http message), or full messages
+themselves.  You can even have streams of streams.
+
+In fact, Colossus itself uses these components in its own infrastructure for
+buffering and routing messages for service connections.  Thus it should be no
+surprise that they are highly optimized for speed and efficient
+batch-processing.
+
+## Pipes, Sources, and Sinks
+
+A `Pipe[I,O]` is a one-way stream of messages.  Input messages of type `I` are
+_pushed_ into the pipe and output messages of type `O` are _pulled_ from it.
+In the simplest cases, `I` and `O` will be the same type and the pipe will act
+as a buffer, but in many situations a pipe can be backed by a complex
+transformation workflow such that the input and output types differ.
+
+@@snip [PipeExamples.scala](../scala/PipeExamples.scala) { #basic_pipe }
+
+Often we want to share a pipe between a producer and consumer, such that the
+producer can only push messages and the consumer only pull them.  The `Sink[I]`
+and `Source[O]` traits are used for this purpose, as `Pipe[I,O]` implements them
+both.
+
+Both pushing and pulling are non-blocking operations.  
+
+@@@ warning
+
+Pipes and other types in the streaming API are **not** thread-safe.  They are
+designed to efficiently handle streaming network I/O (which is always
+single-threaded in Colossus) and are not intended to be used for general
+stream-processing purposes.
+
+@@@
+
+### Pipe Transport States
+
+A Pipe/Source/Sink can be in one of three _transport states_:
+
+* Open : Able to push/pull messages
+* Closed : The Pipe has been shutdown without error and no further messages can be pushed/pulled.
+* Terminated : The pipe has been shutdown due to an error.
+
+The only possible state transitions are open to closed and open to terminated.
+
+In general, the closed state is for pipes that represent a stream of a single
+object like a http message.  Closing the pipe indicates the message has been
+fully sent/received.  Terminating a pipe indicate an irrecoverable error has
+occurred, such as closing a connection mid-stream.
+
+## Back/Forward-Pressure
+
+Aside from acting as buffers, the primary purpose of Pipes is to efficiently
+mediate the asynchronous interactions between producers and consumers of a
+stream.  Pipes handle two situations: _back-pressure_ is when
+consumers are not able to keep up and need to signal to producers to back-off,
+and _forward-pressure_ is when consumers are waiting for work from a producer.
+Both situations require signaling mechanisms; producers need to know when
+consumers are ready to take on more work and consumers need to know when more
+work is available.
+
+### Pushing to Sinks
+
+The primary method of `Sink[I]` is `push(input: I): PushResult`.  The returned
+`PushResult` indicates if the message was successfully pushed into the pipe or
+what should be done if it was not pushed.  When a Sink is _full_, it is
+currently unable to accept any more items and will return a
+`PushResult.Full(signal)`.  The contained `Signal` provides a way for the
+caller to be notified when the sink is able to accept items.  The caller simply
+supplies the signal with a callback function via the `notify` method.
+
+@@snip [PipeExamples.scala](../scala/PipeExamples.scala) { #full_push }
+
+### Pulling from Sources
+
+Similar to sinks, calling `pull()` on a Source returns a `PullResult[T]`.  This may
+be a `PullResult.item(item)` containing the item pulled, or it may be
+`PullResult.Empty(signal)`.  This signal can be given a callback which will get
+called when there is at least one item to pull from the Source.
+
+@@snip [PipeExamples.scala](../scala/PipeExamples.scala) { #empty_pull }
+
+Another highly efficient way to work with sources is through the `pullWhile`
+method which allows you to supply a function that is called whenever an item is
+ready to pull.  It also gives you control over whether to continue using the
+callback function.
+
+See the documentation for @scaladoc[Source](colossus.streaming.Source) for more
+ways to handle pulling items.
+
+### Composing and Transforming Pipes
+
+A wide variety of methods are available to construct more complex streaming
+workflows.
+
+The simplest way to compose Pipes is with `Source.into` which feeds a
+`Source[T]` into a `Sink[T]`.
+
+### Pipe Multiplexing
+
+# Streaming HTTP
+
+Currently the only streaming protocol built-into Colossus is Streaming HTTP.
+While it shares some types with the standard HTTP protocol, it is a separate
+protocol with its own message types.
+
+There are actually two different streaming HTTP API's: a low-level API that
+gives you direct control over streams of http messages and message chunks, and
+a high-level API that is more like a standard HTTP service.
+
+## Streaming Http Service
+
+The high-level API is more-or-less a standard HTTP service, except that the
+body of the request/response is a stream of message chunks.
+
+## Streaming Http Messages
+
+The low-level API gives you direct access to the raw stream of HTTP message
+pieces.  Instead of receiving a stream for each message in a typical
+request/response workflow, there is just one incoming stream to read from and
+one outgoing stream to write to.
+
+

--- a/colossus-docs/src/main/scala/PipeExamples.scala
+++ b/colossus-docs/src/main/scala/PipeExamples.scala
@@ -58,4 +58,19 @@ object PipeExamples extends App {
     
   }
 
+  def pipeTransform = {
+
+    // #pipe_compose
+    val pipe1: Pipe[Int, Int] = new BufferedPipe[Int](10)
+    val pipe2: Pipe[String, String] = new BufferedPipe[String](10)
+
+    val pipe3: Pipe[Int, String] = pipe1.map{i => (i * 2).toString}.weld(pipe2)
+
+    pipe3.push(2)
+    pipe3.pull() // PullResult.Item("4")
+    // #pipe_compose
+  }
+
+    
+
 }

--- a/colossus-docs/src/main/scala/PipeExamples.scala
+++ b/colossus-docs/src/main/scala/PipeExamples.scala
@@ -71,6 +71,4 @@ object PipeExamples extends App {
     // #pipe_compose
   }
 
-    
-
 }

--- a/colossus-docs/src/main/scala/PipeExamples.scala
+++ b/colossus-docs/src/main/scala/PipeExamples.scala
@@ -1,0 +1,61 @@
+import colossus.streaming._
+
+object PipeExamples extends App {
+
+  def basicPipe = {
+    // #basic_pipe
+    // The primary implementation of a Pipe is BufferedPipe, backed by a fixed-length buffer
+    val pipe = new BufferedPipe[Int](5)
+
+    //pushing to a Pipe returns a PushResult indicating if the push succeeded
+    val pushResult: PushResult = pipe.push(2) //PushResult.Ok
+
+    //pulling from a Pipe returns a PullResult
+    val pullResult: PullResult[Int] = pipe.pull() //PullResult.Item(2)
+    // #basic_pipe
+  }
+
+  def fullPush = {
+    // #full_push
+    //create a pipe with a buffer size of 1
+    val pipe = new BufferedPipe[Int](1)
+
+    pipe.push(10) //PushResult.ok
+
+    //the pipe can only buffer one item, so the next push fails and returns a
+    //PushResult.Full
+    val fullResult = pipe.push(12).asInstanceOf[PushResult.Full]
+
+    //provide a callback function for the returned signal
+    fullResult.onReady.notify{
+      println("ready to push")
+    }
+
+    //signal is triggered as soon as the item is pulled.  "ready to push" is
+    //printed before pull() returns
+    val item = pipe.pull()
+
+    // #full_push  
+  }
+
+  def emptyPull = {
+    // #empty_pull
+    val pipe = new BufferedPipe[Int](10)
+
+    //the pipe is empty so it returns a PullResult.Empty
+    val result = pipe.pull().asInstanceOf[PullResult.Empty]
+
+    //provide the returned signal with a callback function
+    result.whenReady.notify {
+      println("items available to pull")
+    }
+
+    //the signal is triggered as soon as an item is pushed into the pipe
+    pipe.push(1)
+
+    // #empty_pull
+
+    
+  }
+
+}

--- a/colossus-docs/src/main/scala/StreamingHttpExample.scala
+++ b/colossus-docs/src/main/scala/StreamingHttpExample.scala
@@ -1,0 +1,40 @@
+import colossus._
+
+import protocols.http._
+import protocols.http.streaming._
+import core.DataBlock
+import service._
+import colossus.streaming._
+
+object StreamServiceExample {
+
+  // #streaming_http
+
+  class MyRequestHandler extends GenRequestHandler[StreamingHttp](serverContext, config) {
+
+    def handle = {
+      case StreamingHttpRequest(head, source) if (head.url == "/chunked") => {
+        source.collected.map { sourceBody =>
+          val responseBody = Source.fromIterator(List("this is ", "a chunked ", "response").toIterator.map { s =>
+            Data(DataBlock(s))
+          })
+          StreamingHttpResponse(
+            HttpResponseHead(head.version, HttpCodes.OK, Some(TransferEncoding.Chunked), None, None, None, HttpHeaders.Empty),
+            responseBody
+          )
+        }
+      }
+    }
+
+    def unhandledError = {
+      case err => StreamingHttpResponse(HttpResponse.error(s"error: $err"))
+    }
+  }
+
+  def start(port: Int)(implicit sys: IOSystem) = {
+    StreamingHttpServer.basic("stream-service", port, serverContext => new MyRequestHandler)
+  }
+
+  // #streaming_http
+}
+

--- a/colossus-docs/src/main/scala/StreamingHttpExample.scala
+++ b/colossus-docs/src/main/scala/StreamingHttpExample.scala
@@ -2,7 +2,7 @@ import colossus._
 
 import protocols.http._
 import protocols.http.streaming._
-import core.DataBlock
+import core._
 import service._
 import colossus.streaming._
 
@@ -10,7 +10,7 @@ object StreamServiceExample {
 
   // #streaming_http
 
-  class MyRequestHandler extends GenRequestHandler[StreamingHttp](serverContext, config) {
+  class MyRequestHandler(serverContext: ServerContext) extends GenRequestHandler[StreamingHttp](serverContext) {
 
     def handle = {
       case StreamingHttpRequest(head, source) if (head.url == "/chunked") => {
@@ -32,7 +32,7 @@ object StreamServiceExample {
   }
 
   def start(port: Int)(implicit sys: IOSystem) = {
-    StreamingHttpServer.basic("stream-service", port, serverContext => new MyRequestHandler)
+    StreamingHttpServer.basic("stream-service", port, serverContext => new MyRequestHandler(serverContext))
   }
 
   // #streaming_http


### PR DESCRIPTION
Fixes #553 

First attempt at more thorough docs for the streaming API.  This focuses more on the fundamentals of pipes, sources, and sinks, since I think once you understand those using the StreamingHttp protocol is more straightforward.  I think there is still more to add but we can improve it incrementally.  I'd also be interested to get people's opinions on what else should be covered.

I tried adding some links to the public scaladocs hosted by `javadoc.io`.  Unfortunately it doesn't work with paradox's built-in `scaladoc` tag, but it seems to work nicely using an `extref` tag.

Writing up these docs uncovered some areas in the API that could be cleaned up and improved a bit, so I'll have another PR soon that'll address some of it. 