### PR TITLE
Move akka teskkit so it's only a compile time dependency for colossus testkit

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,10 @@ import com.lightbend.paradox.sbt.ParadoxPlugin
 import com.lightbend.paradox.sbt.ParadoxPlugin.autoImport._
 import ProjectImplicits._
 
-val AKKA_VERSION      = "2.5.4"
-val SCALATEST_VERSION = "3.0.1"
-val MIMA_PREVIOUS_VERSIONS = Seq("0.9.1")
+val AkkaVersion      = "2.5.6"
+val ScalatestVersion = "3.0.1"
+
+val MIMAPreviousVersions = Seq("0.9.1")
 
 lazy val testAll = TaskKey[Unit]("test-all")
 
@@ -36,13 +37,13 @@ lazy val GeneralSettings = Seq[Setting[_]](
   javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint"),
   scalacOptions in (Compile, console) := Seq(),
   libraryDependencies ++= Seq(
-    "com.typesafe.akka"      %% "akka-actor"                  % AKKA_VERSION,
-    "com.typesafe.akka"      %% "akka-testkit"                % AKKA_VERSION,
-    "org.scalatest"          %% "scalatest"                   % SCALATEST_VERSION % "test, it",
+    "com.typesafe.akka"      %% "akka-actor"                  % AkkaVersion,
+    "com.typesafe.akka"      %% "akka-testkit"                % AkkaVersion % "test",
+    "org.scalatest"          %% "scalatest"                   % ScalatestVersion % "test, it",
     "org.scalamock"          %% "scalamock-scalatest-support" % "3.6.0" % "test",
-    "org.mockito"            % "mockito-all"                  % "1.9.5" % "test",
+    "org.mockito"            %  "mockito-all"                 % "1.9.5" % "test",
     "com.github.nscala-time" %% "nscala-time"                 % "2.16.0",
-    "org.slf4j"              % "slf4j-api"                    % "1.7.6"
+    "org.slf4j"              %  "slf4j-api"                   % "1.7.6"
   ),
   coverageExcludedPackages := "colossus\\.examples\\..*;.*\\.testkit\\.*",
   credentials += Credentials("Sonatype Nexus Repository Manager",
@@ -82,15 +83,14 @@ lazy val noPubSettings = GeneralSettings ++ Seq(
 )
 
 lazy val testkitDependencies = libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % SCALATEST_VERSION
+  "org.scalatest"     %% "scalatest"    % ScalatestVersion,
+  "com.typesafe.akka" %% "akka-testkit" % AkkaVersion
 )
-
-lazy val MetricSettings = ColossusSettings
 
 lazy val ExamplesSettings = Seq(
   libraryDependencies ++= Seq(
-    "org.json4s"     %% "json4s-jackson" % "3.5.3",
-    "ch.qos.logback" % "logback-classic" % "1.2.2"
+    "org.json4s"     %% "json4s-jackson"  % "3.5.3",
+    "ch.qos.logback" %  "logback-classic" % "1.2.2"
   )
 )
 
@@ -102,7 +102,7 @@ lazy val RootProject = Project(id = "root", base = file("."))
 
 lazy val ColossusProject: Project = Project(id = "colossus", base = file("colossus"))
   .settings(ColossusSettings: _*)
-  .withMima(MIMA_PREVIOUS_VERSIONS : _*)
+  .withMima(MIMAPreviousVersions : _*)
   .configs(IntegrationTest)
   .aggregate(ColossusTestsProject)
   .dependsOn(ColossusMetricsProject)
@@ -114,14 +114,14 @@ lazy val ColossusExamplesProject = Project(id = "colossus-examples", base = file
   .dependsOn(ColossusProject)
 
 lazy val ColossusMetricsProject = Project(id = "colossus-metrics", base = file("colossus-metrics"))
-  .settings(MetricSettings: _*)
-  .withMima(MIMA_PREVIOUS_VERSIONS : _*)
+  .settings(ColossusSettings: _*)
+  .withMima(MIMAPreviousVersions : _*)
   .configs(IntegrationTest)
 
 lazy val ColossusTestkitProject = Project(id = "colossus-testkit", base = file("colossus-testkit"))
   .settings(ColossusSettings: _*)
   .settings(testkitDependencies)
-  .withMima(MIMA_PREVIOUS_VERSIONS : _*)
+  .withMima(MIMAPreviousVersions : _*)
   .configs(IntegrationTest)
   .dependsOn(ColossusProject)
 

--- a/colossus-docs/src/test/scala/TestkitExampleSpec.scala
+++ b/colossus-docs/src/test/scala/TestkitExampleSpec.scala
@@ -18,7 +18,7 @@ class TestkitExampleSpec extends HttpServiceSpec {
   implicit val formats = org.json4s.DefaultFormats
 
   override def service: ServerRef = {
-    HttpServer.start("example-server", 9000) { initContext =>
+    HttpServer.start("example-server", 9123) { initContext =>
       new Initializer(initContext) {
         override def onConnect = serverContext => new MyHandler(serverContext)
       }
@@ -34,11 +34,15 @@ class TestkitExampleSpec extends HttpServiceSpec {
     }
 
     "return 200 and body that satisfies predicate" in {
-      expectCodeAndBodyPredicate(HttpRequest.get("ping/1"), HttpCodes.OK, body => {
-        val jsonMap = JsonMethods.parse(body).extract[Map[String, JValue]]
-        val expected = Map("data" -> JInt(1), "type" -> JString("pong"))
-        jsonMap == expected
-      })
+      expectCodeAndBodyPredicate(
+        HttpRequest.get("ping/1"),
+        HttpCodes.OK,
+        body => {
+          val jsonMap  = JsonMethods.parse(body).extract[Map[String, JValue]]
+          val expected = Map("data" -> JInt(1), "type" -> JString("pong"))
+          jsonMap == expected
+        }
+      )
     }
 
   }

--- a/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ConnectionHandlerSpec.scala
@@ -141,9 +141,9 @@ class ConnectionHandlerSpec extends ColossusSpec {
       withIOSystem { implicit io =>
         withServer(RawServer.basic("test", TEST_PORT) { case x => x }) {
           io ! IOCommand.BindAndConnectWorkerItem(new InetSocketAddress("localhost", TEST_PORT), c => new MyHandler(c))
-          probe.expectNoMsg(200.milliseconds)
+          probe.expectNoMessage(200.milliseconds)
         }
-        probe.expectNoMsg(200.milliseconds)
+        probe.expectNoMessage(200.milliseconds)
       }
     }
 
@@ -156,7 +156,7 @@ class ConnectionHandlerSpec extends ColossusSpec {
       }
       withIOSystem { implicit io =>
         io ! IOCommand.BindAndConnectWorkerItem(new InetSocketAddress("localhost", TEST_PORT), c => new MyHandler(c))
-        probe.expectNoMsg(200.milliseconds)
+        probe.expectNoMessage(200.milliseconds)
       }
 
     }

--- a/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/CoreHandlerSpec.scala
@@ -72,7 +72,7 @@ class CoreHandlerSpec extends ColossusSpec {
     "kill does nothing if the connection isn't connected" in {
       val con = MockConnection.server(serverContext => new TestHandler(serverContext, true))
       con.typedHandler.kill(new Exception("foo"))
-      con.workerProbe.expectNoMsg(100.milliseconds)
+      con.workerProbe.expectNoMessage(100.milliseconds)
     }
 
     "become" in {

--- a/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerSpec.scala
@@ -115,7 +115,8 @@ class ServerSpec extends ColossusSpec {
     }
 
     "shutdown when a initializer fails to instantiate" in {
-      val badDelegator: Initializer.Factory = (_: InitContext) => throw new Exception("failed during initializer creation")
+      val badDelegator: Initializer.Factory =
+        (_: InitContext) => throw new Exception("failed during initializer creation")
 
       withIOSystem { implicit io =>
         val cfg = ServerConfig(
@@ -199,12 +200,13 @@ class ServerSpec extends ColossusSpec {
       withIOSystem { implicit io =>
         val serverProbe = TestProbe()
         val failedServer =
-          Server.start("fail",
-                       ServerSettings(TEST_PORT, delegatorCreationPolicy = WaitPolicy(200 milliseconds, NoRetry)))(
-            initContext => new Initializer(initContext) {
+          Server.start(
+            "fail",
+            ServerSettings(TEST_PORT, delegatorCreationPolicy = WaitPolicy(200 milliseconds, NoRetry)))(initContext =>
+            new Initializer(initContext) {
               Thread.sleep(600)
               def onConnect = serverContext => new EchoHandler(serverContext)
-            })
+          })
         serverProbe.watch(failedServer.server)
         serverProbe.expectTerminated(failedServer.server)
       }
@@ -289,7 +291,7 @@ class ServerSpec extends ColossusSpec {
       val workerRouterProbe = TestProbe()
       server.initializerBroadcast("TEST")
       mprobe.expectMsgType[WorkerManager.RegisterServer](50.milliseconds)
-      mprobe.expectNoMsg(100.milliseconds)
+      mprobe.expectNoMessage(100.milliseconds)
       server.server ! WorkerManager.WorkersReady(workerRouterProbe.ref)
       workerRouterProbe.expectMsgType[akka.routing.Broadcast](50.milliseconds)
       server.shutdown()
@@ -303,8 +305,7 @@ class ServerSpec extends ColossusSpec {
         def acceptNewConnection                                            = None // >:(
         override def onConnect: (ServerContext) => ServerConnectionHandler = ???
       }
-      withIOSystemAndServer((ic) => new SleepyInitializer(ic.server, ic.worker), waitTime = 10.seconds)(
-        (io, sys) => ())
+      withIOSystemAndServer((ic) => new SleepyInitializer(ic.server, ic.worker), waitTime = 10.seconds)((io, sys) => ())
     }
 
     "switch to high water timeout when connection count passes the high water mark" in {

--- a/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerItemSpec.scala
@@ -38,7 +38,7 @@ class WorkerItemSpec extends ColossusSpec {
         }
         io ! IOCommand.BindWorkerItem(context => new MyItem(context))
         probe.expectMsg(100.milliseconds, "BOUND")
-        probe.expectNoMsg(100.milliseconds)
+        probe.expectNoMessage(100.milliseconds)
       }
 
     }
@@ -76,7 +76,7 @@ class WorkerItemSpec extends ColossusSpec {
           }
         }
         io ! IOCommand.BindWorkerItem(context => new MyItem(context))
-        probe.expectNoMsg(100.milliseconds)
+        probe.expectNoMessage(100.milliseconds)
       }
     }
 

--- a/colossus-tests/src/test/scala/colossus/core/WorkerManagerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/WorkerManagerSpec.scala
@@ -57,7 +57,7 @@ class WorkerManagerSpec extends ColossusSpec with Eventually {
         probes.foreach { _.expectMsg(window, Worker.CheckIdleConnections) }
 
         //no more messages should be sent, until acks are received
-        probes.foreach { _.expectNoMsg(window * 2) }
+        probes.foreach { _.expectNoMessage(window * 2) }
 
         //lets now send the acks back
         probes.foreach { x =>

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -197,16 +197,18 @@ class WebsocketSpec extends ColossusSpec with MockFactory with ControllerMocks {
     import subprotocols.rawstring._
     val myinit = new WebsocketInitializer[RawString](FakeIOSystem.fakeWorker.worker) {
       def provideCodec = new RawStringCodec
-      def onConnect = serverContext => new WebsocketServerHandler[RawString](serverContext) {
-        def handle = {
-          case "A" => {
-            send("B")
-          }
+      def onConnect =
+        serverContext =>
+          new WebsocketServerHandler[RawString](serverContext) {
+            def handle = {
+              case "A" => {
+                send("B")
+              }
+            }
+            def handleError(reason: Throwable): Unit = {
+              send("E")
+            }
         }
-        def handleError(reason: Throwable): Unit = {
-          send("E")
-        }
-      }
     }
 
     def createHandler = {
@@ -233,7 +235,7 @@ class WebsocketSpec extends ColossusSpec with MockFactory with ControllerMocks {
       con.iterate()
       con.withExpectedWrite(_.utf8String.contains("400") mustBe true)
       con.iterate()
-      con.workerProbe.expectNoMsg(100.milliseconds)
+      con.workerProbe.expectNoMessage(100.milliseconds)
 
     }
   }

--- a/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/CallbackSpec.scala
@@ -142,7 +142,7 @@ class CallbackSpec extends ColossusSpec {
           res = x.toUpperCase
         }
         .execute()
-      t.expectNoMsg(100.milliseconds)
+      t.expectNoMessage(100.milliseconds)
       p.complete(Success("hello"))
       val ex = t.receiveOne(50.milliseconds) match {
         case e: CallbackExec => e
@@ -556,8 +556,8 @@ class CallbackSpec extends ColossusSpec {
       class FoobarException extends Exception("FOOBAR")
 
       intercept[CallbackExecutionException] {
-        Callback(func).execute {
-          _ => throw new FoobarException
+        Callback(func).execute { _ =>
+          throw new FoobarException
         }
       }
 
@@ -566,14 +566,14 @@ class CallbackSpec extends ColossusSpec {
           .flatMap { x =>
             Callback(func)
           }
-          .execute {
-            _ => throw new FoobarException
+          .execute { _ =>
+            throw new FoobarException
           }
       }
 
       intercept[CallbackExecutionException] {
-        Callback.successful(true).execute {
-          _ => throw new FoobarException
+        Callback.successful(true).execute { _ =>
+          throw new FoobarException
         }
       }
 

--- a/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceServerSpec.scala
@@ -87,7 +87,7 @@ class ServiceServerSpec extends ColossusSpec with MockFactory with ControllerMoc
       t.typedHandler.receivedData(DataBuffer(r1))
       t.typedHandler.disconnect()
       t.status must equal(ConnectionStatus.Connected)
-      t.workerProbe.expectNoMsg(100.milliseconds)
+      t.workerProbe.expectNoMessage(100.milliseconds)
       promises(0).success(ByteString("B"))
       t.iterate()
       t.iterate() //second one is needed for disconnect behavior


### PR DESCRIPTION
It is now only a compile time dependency for colossus-testkit. Whilst there I also bump akka version (which caused the `expectNoMsg` to `expectNoMsg` change) and changed the port number used by `TestkitExampleSpec` since it always conflicts with other stuff I'm running.

Fixes #611 

@dxuhuang @aliyakamercan @jlbelmonte @amotamed @DanSimon @nsauro 