### PR TITLE
ServerSettings and ServiceConfig combined

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,3 +147,4 @@ lazy val ColossusTestsProject = Project(
   base = file("colossus-tests"),
   dependencies = Seq(ColossusTestkitProject % "compile;test->test")
 ).settings(noPubSettings: _*).configs(IntegrationTest)
+  .settings(libraryDependencies ++= Seq("ch.qos.logback" % "logback-classic" % "1.2.2"))

--- a/colossus-examples/src/main/scala/colossus.examples/StreamServiceExample.scala
+++ b/colossus-examples/src/main/scala/colossus.examples/StreamServiceExample.scala
@@ -1,10 +1,9 @@
 package colossus.examples
 
 import colossus._
-
 import protocols.http._
 import protocols.http.streaming._
-import core.DataBlock
+import core.{DataBlock, ServerSettings}
 import service._
 import colossus.streaming._
 
@@ -15,42 +14,39 @@ object StreamServiceExample {
     val headers  = HttpHeaders(HttpHeader("Content-Length", bodydata.data.length.toString))
     val body     = HttpBody("Hello World!")
 
-    val config = ServiceConfig.Default.copy(
-      requestMetrics = false
-    )
-
     StreamingHttpServer.basic(
       "stream-service",
       port,
-      serverContext => new GenRequestHandler[StreamingHttp](serverContext, config) {
+      serverContext =>
+        new GenRequestHandler[StreamingHttp](serverContext) {
 
-        def handle = {
-          case StreamingHttpRequest(head, source) if (head.url == "/plaintext") =>
-            source.collected.map { _ =>
-              StreamingHttpResponse(
-                HttpResponse(HttpResponseHead(head.version, HttpCodes.OK, None, None, None, None, headers), body))
-            }
+          def handle = {
+            case StreamingHttpRequest(head, source) if (head.url == "/plaintext") =>
+              source.collected.map { _ =>
+                StreamingHttpResponse(
+                  HttpResponse(HttpResponseHead(head.version, HttpCodes.OK, None, None, None, None, headers), body))
+              }
 
-          case StreamingHttpRequest(head, source) if (head.url == "/chunked") =>
-            source.collected.map { _ =>
-              StreamingHttpResponse(
-                HttpResponseHead(head.version,
-                                 HttpCodes.OK,
-                                 Some(TransferEncoding.Chunked),
-                                 None,
-                                 None,
-                                 None,
-                                 HttpHeaders.Empty),
-                Source.fromIterator(List("hello", "world", "blah").toIterator.map { s =>
-                  Data(DataBlock(s))
-                })
-              )
-            }
-        }
+            case StreamingHttpRequest(head, source) if (head.url == "/chunked") =>
+              source.collected.map { _ =>
+                StreamingHttpResponse(
+                  HttpResponseHead(head.version,
+                                   HttpCodes.OK,
+                                   Some(TransferEncoding.Chunked),
+                                   None,
+                                   None,
+                                   None,
+                                   HttpHeaders.Empty),
+                  Source.fromIterator(List("hello", "world", "blah").toIterator.map { s =>
+                    Data(DataBlock(s))
+                  })
+                )
+              }
+          }
 
-        def unhandledError = {
-          case err => StreamingHttpResponse(HttpResponse.error(s"error: $err"))
-        }
+          def unhandledError = {
+            case err => StreamingHttpResponse(HttpResponse.error(s"error: $err"))
+          }
       }
     )
 

--- a/colossus-testkit/src/main/scala/colossus.testkit/ColossusSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus.testkit/ColossusSpec.scala
@@ -104,10 +104,7 @@ abstract class ColossusSpec(_system: ActorSystem)
     withIOSystem { implicit io =>
       val config = ServerConfig(
         name = "async-test",
-        settings = customSettings.getOrElse(
-          ServerSettings(
-            port = TEST_PORT
-          )),
+        settings = customSettings.getOrElse(ServerSettings.default.copy(port = TEST_PORT)),
         initializerFactory = factory
       )
       val server = Server(config)

--- a/colossus-testkit/src/main/scala/colossus.testkit/FakeIOSystem.scala
+++ b/colossus-testkit/src/main/scala/colossus.testkit/FakeIOSystem.scala
@@ -39,13 +39,13 @@ object FakeIOSystem {
 
   def fakeContext(implicit system: ActorSystem) = fakeWorker.worker.generateContext()
 
-  def fakeServerContext(implicit system: ActorSystem) = {
-    val (_serverProbe, server) = FakeIOSystem.fakeServerRef
+  def fakeServerContext(config: Option[ServerSettings] = None)(implicit system: ActorSystem) = {
+    val (_serverProbe, server) = FakeIOSystem.fakeServerRef(config)
     ServerContext(server, fakeContext)
   }
 
-  def fakeInitContext(implicit system: ActorSystem) = {
-    val (_, s) = fakeServerRef
+  def fakeInitContext(config: Option[ServerSettings] = None)(implicit system: ActorSystem) = {
+    val (_, s) = fakeServerRef(config)
     val (_, w) = fakeWorkerRef
     InitContext(s, w)
   }
@@ -53,12 +53,12 @@ object FakeIOSystem {
   /**
     * Returns a ServerRef representing a server in the Bound state
     */
-  def fakeServerRef(implicit system: ActorSystem): (TestProbe, ServerRef) = {
+  def fakeServerRef(configOpt: Option[ServerSettings] = None)(implicit system: ActorSystem): (TestProbe, ServerRef) = {
     val probe = TestProbe()
     val config = ServerConfig(
       "/foo",
       (initContext) => ???,
-      ServerSettings(987)
+      configOpt.getOrElse(ServerSettings.default.copy(port = 987))
     )
     val ref = ServerRef(config,
                         probe.ref,

--- a/colossus-testkit/src/main/scala/colossus.testkit/MockConnection.scala
+++ b/colossus-testkit/src/main/scala/colossus.testkit/MockConnection.scala
@@ -70,9 +70,11 @@ trait TypedMockConnection[T <: ConnectionHandler] extends MockConnection {
 
 object MockConnection {
 
-  def server[T <: ServerConnectionHandler](handlerF: ServerContext => T, _maxWriteSize: Int = 1024)(
+  def server[T <: ServerConnectionHandler](handlerF: ServerContext => T,
+                                           _maxWriteSize: Int = 1024,
+                                           config: Option[ServerSettings] = None)(
       implicit sys: ActorSystem): ServerConnection with TypedMockConnection[T] = {
-    val (_serverProbe, server) = FakeIOSystem.fakeServerRef
+    val (_serverProbe, server) = FakeIOSystem.fakeServerRef(config)
     val fw                     = FakeIOSystem.fakeWorker
     val ctx                    = ServerContext(server, fw.worker.generateContext())
     val _handler               = handlerF(ctx)

--- a/colossus-tests/src/test/resources/application.conf
+++ b/colossus-tests/src/test/resources/application.conf
@@ -1,8 +1,8 @@
-colossus.service.config-loading-spec {
+colossus.server.config-loading-spec {
 
   request-buffer-size = 9876
 }
 
-colossus.service.bad-config {
+colossus.server.bad-config {
   request-buffer-size = "hello"
 }

--- a/colossus-tests/src/test/resources/logback.xml
+++ b/colossus-tests/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <Pattern>%d %-4relative [%thread] %-5level %logger{35} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="consoleAppender" />
+    </root>
+</configuration>

--- a/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/core/ServerConfigLoadingSpec.scala
@@ -43,9 +43,6 @@ class ServerConfigLoadingSpec extends ColossusSpec {
           |    max-connections : 1000
           |    max-idle-time : "1 second"
           |    shutdown-timeout : "2 seconds"
-          |}
-          |colossus.server {
-          |   shutdown-timeout : "3 seconds"
           |    tcp-backlog-size : 100
           |}
         """.stripMargin

--- a/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/websocket/WebsocketSpec.scala
@@ -153,7 +153,7 @@ class WebsocketSpec extends ColossusSpec with MockFactory with ControllerMocks {
     def mock(): (TestUpstream[WebsocketEncoding], WebsocketController[CString]) = {
 
       val cstub      = new TestUpstream[WebsocketEncoding]
-      val handler    = new MyHandler(FakeIOSystem.fakeServerContext)
+      val handler    = new MyHandler(FakeIOSystem.fakeServerContext())
       val controller = new WebsocketController(handler, new CStringCodec)
       controller.setUpstream(cstub)
       controller.connected()
@@ -212,7 +212,7 @@ class WebsocketSpec extends ColossusSpec with MockFactory with ControllerMocks {
     }
 
     def createHandler = {
-      val init = new colossus.protocols.http.Initializer(FakeIOSystem.fakeInitContext) {
+      val init = new colossus.protocols.http.Initializer(FakeIOSystem.fakeInitContext()) {
         def onConnect = serverContext => new WebsocketHttpHandler(serverContext, myinit, "/foo", List.empty)
       }
       MockConnection.server(ctx => init.fullHandler(init.onConnect(ctx)))

--- a/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceClientSpec.scala
@@ -463,7 +463,7 @@ class ServiceClientSpec extends ColossusSpec with MockFactory {
 
           val client = Raw.futureFactory(config)
           TestUtil.expectServerConnections(server, 0)
-          TestClient.waitForStatus(client, ConnectionStatus.NotConnected)
+          TestClient.waitForStatus(client, ConnectionStatus.NotConnected, 10)
         }
       }
     }

--- a/colossus-tests/src/test/scala/colossus/service/ServiceConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ServiceConfigLoadingSpec.scala
@@ -1,7 +1,9 @@
 package colossus.service
 
+import colossus.core.ServerSettings
 import colossus.parsing.DataSize._
-import org.scalatest.{WordSpec, MustMatchers}
+import com.typesafe.config.ConfigException.WrongType
+import org.scalatest.{MustMatchers, WordSpec}
 
 import scala.concurrent.duration.Duration
 
@@ -9,7 +11,7 @@ class ServiceConfigLoadingSpec extends WordSpec with MustMatchers {
 
   "Service configuration loading" should {
     "load defaults" in {
-      val config = ServiceConfig.Default
+      val config = ServerSettings.default
       config.logErrors mustBe true
       config.maxRequestSize mustBe 10.MB
       config.requestBufferSize mustBe 100
@@ -18,14 +20,14 @@ class ServiceConfigLoadingSpec extends WordSpec with MustMatchers {
     }
 
     "load a config based on path with fallback to defaults" in {
-      val config = ServiceConfig.load("config-loading-spec")
+      val config = ServerSettings.load("config-loading-spec")
       config.requestBufferSize mustBe 9876
       config.requestMetrics mustBe true
     }
 
     "throw a ServiceConfigException when something is wrong" in {
-      intercept[ServiceConfigException] {
-        ServiceConfig.load("bad-config")
+      intercept[WrongType] {
+        ServerSettings.load("bad-config")
       }
     }
 

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -14,45 +14,42 @@ colossus{
   }
 
   server {
-    name : "/"
-    port : 9876
-    max-connections : 1000
-    slow-start {
-      enabled = false
-      initial = 20
-      duration = 5 seconds
-    }
-    max-idle-time : "Inf"
-    low-watermark-percentage : 0.75
-    high-watermark-percentage : 0.85
-    highwater-max-idle-time : "100 milliseconds"
-    #tcp-backlog-size : 100  #optional
-    binding-retry : {
-      type : "backoff"
-      multiplier : {
-        type : "exponential"
-        max : "1 second"
-      }
-      base : "100 milliseconds"
-      immediate-first-attempt : false
-    }
-    delegator-creation-policy : {
-      wait-time : "500 milliseconds"
-      retry-policy : {
-        type : "backoff"
-        multiplier : {
-          type : "constant"
-        }
-        base : "100 milliseconds"
-        immediate-first-attempt : false
-      }
-    }
-    shutdown-timeout : "100 milliseconds"
-    #so-reuse-address : true
-  }
-
-  service {
     default {
+      name: "/"
+      port: 9876
+      max-connections: 1000
+      slow-start {
+        enabled = false
+        initial = 20
+        duration = 5 seconds
+      }
+      max-idle-time: "Inf"
+      low-watermark-percentage: 0.75
+      high-watermark-percentage: 0.85
+      highwater-max-idle-time: "100 milliseconds"
+      #tcp-backlog-size : 100  #optional
+      #so-reuse-address : true
+      binding-retry: {
+        type: "backoff"
+        multiplier: {
+          type: "exponential"
+          max: "1 second"
+        }
+        base: "100 milliseconds"
+        immediate-first-attempt: false
+      }
+      delegator-creation-policy: {
+        wait-time: "500 milliseconds"
+        retry-policy: {
+          type: "backoff"
+          multiplier: {
+            type: "constant"
+          }
+          base: "100 milliseconds"
+          immediate-first-attempt: false
+        }
+      }
+      shutdown-timeout: "100 milliseconds"
       request-timeout : "Inf"
       request-buffer-size : 100
       log-errors : true
@@ -64,6 +61,7 @@ colossus{
       }
     }
   }
+
 
   client {
     defaults {

--- a/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpServer.scala
@@ -2,7 +2,7 @@ package colossus.protocols.http
 
 import colossus.IOSystem
 import colossus.controller.Controller
-import colossus.core.{InitContext, PipelineHandler, ServerContext}
+import colossus.core.{InitContext, PipelineHandler, ServerContext, ServerSettings}
 import colossus.service._
 
 class HttpServiceHandler(rh: RequestHandler) extends ServiceServer[Http](rh) {}
@@ -31,8 +31,7 @@ abstract class Initializer(ctx: InitContext) extends Generator(ctx) with Service
 /**
   * A RequestHandler contains the business logic for transforming [[HttpRequest]] into [[HttpResponse]] objects.
   */
-abstract class RequestHandler(ctx: ServerContext, config: ServiceConfig) extends GenRequestHandler[Http](ctx, config) {
-  def this(ctx: ServerContext) = this(ctx, ServiceConfig.load(ctx.name))
+abstract class RequestHandler(ctx: ServerContext) extends GenRequestHandler[Http](ctx) {
 
   val defaults = new Http.ServerDefaults
 

--- a/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
+++ b/colossus/src/main/scala/colossus/protocols/websocket/Websocket.scala
@@ -281,7 +281,7 @@ class WebsocketHttpHandler[E <: Encoding](ctx: ServerContext,
                                           websocketInit: WebsocketInitializer[E],
                                           upgradePath: String,
                                           origins: List[String])
-    extends colossus.protocols.http.RequestHandler(ctx, ServiceConfig.Default) {
+    extends colossus.protocols.http.RequestHandler(ctx) {
   def handle = {
     case request if (request.head.path == upgradePath) => {
       val response = UpgradeRequest.validate(request, origins) match {
@@ -300,7 +300,6 @@ class WebsocketHttpHandler[E <: Encoding](ctx: ServerContext,
 
 object WebsocketServer {
   import colossus.protocols.http._
-  
 
   /**
     * Start a Websocket server on the specified port.  Since Websocket

--- a/colossus/src/main/scala/colossus/service/RequestHandler.scala
+++ b/colossus/src/main/scala/colossus/service/RequestHandler.scala
@@ -18,7 +18,7 @@ object GenRequestHandler {
 }
 import GenRequestHandler._
 
-abstract class GenRequestHandler[P <: Protocol](val serverContext: ServerContext, val config: ServiceConfig)
+abstract class GenRequestHandler[P <: Protocol](val serverContext: ServerContext)
     extends DownstreamEvents
     with HandlerTail
     with UpstreamEventHandler[ServiceUpstream[P]] {
@@ -26,11 +26,11 @@ abstract class GenRequestHandler[P <: Protocol](val serverContext: ServerContext
   type Request  = P#Request
   type Response = P#Response
 
-  def this(context: ServerContext) = this(context, ServiceConfig.load(context.name))
-
   protected val server = serverContext.server
   def context          = serverContext.context
   implicit val worker  = context.worker
+
+  val config = serverContext.server.config.settings
 
   private var _connectionManager: Option[ConnectionManager] = None
 

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -87,8 +87,7 @@ trait BasicServiceDSL[P <: Protocol] {
 
   abstract class Initializer(context: InitContext) extends Generator(context) with ServiceInitializer[RequestHandler]
 
-  abstract class RequestHandler(ctx: ServerContext, config: ServiceConfig) extends GenRequestHandler[P](ctx, config) {
-    def this(ctx: ServerContext) = this(ctx, ServiceConfig.load(ctx.name))
+  abstract class RequestHandler(ctx: ServerContext) extends GenRequestHandler[P](ctx) {
 
     def unhandledError = {
       case error => errorMessage(error)
@@ -182,7 +181,7 @@ trait ClientFactory[P <: Protocol, M[_], +T <: Sender[P, M], E] {
 trait ServiceClientFactory[P <: Protocol] extends ClientFactory[P, Callback, ServiceClient[P], WorkerRef] {
 
   implicit def clientTagDecorator: TagDecorator[P]
-  
+
   def connectionHandler(base: ServiceClient[P], codec: Codec[Encoding.Client[P]]): ClientConnectionHandler = {
     new UnbindHandler(new Controller[Encoding.Client[P]](base, codec), base)
   }
@@ -203,7 +202,8 @@ trait ServiceClientFactory[P <: Protocol] extends ClientFactory[P, Callback, Ser
 
 object ServiceClientFactory {
 
-  def basic[P <: Protocol](name: String, provider: () => Codec.Client[P],
+  def basic[P <: Protocol](name: String,
+                           provider: () => Codec.Client[P],
                            tagDecorator: TagDecorator[P] = TagDecorator.default[P]) = new ServiceClientFactory[P] {
 
     def defaultName = name


### PR DESCRIPTION
Probably another controversial change. Here I am moving `ServiceConfig` into `ServerSettings`. This was mainly motived when we ended up with config that looks like this in one of our services:

```
colossus.server.service-name.max-connections = 4000
colossus.service.service-name.request-timeout = 1 second
```

It is not intuitive why some config is part of a "server" and other config is part of a "service". What is the use case for having a distinction between a server and service?

@DanSimon @amotamed @aliyakamercan @jlbelmonte @dxuhuang 