### PR TITLE
Fix publish script for snapshots

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,27 @@ In order to accept your pull request, we need you to submit a Contributor Licens
     
 6. Merge master into develop and update version in `version.sbt` to point to the next snapshot.
 
+# Publishing Snapshots
+
+1. Update version ending with `-SNAPSHOT` in `version.sbt` 
+    ```bash
+    git add version.sbt
+    git commit -m "v{VERSION NUMBER}"
+    ```
+2. Create tag using just the version with `-SNAPSHOT`.
+    ```bash
+    git tag -a v{VERSION NUMBER}
+    ```
+3. Push changes to remote; travis will build and automatically publish to [sonatype](https://oss.sonatype.org/).
+    ```bash
+    git push origin 
+    ``` 
+4. Remove tag
+    ```bash
+    git tag --delete tagname
+    git push --delete origin tagname
+    ```
+
 ## License
 
 By contributing to Colossus you agree that your contributions will be licensed under its Apache 2.0 license.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ In order to accept your pull request, we need you to submit a Contributor Licens
 # Publish
 
 1. Merge develop (or hot fix branch) into master.
-2. Update version in `version.sbt` and add to `docs.yml`
+2. Update version in `version.sbt` and add to `docs.yml` (append `RC{X}` for release candidates)
 
     ```bash
     git add version.sbt
@@ -106,14 +106,14 @@ In order to accept your pull request, we need you to submit a Contributor Licens
     
 6. Merge master into develop and update version in `version.sbt` to point to the next snapshot.
 
-# Publishing Snapshots
+# Publishing Milestones
 
-1. Update version ending with `-SNAPSHOT` in `version.sbt` 
+1. On develop update version (must end with `-M{milestone number}`) in `version.sbt` 
     ```bash
     git add version.sbt
     git commit -m "v{VERSION NUMBER}"
     ```
-2. Create tag using just the version with `-SNAPSHOT`.
+2. Create tag using just the version (with `-M{X}`).
     ```bash
     git tag -a v{VERSION NUMBER}
     ```
@@ -121,11 +121,6 @@ In order to accept your pull request, we need you to submit a Contributor Licens
     ```bash
     git push origin 
     ``` 
-4. Remove tag
-    ```bash
-    git tag --delete tagname
-    git push --delete origin tagname
-    ```
 
 ## License
 

--- a/publish.sh
+++ b/publish.sh
@@ -5,7 +5,7 @@ if [[ $CI != 'true' ]]; then
     exit 0
 fi
  
-if [[ $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+|-M[0-9]+)?$ || ($TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ && $(cat version.sbt) =~ "-SNAPSHOT") ]]; then
+if [[ $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+|-M[0-9]+)?$ ]]; then
     # decrypt secrets & untar 
     openssl aes-256-cbc -K $encrypted_9df8dc1a95a3_key -iv $encrypted_9df8dc1a95a3_iv -in secrets.tar.enc -out secrets.tar -d
     tar xvf secrets.tar

--- a/publish.sh
+++ b/publish.sh
@@ -5,13 +5,13 @@ if [[ $CI != 'true' ]]; then
     exit 0
 fi
  
-if [[ $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+|-M[0-9]+)?$ || ($TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "develop" && $(cat version.sbt) =~ "-SNAPSHOT") ]]; then
+if [[ $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-RC[0-9]+|-M[0-9]+)?$ || ($TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH =~ ^v[0-9]+\.[0-9]+\.[0-9]+-SNAPSHOT$ && $(cat version.sbt) =~ "-SNAPSHOT") ]]; then
     # decrypt secrets & untar 
     openssl aes-256-cbc -K $encrypted_9df8dc1a95a3_key -iv $encrypted_9df8dc1a95a3_iv -in secrets.tar.enc -out secrets.tar -d
     tar xvf secrets.tar
     # publish, close & release
     sbt ++$TRAVIS_SCALA_VERSION publishSigned sonatypeReleaseAll
 else 
-    echo 'Only publishing on version tags or develop snapshots'
+    echo 'Only publishing on version tags'
     exit 0
 fi


### PR DESCRIPTION
@amotamed @jlbelmonte @benblack86 @DanSimon @dxuhuang 

Checking `-SNAPSHOT` git tag. 

I am not sure about this. Maybe we should release snapshots with each merge to develop (<version>_<commit sha>-SNAPSHOT) ?

Any preferences?