### PR TITLE
Turn traits into objects for easy implicit access

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpParseSpec.scala
@@ -12,7 +12,6 @@ class HttpParserSuite extends WordSpec with MustMatchers {
   def requestParser = HttpRequestParser(maxRequestSize = 10.MB)
 
   import HttpHeader.Conversions._
-  import HttpBody._
 
   "http request parser" must {
     "parse a basic request" in {
@@ -392,8 +391,8 @@ class HttpParserSuite extends WordSpec with MustMatchers {
     }
 
     "parse requests with request parameters" in {
-      val req = HttpRequest(HttpRequestHead(HttpMethod.Get, "a/path/with/1?a=bla&b=2", HttpVersion.`1.1`, Nil),
-                            HttpBody.NoBody)
+      val req =
+        HttpRequest(HttpRequestHead(HttpMethod.Get, "a/path/with/1?a=bla&b=2", HttpVersion.`1.1`, Nil), HttpBody.NoBody)
       req match {
         case r @ Get on Root / "a" / "path" / "with" / Integer(1) =>
         case _                                                    => throw new Exception(s"$req failed to parse correctly")

--- a/colossus/src/main/scala/colossus/protocols/http/HttpBody.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpBody.scala
@@ -39,7 +39,7 @@ trait HttpBodyDecoder[T] {
 
 }
 
-trait HttpBodyDecoders {
+object HttpBodyDecoder {
 
   implicit object StringDecoder extends HttpBodyDecoder[String] {
     def decode(body: Array[Byte]) = Try {
@@ -67,24 +67,27 @@ trait HttpBodyEncoder[T] {
 
 }
 
-trait HttpBodyEncoders {
+object HttpBodyEncoder {
   implicit object ByteStringEncoder extends HttpBodyEncoder[ByteString] {
     val contentType = None
+
     def encode(data: ByteString): HttpBody = new HttpBody(data.toArray)
   }
 
   implicit object StringEncoder extends HttpBodyEncoder[String] {
     val contentType = Some(ContentType.TextPlain)
+
     def encode(data: String): HttpBody = new HttpBody(data.getBytes("UTF-8"))
   }
 
   implicit object IdentityEncoder extends HttpBodyEncoder[HttpBody] {
     val contentType = None
+
     def encode(b: HttpBody) = b
   }
 }
 
-object HttpBody extends HttpBodyEncoders {
+object HttpBody {
 
   val NoBody = new HttpBody(Array.emptyByteArray)
 

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -3,9 +3,18 @@ package colossus.protocols
 import colossus.core.DataOutBuffer
 import colossus.metrics.TagMap
 import colossus.protocols.http.HttpClient.HttpClientLifter
-import colossus.service.{ClientFactories, IrrecoverableError, ProcessingFailure, Protocol, RecoverableError, ServiceClientFactory, TagDecorator, UnhandledRequestException}
+import colossus.service.{
+  ClientFactories,
+  IrrecoverableError,
+  ProcessingFailure,
+  Protocol,
+  RecoverableError,
+  ServiceClientFactory,
+  TagDecorator,
+  UnhandledRequestException
+}
 
-package object http extends HttpBodyEncoders with HttpBodyDecoders {
+package object http {
 
   class InvalidRequestException(message: String) extends Exception(message)
 


### PR DESCRIPTION
I was messing around with cleaning up some imports I ran into a problem with an implicit being found in two places.

```
[error] /Users/benblack/Documents/pollscala/src/main/scala/com/tumblr/pollscala/PollscalaHandler.scala:125:14: ambiguous implicit values:
[error]  both object IdentityEncoder in trait HttpBodyEncoders of type colossus.protocols.http.HttpBody.IdentityEncoder.type
[error]  and object IdentityEncoder in trait HttpBodyEncoders of type colossus.protocols.http.package.IdentityEncoder.type
[error]  match expected type colossus.protocols.http.HttpBodyEncoder[colossus.protocols.http.HttpBody]
[error]           .ok(
[error]              ^
[error] one error found
[error] (compile:compileIncremental) Compilation failed
[error] Total time: 5 s, completed Oct 26, 2017 1:49:44 PM
```

I've turned `HttpBodyEncoders` and `HttpBodyDecoders` into companion objects for their implicits so they should be automatically found, rather then having to import from the http package.

@aliyakamercan @jlbelmonte @amotamed @dxuhuang @DanSimon 