### PR TITLE
Service client

### DIFF
--- a/colossus-docs/src/main/scala/PlayingWithServiceClientCallbacks.scala
+++ b/colossus-docs/src/main/scala/PlayingWithServiceClientCallbacks.scala
@@ -1,0 +1,45 @@
+import akka.actor.ActorSystem
+import akka.util.ByteString
+import colossus.IOSystem
+import colossus.metrics.logging.ColossusLogging
+import colossus.protocols.http.HttpMethod._
+import colossus.protocols.http.UrlParsing._
+import colossus.protocols.http.{Http, HttpServer, Initializer, RequestHandler}
+import colossus.protocols.redis.Redis
+import colossus.service.GenRequestHandler.PartialHandler
+import colossus.service.HostManager
+
+import scala.util.{Failure, Success, Try}
+
+object PlayingWithServiceClientCallbacks extends App with ColossusLogging {
+
+  implicit val actorSystem = ActorSystem()
+  implicit val ioSystem    = IOSystem()
+  implicit val ec          = actorSystem.dispatcher
+
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
+
+      val hostManager = HostManager()
+      hostManager.addHost("localhost", 6379)
+      hostManager.addHost("localhost", 6379)
+      hostManager.addHost("localhost", 6379)
+      hostManager.addHost("localhost", 6379)
+
+      val redisClient = Redis.client(hostManager)
+
+      override def onConnect =
+        serverContext =>
+          new RequestHandler(serverContext) {
+            override def handle: PartialHandler[Http] = {
+
+              case req @ Get on Root / "bang" =>
+                redisClient.get(ByteString("bang")).mapTry {
+                  case Success(data) => Try(req.ok(data))
+                  case Failure(e)    => Try(req.ok(s"NOPE: $e"))
+                }
+            }
+        }
+    }
+  }
+}

--- a/colossus-docs/src/main/scala/PlayingWithServiceClientFutures.scala
+++ b/colossus-docs/src/main/scala/PlayingWithServiceClientFutures.scala
@@ -1,0 +1,53 @@
+import akka.actor.ActorSystem
+import akka.util.ByteString
+import colossus.IOSystem
+import colossus.metrics.logging.ColossusLogging
+import colossus.protocols.http.Http
+import colossus.protocols.http.HttpMethod._
+import colossus.protocols.http.UrlParsing._
+import colossus.protocols.http.{HttpServer, Initializer, RequestHandler}
+import colossus.protocols.redis.Redis
+import colossus.service.GenRequestHandler.PartialHandler
+import colossus.service.{Callback, HostManager}
+
+import scala.concurrent.Future
+
+object PlayingWithServiceClientFutures extends App with ColossusLogging {
+
+  implicit val actorSystem = ActorSystem()
+  implicit val ioSystem    = IOSystem()
+  implicit val ec          = actorSystem.dispatcher
+
+  HttpServer.start("example-server", 9000) { initContext =>
+    new Initializer(initContext) {
+
+      val hostManager = HostManager()
+      hostManager.addHost("localhost", 6379)
+      hostManager.addHost("localhost", 6379)
+      hostManager.addHost("localhost", 6379)
+      hostManager.addHost("localhost", 6379)
+
+      val redisClient = Redis.futureClient(hostManager)
+
+      override def onConnect =
+        serverContext =>
+          new RequestHandler(serverContext) {
+            override def handle: PartialHandler[Http] = {
+
+              case req @ Get on Root / "bang" =>
+                val f = redisClient
+                  .get(ByteString("bang"))
+                  .map { data =>
+                    req.ok(data)
+                  }
+                  .recoverWith {
+                    case e => Future(req.ok(s"NOPE: $e"))
+                  }
+
+                Callback.fromFuture(f)
+            }
+        }
+    }
+  }
+
+}

--- a/colossus/src/main/scala/colossus/service/Async.scala
+++ b/colossus/src/main/scala/colossus/service/Async.scala
@@ -1,9 +1,11 @@
 package colossus.service
 
-import scala.concurrent.Future
+import scala.concurrent.{Future, Promise}
 import scala.language.higherKinds
 import colossus.IOSystem
 import colossus.core.WorkerRef
+
+import scala.concurrent.duration.FiniteDuration
 
 /**
   * A Sender is anything that is able to asynchronously send a request and
@@ -36,6 +38,11 @@ trait Async[M[_]] {
 
   def failure[T](ex: Throwable): M[T]
 
+  def recoverWith[T, U >: T](t: M[T])(p: PartialFunction[Throwable, M[U]]): M[U]
+
+  def delay[T](delay: FiniteDuration)(block: => M[T]): M[T]
+
+  def execute[T](t: M[T]): Unit
 }
 
 /**
@@ -50,19 +57,19 @@ trait AsyncBuilder[M[_], E] {
 object AsyncBuilder {
 
   implicit object CallbackAsyncBuilder extends AsyncBuilder[Callback, WorkerRef] {
-    def build(w: WorkerRef) = CallbackAsync
+    def build(w: WorkerRef) = new CallbackAsync(w.callbackExecutor)
   }
 
   implicit object FutureAsyncBuilder extends AsyncBuilder[Future, IOSystem] {
-    def build(i: IOSystem) = new FutureAsync()(i)
+    def build(i: IOSystem) = new FutureAsync(i)
   }
 }
 
-object CallbackAsync extends Async[Callback] {
+class CallbackAsync(val callbackExecutor: CallbackExecutor) extends Async[Callback] {
 
-  type E = Unit //we don't actually need any environment for callbacks
+  type E = CallbackExecutor
 
-  implicit val environment: E = ()
+  implicit val environment: E = callbackExecutor
 
   def map[T, U](t: Callback[T])(f: (T) => U): Callback[U] = t.map(f)
 
@@ -71,9 +78,18 @@ object CallbackAsync extends Async[Callback] {
   def success[T](t: T): Callback[T] = Callback.successful(t)
 
   def failure[T](ex: Throwable): Callback[T] = Callback.failed(ex)
+
+  def recoverWith[T, U >: T](t: Callback[T])(p: PartialFunction[Throwable, Callback[U]]): Callback[U] = t.recoverWith(p)
+
+  def delay[T](delay: FiniteDuration)(block: => Callback[T]): Callback[T] =
+    Callback.schedule(delay)(block)
+
+  override def execute[T](t: Callback[T]): Unit = {
+    t.execute()
+  }
 }
 
-class FutureAsync(implicit val environment: IOSystem) extends Async[Future] {
+class FutureAsync(val environment: IOSystem) extends Async[Future] {
 
   type E = IOSystem
 
@@ -86,4 +102,24 @@ class FutureAsync(implicit val environment: IOSystem) extends Async[Future] {
   def success[T](t: T): Future[T] = Future.successful(t)
 
   def failure[T](ex: Throwable): Future[T] = Future.failed(ex)
+
+  def recoverWith[T, U >: T](t: Future[T])(p: PartialFunction[Throwable, Future[U]]): Future[U] = t.recoverWith(p)
+
+  def delay[T](delay: FiniteDuration)(block: => Future[T]): Future[T] = {
+    val promise = Promise[T]
+    environment.actorSystem.scheduler.scheduleOnce(delay) {
+      val whenItGoesWell = flatMap(block) { t =>
+        promise.success(t).future
+      }
+      recoverWith(whenItGoesWell) {
+        case throwable =>
+          promise.failure(throwable).future
+      }
+    }
+    promise.future
+  }
+
+  override def execute[T](t: Future[T]): Unit = {
+    Unit
+  }
 }

--- a/colossus/src/main/scala/colossus/service/HostManager.scala
+++ b/colossus/src/main/scala/colossus/service/HostManager.scala
@@ -1,0 +1,70 @@
+package colossus.service
+
+import scala.concurrent.duration._
+
+sealed trait LBBackoff
+
+case class LinearBackoff(
+    pause: FiniteDuration = 100.milliseconds
+) extends LBBackoff
+
+case class ExponentialBackoff(
+    initial: FiniteDuration = 1.milliseconds,
+    max: FiniteDuration = 1.second
+) extends LBBackoff
+
+sealed trait LBReplacement
+case object Random             extends LBReplacement
+case object WithoutReplacement extends LBReplacement
+
+sealed trait LBAttempts
+case class MaxAttempts(max: Int)                     extends LBAttempts
+case class EveryHost(upperLimit: Int = Int.MaxValue) extends LBAttempts
+
+case class LBRetryPolicy(
+    replacement: LBReplacement = WithoutReplacement,
+    backoff: LBBackoff = ExponentialBackoff(),
+    attempts: LBAttempts = EveryHost()
+)
+
+case class HostManager(retryPolicy: LBRetryPolicy = LBRetryPolicy()) {
+
+  private var hosts                = Seq.empty[(String, Int)]
+  private var loadBalancingClients = Seq.empty[LBC]
+
+  def addHost(host: String, port: Int): Unit = {
+    hosts = (host, port) +: hosts
+
+    loadBalancingClients.foreach(_.addClient(host, port))
+  }
+
+  def removeHost(host: String, port: Int, allInstances: Boolean = true): Unit = {
+    val pair = (host, port)
+    hosts = if (allInstances) {
+      hosts.filterNot(_ == pair)
+    } else {
+      dropFirstMatch(hosts, pair)
+    }
+
+    loadBalancingClients.foreach(_.removeClient(host, port, allInstances))
+  }
+
+  private def dropFirstMatch[A](ls: Seq[A], value: A): Seq[A] = {
+    val index = ls.indexOf(value) //index is -1 if there is no match
+    if (index < 0) {
+      ls
+    } else if (index == 0) {
+      ls.tail
+    } else {
+      // splitAt keeps the matching element in the second group
+      val (a, b) = ls.splitAt(index)
+      a ++ b.tail
+    }
+  }
+
+  private[service] def attachLoadBalancer(loadBalanceClient: LBC): Unit = {
+    loadBalancingClients = loadBalanceClient +: loadBalancingClients
+
+    hosts.foreach { case (host, port) => loadBalanceClient.addClient(host, port) }
+  }
+}

--- a/colossus/src/main/scala/colossus/service/LoadBalanceClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalanceClient.scala
@@ -1,0 +1,106 @@
+package colossus.service
+
+import colossus.metrics.logging.ColossusLogging
+
+import scala.concurrent.duration._
+import scala.language.higherKinds
+
+trait LBC {
+  def addClient(host: String, port: Int): Unit
+  def removeClient(host: String, port: Int, allInstances: Boolean): Unit
+}
+
+case class LoadBalanceClient[P <: Protocol, M[_], +T <: Sender[P, M], E](
+    hostManager: HostManager,
+    clientFactory: ClientFactory[P, M, T, E])(implicit env: E, async: Async[M])
+    extends Sender[P, M]
+    with LBC
+    with ColossusLogging {
+
+  case class ClientWrapper(client: Sender[P, M], host: String, port: Int)
+
+  private var clients = Seq.empty[ClientWrapper]
+
+  private val retryPolicy = hostManager.retryPolicy
+
+  private var permutations = new PermutationGenerator(clients.map { _.client })
+
+  // first register with the host manager, which acts as the interface between the user and this class
+  hostManager.attachLoadBalancer(this)
+
+  def addClient(host: String, port: Int): Unit = {
+    clients = ClientWrapper(clientFactory(host, port), host, port) +: clients
+    regeneratePermutations()
+  }
+
+  // TODO will this fuck up requests in progress?
+  def removeClient(host: String, port: Int, allInstances: Boolean): Unit = {
+    if (allInstances) {
+      val (removedClients, keepClients) =
+        clients.partition(clientWrapper => clientWrapper.host == host && clientWrapper.port == port)
+      // disconnect the old clients
+      removedClients.foreach(_.client.disconnect())
+
+      clients = keepClients
+    } else {
+      ???
+    }
+    regeneratePermutations()
+  }
+
+  private def regeneratePermutations() {
+    permutations = new PermutationGenerator(clients.map { _.client })
+  }
+
+  def send(request: P#Request): M[P#Response] = {
+
+    retryPolicy match {
+      case LBRetryPolicy(Random, backoff, attempts) => ???
+
+      case LBRetryPolicy(WithoutReplacement, backoff, attempts) =>
+        val maxTries = attempts match {
+          case MaxAttempts(max)      => max
+          case EveryHost(upperLimit) => clients.size.min(upperLimit)
+        }
+
+        val retryList = permutations.next().take(maxTries)
+
+        def go(next: Sender[P, M], list: List[Sender[P, M]], attempt: Int): M[P#Response] = {
+          async.recoverWith(next.send(request)) {
+            case throwable =>
+              list match {
+                case head :: tail =>
+                  async.delay(backoffDuration(backoff, attempt))(go(head, tail, attempt + 1))
+                case Nil =>
+                  async.failure(new SendFailedException(retryList.size, throwable))
+              }
+          }
+        }
+
+        if (retryList.isEmpty) {
+          async.failure(new SendFailedException(retryList.size, new Exception("Empty client list!")))
+        } else {
+          val f = async.failure(new SendFailedException(retryList.size, new Exception("HAHA")))
+          go(retryList.head, retryList.tail, 1)
+        }
+    }
+  }
+
+  private def backoffDuration(backoff: LBBackoff, attempt: Int): FiniteDuration = {
+    backoff match {
+      case LinearBackoff(pause) => pause
+      case ExponentialBackoff(initial, max) =>
+        val calculatedBackoff = initial * attempt
+        if (calculatedBackoff > max) {
+          max
+        } else {
+          calculatedBackoff
+        }
+    }
+  }
+
+  def disconnect(): Unit = {
+    clients.foreach(_.client.disconnect())
+  }
+
+}

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -243,6 +243,10 @@ class CodecClientFactory[P <: Protocol, M[_], T[M[_]] <: Sender[P, M], E](
   def apply(sender: Sender[P, M])(implicit env: E): T[M] = {
     lifter.lift(sender, None)(builder.build(env))
   }
+
+  def apply(hostManager: HostManager)(implicit env: E): T[M] = {
+    apply(new LoadBalanceClient(hostManager, this)(env, builder.build(env)))
+  }
 }
 
 /**


### PR DESCRIPTION
Behold, the new service client MVP. It looks like this:

```
val hostManager = HostManager()
hostManager.addHost("localhost", 6379)
hostManager.addHost("localhost", 6379)
hostManager.addHost("localhost", 6379)

val redisClient = Redis.futureClient(hostManager)
```

The default behavior is to try every host with exponential backoff. However, you could configure something different, for example:

```
val hostManager = HostManager(
  LBRetryPolicy(
    replacement = Random,
    backoff = LinearBackoff(1.second),
    attempts = MaxAttempts(3)
  )
)
```

The possibilities are endless.

It's missing some implementation details and tests, but my main concern is around removing a client from the host manager. When a client is removed, it is disconnected, meaning that any requests that are currently using it will be affected. Maybe this is fine (making the assumption retries is turned on), maybe we should disconnect after a few seconds, or maybe the disconnect should only happen when we know for certain that no request is using it (not sure how feasible that is).

Thoughts?

@DanSimon @amotamed @aliyakamercan @nsauro @dxuhuang @jlbelmonte 


