### PR TITLE
Service client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -146,4 +146,10 @@ lazy val ColossusTestsProject = Project(
   id = "colossus-tests",
   base = file("colossus-tests"),
   dependencies = Seq(ColossusTestkitProject % "compile;test->test")
-).settings(noPubSettings: _*).configs(IntegrationTest)
+  ).settings(noPubSettings: _*)
+  .settings(
+    libraryDependencies ++= Seq(
+      "ch.qos.logback" %  "logback-classic" % "1.2.2"
+    )
+  ).configs(IntegrationTest)
+

--- a/colossus-docs/src/main/paradox/clients.md
+++ b/colossus-docs/src/main/paradox/clients.md
@@ -12,12 +12,11 @@ or to open a new connection per request, since Colossus is primarily intended to
 build long-running services, so too are clients designed for persistent
 connections to a single host.
 
-Clients are pipelined and will send multiple requests at once (up to the
-configured `inFlightConcurrency` limit, buffering once the limit is hit).
+A client can open many connections to the same or different external systems depending on how it is setup. If
+it opens many connections then it will load balance between the connections, sending different requests on different
+connections.
 
-### Connection Management
-
-A Client attempts to open a connection as soon as it is created.  Depending on
+A Client will attempt to open its connections as soon as it is created.  Depending on
 how a client is configured, it will immediately accept requests to be sent and
 buffer them until the connection is established, so for the most part a Client's
 connection management happens in the background.
@@ -27,10 +26,19 @@ immediately reject any new requests, but allow currently in-flight requests to
 complete (assuming they don't timeout).  Once a client has been manually
 disconnected, it cannot be reused.
 
-If a client unexpectedly loses its connection, it will automatically attempt to
-reconnect.  If/how a client reconnects can be controlled by its `connectRetry`
+If a client unexpectedly loses one of its connection, it will automatically attempt to
+reconnect.  If/how a connection reconnects can be controlled by its `connectRetry`
 configuration.  During the reconnection, the client will still accept and buffer
 new requests (though this can be disabled by setting `failFast` to true).
+
+Clients are pipelined and will send multiple requests at once (up to the configured `inFlightConcurrency` limit, 
+buffering once the limit is hit).
+
+If a client is setup with multiple connections, then a request failure will automatically be retried on another 
+connection. The request will be retried on each of the connections until success or each connection has been tried. The
+retry policy can be configured by altering `request-retry-policy`, such that retries can be turned off and backoff can
+be applied between retry attempts. Retry attempts can be set higher than available connections, in which case the same
+connection could be reused.
 
 ## Local vs Future Clients
 
@@ -56,46 +64,31 @@ at least twice.
 
 Therefore these two rules may help when choosing what to use:
 
-* When opening a client within a service, use local clients.  Usually you'll want to open one client per worker.
+* When opening a client within a service, use local clients.
 * When opening a client from outside a service, such as from inside an actor or some other general use case, use a future client.
 
-## Failure Management
- 
-### Client Behavior 
+## Retry Policy
 
-Failures can be broken down into two categories: Connection Failures and 
-Request Failures.  Regardless of which type, if a failure occurs the response
-is sent back as a failure and NOT retried.  If failfast is enabled, then all
-queued requests in the ServiceClient are immediately failed and removed. 
- 
-If a Request Failure occurs (example: service isn't responding) the response is
-sent back as a failure and no subsequent action is taken.
+In the event of a connection failure or request failure, the client uses a @extref[RetryPolicy](docs:colossus.core.RetryPolicy)
+to determine what to do next.
 
-If a Connection Failure occurs (example: connection is closed, host 
-unavailable) the response is sent back as a failure and the retry policy (more
-below) takes effect.
+The connection retry policy defaults to an exponential backoff starting at 50 milliseconds with a maximum of 5 seconds,
+and will retry forever. The request retry policy defaults to having no backoff between retries and will retry up to
+the number of connections.
 
+The policy type can be either @extref[NoRetry](docs:colossus.core.NoRetry) or 
+@extref[BackoffPolicy](docs:colossus.core.BackoffPolicy). A backoff retry policy contains a multiplier which can be:
 
-### Retrying Requests
+ * Constant
+ * Linear
+ * Exponential
 
-To enable retries, the LoadBalancingClient (LBC) should be used.  The LBC takes
-in a generator that builds a ServiceClient from an InetSocketAddress and a list
-of InetSocketAddresses.  The LBC defaults to using an unused host for a request
-or the max retry number, whichever is lower.  An example: if the retry count is
-set to four but there are only two hosts, it'll only attempt a request twice.
-
-Any failure occurring before the client receives the response (example: 
-connection closed, host not responding) is treated as an attempt and is 
-retried on the next connection.  If the maximum number of tries are exhausted, 
-a SendFailedException is returned with the last exception.
-
-### Example
-
-
-Below is an example of retrying three times to the same host
+Below is an example of setting up a client to retry three times:
 
 @@snip [RedisRetryClient.scala](../scala/RedisRetryClient.scala) { #example }
 
+
+## Examples
 
 ### HTTP Example
 
@@ -110,7 +103,8 @@ An implicit ClientCodecProvider is required.
 
 Below is a simple memcached get example.  It can be tested locally
 by starting up a memcached server and setting a value for the key of 1.
-The equivalent command would be "get 1" from a telnet session on 11211.  
+The equivalent command would be "get 1" from a telnet session on 11211. 
+
 When using the memcached client an implicit workerRef is required when using the Callback
 interface.  An implicit ClientCodeProvider is required.
 
@@ -128,23 +122,8 @@ interface.  An implicit ClientCodeProvider is required.
 @@snip [RedisClientExample.scala](../scala/RedisClientExample.scala) { #example }
 
 
-### Retry Policy
 
-In the event of a Connection Failure, the service client uses a 
-[RetryPolicy](https://tumblr.github.io/colossus/api/index.html#colossus.core.RetryPolicy)
-for re-establishing connections.  Each service client takes in a RetryPolicy on
-creation.  The client defaults to an exponential backoff starting at 50 
-milliseconds and with a maximum of 5 seconds.  The policy type can be either 
-[NoRetry](https://tumblr.github.io/colossus/api/index.html#colossus.core.NoRetry) 
-or [BackoffPolicy](https://tumblr.github.io/colossus/api/index.html#colossus.core.BackoffPolicy).
-
-A Backoff retry policy contains a multiplier which can be:
- 
- * Constant
- * Linear
- * Exponential
-
-# Generic clients
+## Generic clients
 
 Notice that the concurrency type (Callback/Future) is encoded in the type of the
 client.  The clients abstract over these two types with the `Async` typeclass.

--- a/colossus-docs/src/main/scala/RedisRetryClient.scala
+++ b/colossus-docs/src/main/scala/RedisRetryClient.scala
@@ -3,13 +3,17 @@ import java.net.InetSocketAddress
 import akka.actor.ActorSystem
 import akka.util.ByteString
 import colossus.IOSystem
+import colossus.core.{BackoffMultiplier, BackoffPolicy}
+import colossus.metrics.MetricAddress
 import colossus.protocols.http.HttpMethod.Get
 import colossus.protocols.http.Http
 import colossus.protocols.http.UrlParsing.{Root, on}
 import colossus.protocols.http.{HttpServer, Initializer, RequestHandler}
 import colossus.protocols.redis.Redis
+import colossus.service.ClientConfig
 import colossus.service.GenRequestHandler.PartialHandler
-import colossus.service.LoadBalancingClient
+
+import scala.concurrent.duration._
 
 object RedisRetryClient extends App {
 
@@ -20,22 +24,29 @@ object RedisRetryClient extends App {
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
 
-      val generator = (address: InetSocketAddress) => {
-        Redis.client(address.getHostName, address.getPort)
-      }
+      val config = ClientConfig(
+        address = Seq(new InetSocketAddress("localhost", 6379)),
+        requestTimeout = 1.second,
+        name = MetricAddress.Root / "redis",
+        requestRetry = BackoffPolicy(
+          baseBackoff = 0.milliseconds,
+          multiplier = BackoffMultiplier.Constant,
+          maxTries = Some(3)
+        )
+      )
 
-      val addresses                 = List.fill(3)(new InetSocketAddress("localhost", 6379))
-      val loadBalancingRedisClients = new LoadBalancingClient[Redis](worker, generator, 3, addresses)
-      val redisClient               = Redis.client(loadBalancingRedisClients)
+      val redisClient = Redis.client(config)
 
-      override def onConnect = serverContext => new RequestHandler(serverContext) {
-        override def handle: PartialHandler[Http] = {
-          case request @ Get on Root =>
-            redisClient.append(ByteString("key"), ByteString("VALUE")).map { result =>
-              request.ok(s"Length of key is $result")
+      override def onConnect =
+        serverContext =>
+          new RequestHandler(serverContext) {
+            override def handle: PartialHandler[Http] = {
+              case request @ Get on Root =>
+                redisClient.append(ByteString("key"), ByteString("VALUE")).map { result =>
+                  request.ok(s"Length of key is $result")
+                }
             }
         }
-      }
     }
   }
   // #example

--- a/colossus-metrics/src/main/scala/colossus/metrics/ConfigHelper.scala
+++ b/colossus-metrics/src/main/scala/colossus/metrics/ConfigHelper.scala
@@ -59,11 +59,16 @@ object ConfigHelpers {
       }
     }
 
-    def getInetSocketAddress(path: String): InetSocketAddress = {
-      val raw = config.getString(path)
-      raw.split(":") match {
-        case Array(host, Port(x)) => new InetSocketAddress(host, x)
-        case _                    => throw new InvalidHostAddressException(raw)
+    def getInetSocketAddressList(path: String): Seq[InetSocketAddress] = {
+      val raw  = config.getList(path)
+      val list = raw.iterator().asScala.toList
+      list.map { configValue =>
+        println(configValue.unwrapped().asInstanceOf[String])
+
+        configValue.unwrapped().asInstanceOf[String].split(":") match {
+          case Array(host, Port(x)) => new InetSocketAddress(host, x)
+          case _                    => throw new InvalidHostAddressException(raw.render())
+        }
       }
     }
 

--- a/colossus-testkit/src/main/scala/colossus.testkit/MockClientFactory.scala
+++ b/colossus-testkit/src/main/scala/colossus.testkit/MockClientFactory.scala
@@ -1,9 +1,12 @@
 package colossus.testkit
 
+import java.net.InetSocketAddress
+
 import scala.language.higherKinds
 import colossus.IOSystem
 import colossus.core.WorkerRef
 import colossus.service._
+
 import scala.concurrent.Future
 
 object MockSender {
@@ -14,6 +17,10 @@ object MockSender {
     def disconnect() {}
 
     override def addInterceptor(interceptor: Interceptor[P]): Unit = {}
+
+    override def address() = new InetSocketAddress(8888)
+
+    override def update(addresses: Seq[InetSocketAddress]): Unit = {}
   }
 }
 

--- a/colossus-testkit/src/main/scala/colossus.testkit/ServiceSpec.scala
+++ b/colossus-testkit/src/main/scala/colossus.testkit/ServiceSpec.scala
@@ -31,7 +31,7 @@ abstract class ServiceSpec[P <: Protocol](implicit clientFactory: FutureClientFa
 
   def clientConfig(timeout: FiniteDuration) = ClientConfig(
     name = "/test-client",
-    address = new InetSocketAddress("localhost", runningService.config.settings.port),
+    address = Seq(new InetSocketAddress("localhost", runningService.config.settings.port)),
     requestTimeout = timeout
   )
 

--- a/colossus-testkit/src/test/scala/colossus.testkit/MockClientSpec.scala
+++ b/colossus-testkit/src/test/scala/colossus.testkit/MockClientSpec.scala
@@ -24,7 +24,7 @@ class MockClientSpec extends ColossusSpec {
       implicit val worker = FakeIOSystem.fakeWorker.worker
       val l: LoadBalancingClient[Http] = new LoadBalancingClient(
         List(new InetSocketAddress("1.1.1.1", 34)),
-        ClientConfig(address = new InetSocketAddress("0.0.0.0", 1), name = "/foo", requestTimeout = 1.second),
+        ClientConfig(address = Seq(new InetSocketAddress("0.0.0.0", 1)), name = "/foo", requestTimeout = 1.second),
         MockClientFactory.client[Http]((x: HttpRequest) => Callback.successful(x.ok("test"))),
         4
       )

--- a/colossus-tests/src/it/scala/colossus/BaseRedisITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/BaseRedisITSpec.scala
@@ -26,7 +26,7 @@ abstract class BaseRedisITSpec extends ColossusSpec with ScalaFutures with Scale
 
   def keyPrefix : String
 
-  val client = Redis.futureClient(ClientConfig(new InetSocketAddress("localhost", 6379), 1.second, "redis"))
+  val client = Redis.futureClient(ClientConfig(Seq(new InetSocketAddress("localhost", 6379)), 1.second, "redis"))
 
   val usedKeys = scala.collection.mutable.HashSet.empty[ByteString]
 

--- a/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala
@@ -30,7 +30,7 @@ class MemcacheITSpec extends ColossusSpec with ScalaFutures{
 
   implicit val sys = IOSystem("test-system", Some(2), MetricSystem.deadSystem)
 
-  val client = Memcache.futureClient(ClientConfig(new InetSocketAddress("localhost", 11211), 2.seconds, "memcache"))
+  val client = Memcache.futureClient(ClientConfig(Seq(new InetSocketAddress("localhost", 11211)), 2.seconds, "memcache"))
 
   val usedKeys = scala.collection.mutable.HashSet[ByteString]()
 

--- a/colossus-tests/src/test/resources/logback.xml
+++ b/colossus-tests/src/test/resources/logback.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>UTF-8</charset>
+            <Pattern>%d %-4relative [%thread] %-5level %logger{35} - %msg%n</Pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="consoleAppender" />
+    </root>
+</configuration>

--- a/colossus-tests/src/test/scala/colossus/Util.scala
+++ b/colossus-tests/src/test/scala/colossus/Util.scala
@@ -142,7 +142,7 @@ object TestClient {
     val config = ClientConfig(
       name = "/test",
       requestTimeout = 100.milliseconds,
-      address = new InetSocketAddress("localhost", port),
+      address = Seq(new InetSocketAddress("localhost", port)),
       pendingBufferSize = 10,
       failFast = true,
       connectRetry = connectRetry

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpClientSpec.scala
@@ -15,7 +15,7 @@ class HttpClientSpec extends ColossusSpec with MockFactory {
   "Http Client" must {
 
     val clientConfig = ClientConfig(
-      address = new InetSocketAddress("localhost", 80),
+      address = Seq(new InetSocketAddress("localhost", 80)),
       requestTimeout = Duration.Inf,
       name = MetricAddress.Root / "testMetric"
     )
@@ -27,6 +27,7 @@ class HttpClientSpec extends ColossusSpec with MockFactory {
         val sender = mock[Sender[Http, Future]]
 
         val expectedRequest = request.withHeader("host", "localhost")
+        (sender.address _).expects().returns(new InetSocketAddress("localhost", 88))
         (sender.send _).expects(expectedRequest)
 
         val httpClient = Http.futureClient(sender, clientConfig)

--- a/colossus-tests/src/test/scala/colossus/service/AsyncServiceClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/AsyncServiceClientSpec.scala
@@ -81,7 +81,7 @@ class FutureClientSpec extends ColossusSpec {
     "properly buffer messages before workeritem bound" in {
       withIOSystem { implicit io =>
         val client = TestClient(io, TEST_PORT, waitForConnected = false)
-        intercept[NotConnectedException] {
+        intercept[SendFailedException] {
           Await.result(client.send(ByteString("foo")), 500.milliseconds)
         }
       }

--- a/colossus-tests/src/test/scala/colossus/service/ClientConfigLoadingSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/ClientConfigLoadingSpec.scala
@@ -16,7 +16,7 @@ class ClientConfigLoadingSpec extends WordSpec with MustMatchers {
       val userOverrides =
         """
           |colossus.client.my-client {
-          |  address : "127.0.0.1:6379"
+          |  address : ["127.0.0.1:6379"]
           |  name : "redis"
           |  pending-buffer-size : 500
           |}
@@ -25,7 +25,7 @@ class ClientConfigLoadingSpec extends WordSpec with MustMatchers {
       val c            = ConfigFactory.parseString(userOverrides).withFallback(ConfigFactory.defaultReference())
       val clientConfig = ClientConfig.load("my-client", c)
 
-      val expected = ClientConfig(new InetSocketAddress("127.0.0.1", 6379),
+      val expected = ClientConfig(Seq(new InetSocketAddress("127.0.0.1", 6379)),
                                   requestTimeout = 1.second,
                                   name = MetricAddress("redis"),
                                   pendingBufferSize = 500)

--- a/colossus-tests/src/test/scala/colossus/service/LoadBalancerSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/LoadBalancerSpec.scala
@@ -1,0 +1,215 @@
+package colossus.service
+
+import java.net.InetSocketAddress
+import java.util.concurrent.atomic.AtomicInteger
+
+import colossus.controller.Codec
+import colossus.core.BackoffMultiplier.Constant
+import colossus.core.{BackoffPolicy, ConnectionStatus, NoRetry, WorkerRef}
+import colossus.metrics.MetricAddress
+import colossus.protocols.http.{Http, HttpRequest, HttpResponse}
+import colossus.testkit.{CallbackAwait, ColossusSpec, FakeIOSystem}
+import org.scalatest.mockito.MockitoSugar
+
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration._
+
+class LoadBalancerSpec extends ColossusSpec with MockitoSugar {
+
+  "Load balancer" must {
+
+    implicit val workerRef: WorkerRef = mock[WorkerRef]
+
+    val address1 = new InetSocketAddress(1)
+    val address2 = new InetSocketAddress(2)
+    val address3 = new InetSocketAddress(3)
+    val address4 = new InetSocketAddress(4)
+    val address5 = new InetSocketAddress(5)
+
+    val simplePermutationFactory =
+      (clients: Seq[Client[Http, Callback]]) =>
+        new PermutationGenerator[Client[Http, Callback]] {
+          override def next(): List[Client[Http, Callback]] = clients.toList
+      }
+
+    "correctly add and remove clients" in {
+      val beginningClients = Seq(address1, address2, address3, address3, address4)
+
+      val config = ClientConfig(
+        beginningClients,
+        1.second,
+        MetricAddress("/")
+      )
+
+      val (serviceClientFactory, sentToClients, interceptorCount) = createServiceClientFactory()
+
+      val lb = new LoadBalancer[Http](config, serviceClientFactory, simplePermutationFactory)
+      lb.addInterceptor((request: HttpRequest, callback: Callback[HttpResponse] => Callback[HttpResponse]) => {
+        (request, callback)
+      })
+
+      // each client should have the interceptor added
+      assert(interceptorCount.get() == 5)
+
+      val newAddresses = Seq(address1, address2, address2, address3, address5)
+
+      lb.send(HttpRequest.get("/")).execute()
+
+      assert(sentToClients == beginningClients)
+
+      lb.update(newAddresses)
+
+      // new clients should have the interceptor added (only two added)
+      assert(interceptorCount.get() == 7)
+
+      sentToClients.clear()
+
+      lb.send(HttpRequest.get("/")).execute()
+
+      assert(sentToClients.map(_.toString).sorted == newAddresses.map(_.toString).sorted)
+    }
+
+    "send to only one client when configured with no retry" in {
+      val config = ClientConfig(
+        Seq(address1, address2, address3),
+        1.second,
+        MetricAddress("/"),
+        requestRetry = NoRetry
+      )
+
+      val (serviceClientFactory, sentToClients, _) = createServiceClientFactory()
+
+      val lb = new LoadBalancer[Http](config, serviceClientFactory, simplePermutationFactory)
+
+      lb.send(HttpRequest.get("/")).execute()
+
+      assert(sentToClients == Seq(address1))
+    }
+
+    "send to all clients when no max tries specified" in {
+      val clients = Seq(address1, address2, address3)
+
+      val config = ClientConfig(
+        clients,
+        1.second,
+        MetricAddress("/"),
+        requestRetry = BackoffPolicy(
+          baseBackoff = 0.second,
+          multiplier = Constant,
+          maxTries = None
+        )
+      )
+
+      val (serviceClientFactory, sentToClients, _) = createServiceClientFactory()
+
+      val lb = new LoadBalancer[Http](config, serviceClientFactory, simplePermutationFactory)
+
+      lb.send(HttpRequest.get("/")).execute()
+
+      assert(sentToClients == clients)
+    }
+
+    "send to X clients when max tries specified" in {
+      val config = ClientConfig(
+        Seq(address1, address2, address3),
+        1.second,
+        MetricAddress("/"),
+        requestRetry = BackoffPolicy(
+          baseBackoff = 0.second,
+          multiplier = Constant,
+          maxTries = Some(2)
+        )
+      )
+
+      val (serviceClientFactory, sentToClients, _) = createServiceClientFactory()
+
+      val lb = new LoadBalancer[Http](config, serviceClientFactory, simplePermutationFactory)
+
+      lb.send(HttpRequest.get("/")).execute()
+
+      assert(sentToClients == Seq(address1, address2))
+    }
+
+    "send to the same connection when retries is set higher than connections available" in {
+      val config = ClientConfig(
+        Seq(address1),
+        1.second,
+        MetricAddress("/"),
+        requestRetry = BackoffPolicy(
+          baseBackoff = 0.second,
+          multiplier = Constant,
+          maxTries = Some(3)
+        )
+      )
+
+      val (serviceClientFactory, sentToClients, _) = createServiceClientFactory()
+
+      val lb = new LoadBalancer[Http](config, serviceClientFactory, simplePermutationFactory)
+
+      lb.send(HttpRequest.get("/")).execute()
+
+      assert(sentToClients == Seq(address1, address1, address1))
+    }
+
+    "return failure when no clients provided" in {
+      val config = ClientConfig(
+        Seq(),
+        1.second,
+        MetricAddress("/")
+      )
+
+      val (serviceClientFactory, sentToClients, _) = createServiceClientFactory()
+
+      val lb = new LoadBalancer[Http](config, serviceClientFactory, simplePermutationFactory)
+
+      val callback = lb.send(HttpRequest.get("/"))
+
+      implicit val callbackExecutor: CallbackExecutor = FakeIOSystem.testExecutor
+
+      intercept[SendFailedException] {
+        CallbackAwait.result(callback, 1.second)
+      }
+
+      assert(sentToClients.isEmpty)
+    }
+  }
+
+  def createServiceClientFactory(): (ServiceClientFactory[Http], ArrayBuffer[InetSocketAddress], AtomicInteger) = {
+    val sentToClients = ArrayBuffer.empty[InetSocketAddress]
+
+    var interceptorCount = new AtomicInteger(0)
+    var disconnectCount  = new AtomicInteger(0)
+
+    val serviceClientFactory = new ServiceClientFactory[Http] {
+      override implicit def clientTagDecorator: TagDecorator[Http] = ???
+
+      override def codecProvider: Codec.Client[Http] = ???
+
+      override def defaultName: String = ???
+
+      override def createClient(config: ClientConfig, clientAddress: InetSocketAddress)(
+          implicit worker: WorkerRef): Client[Http, Callback] = {
+        new Client[Http, Callback] {
+          override def connectionStatus: Callback[ConnectionStatus] = ???
+
+          override def send(input: HttpRequest): Callback[HttpResponse] = {
+            sentToClients.append(clientAddress)
+            Callback.failed(new Exception("fake"))
+          }
+
+          override def disconnect(): Unit = {}
+
+          override def addInterceptor(interceptor: Interceptor[Http]): Unit = {
+            interceptorCount.incrementAndGet()
+          }
+
+          override def address(): InetSocketAddress = clientAddress
+
+          override def update(addresses: Seq[InetSocketAddress]): Unit = {}
+        }
+      }
+    }
+
+    (serviceClientFactory, sentToClients, interceptorCount)
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/service/LoadBalancingClientSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/LoadBalancingClientSpec.scala
@@ -69,6 +69,10 @@ class LoadBalancingClientSpec extends ColossusSpec with MockFactory {
         def disconnect() {}
 
         override def addInterceptor(interceptor: Interceptor[PR]): Unit = {}
+
+        override def address(): InetSocketAddress = ???
+
+        override def update(addresses: Seq[InetSocketAddress]): Unit = {}
       }
       (1 to 5).foreach { num =>
         val ops       = (1 to num).permutations.toList.size //lazy factorial
@@ -185,7 +189,7 @@ class LoadBalancingClientSpec extends ColossusSpec with MockFactory {
       implicit val w = FakeIOSystem.fakeWorker.worker
       val l = new LoadBalancingClient[Http](
         List(new InetSocketAddress("127.0.0.1", 1)),
-        ClientConfig(address = new InetSocketAddress("0.0.0.0", 1), name = "/foo", requestTimeout = 1.second),
+        ClientConfig(address = Seq(new InetSocketAddress("0.0.0.0", 1)), name = "/foo", requestTimeout = 1.second),
         Http.client,
         4
       )
@@ -196,10 +200,10 @@ class LoadBalancingClientSpec extends ColossusSpec with MockFactory {
   "ServiceClientPool" must {
     val fw = FakeIOSystem.fakeWorker
     def pool() = new ServiceClientPool(
-      ClientConfig(address = new InetSocketAddress("0.0.0.0", 1), name = "/foo", requestTimeout = 1.second),
+      ClientConfig(address = Seq(new InetSocketAddress("0.0.0.0", 1)), name = "/foo", requestTimeout = 1.second),
       fw.worker,
       (config, worker) => {
-        mockClient(config.address.getPort)
+        mockClient(config.address.head.getPort)
       }
     )
 

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -9,7 +9,7 @@ akka.log-dead-letters = 0
 colossus{
 
   iosystem {
-    #If num-workers is omitted, it will default to the CPU core count on the host machine
+    # If num-workers is omitted, it will default to the CPU core count on the host machine
     #num-workers : 4
   }
 
@@ -43,6 +43,7 @@ colossus{
       }
     }
     shutdown-timeout : "100 milliseconds"
+    # If so-reuse-address is omitted, it will default to the implementation default
     #so-reuse-address : true
   }
 
@@ -62,6 +63,7 @@ colossus{
 
   client {
     defaults {
+      # Provide address and name in config or by code
       #address - 127.0.0.1:333 or myserver.on.the.web:5678 must be provided
       #name  - must be provided
       request-timeout : "1 second"
@@ -79,13 +81,15 @@ colossus{
       }
       idle-timeout : "Inf"
       max-response-size : "1 MB"
+      request-retry-policy : {
+        type : "backoff"
+        multiplier : {
+          type : "constant"
+        }
+        base : 0 seconds
+        immediate-first-attempt : true
+      }
     }
-    #user defined clients go here.
-    #redis-client {
-      #address : 127.0.0.1:6379
-      #name : redis
-      #fail-fast : true
-    #}
   }
 
   metrics {

--- a/colossus/src/main/scala/colossus/core/Connection.scala
+++ b/colossus/src/main/scala/colossus/core/Connection.scala
@@ -14,6 +14,7 @@ object ConnectionStatus {
   case object NotConnected extends ConnectionStatus
   case object Connected    extends ConnectionStatus
   case object Connecting   extends ConnectionStatus
+  case object Mixed        extends ConnectionStatus
 }
 
 /**

--- a/colossus/src/main/scala/colossus/core/RetryPolicy.scala
+++ b/colossus/src/main/scala/colossus/core/RetryPolicy.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration._
   * how it should try to reconnect if it's first attempt to connect fails.
   *
   * RetryPolicy acts as a factory for [[RetryIncident]], which is a per-incident
-  * manager of retries.  So everytime a user encounters a sitiation where an
+  * manager of retries.  So every time a user encounters a situation where an
   * operation needs to be retried, it should use the `RetryPolicy` create a new
   * incident, and use the incident until either the operation succeeds or the
   * incident indicates to stop retrying.

--- a/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpClient.scala
@@ -1,4 +1,5 @@
 package colossus.protocols.http
+
 import colossus.service._
 
 import scala.language.higherKinds
@@ -7,15 +8,13 @@ trait BaseHttpClient[M[_], B, P <: BaseHttp[B]] extends LiftedClient[P, M] {
 
   def ops: MessageOps[HttpRequestHead, B, P#Request] // = implicitly[MessageOps[HttpRequestHead, B, P#Request]]
 
-  protected lazy val hostHeader = clientConfig.map(config => {
-    HttpHeader(HttpHeaders.Host, config.address.getHostName)
-  })
+  protected lazy val hostHeader = HttpHeader(HttpHeaders.Host, address.getHostName)
 
   override def send(input: P#Request): M[P#Response] = {
     val headers = input.head.headers
     val decoratedRequest = headers.firstValue(HttpHeaders.Host) match {
       case Some(_) => input // Host header is already present.
-      case None    => hostHeader.map(header => ops.withHeader(input, header)).getOrElse(input)
+      case None    => ops.withHeader(input, hostHeader)
     }
     super.send(decoratedRequest)
   }

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -5,6 +5,7 @@ import colossus.metrics.TagMap
 import colossus.protocols.http.HttpClient.HttpClientLifter
 import colossus.service.{
   ClientFactories,
+  FutureClient,
   IrrecoverableError,
   ProcessingFailure,
   Protocol,
@@ -35,7 +36,8 @@ package object http {
 
   object Http extends ClientFactories[Http, HttpClient](HttpClientLifter) {
 
-    implicit lazy val clientFactory = ServiceClientFactory.basic("http", () => new StaticHttpClientCodec)
+    implicit lazy val clientFactory: FutureClient.BaseFactory[Http] =
+      ServiceClientFactory.basic("http", () => new StaticHttpClientCodec)
 
     class ServerDefaults {
       def errorResponse(error: ProcessingFailure[HttpRequest]) = error match {

--- a/colossus/src/main/scala/colossus/protocols/http/streaming/StreamingHttpClient.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/streaming/StreamingHttpClient.scala
@@ -18,18 +18,24 @@ object StreamingHttpClient {
   val client = new ClientFactory[StreamingHttp, Callback, StreamingHttpClient, WorkerRef] {
     def defaultName = "streaming-http-client"
 
-    def apply(config: ClientConfig)(implicit worker: WorkerRef): StreamingHttpClient = {
-      val client = new ServiceClient[StreamingHttp](config, worker.generateContext())
-      val handler = new UnbindHandler(
-        new Controller[Encoding.Client[StreamHttp]](
-          new HttpStreamClientController(client),
-          new StreamHttpClientCodec
-        ),
-        client
-      )
-      worker.worker ! WorkerCommand.Bind(handler)
-      new BasicLiftedClient(client, Some(config))(implicitly[AsyncBuilder[Callback, WorkerRef]].build(worker))
-      with StreamingHttpClient
+    override def apply(config: ClientConfig)(implicit worker: WorkerRef): StreamingHttpClient = {
+      if (config.address.size > 1) {
+        throw new Exception("Streaming http client not designed to be load balanced")
+      } else {
+        config.address.map { address =>
+          val client = new ServiceClient[StreamingHttp](address, config, worker.generateContext())
+          val handler = new UnbindHandler(
+            new Controller[Encoding.Client[StreamHttp]](
+              new HttpStreamClientController(client),
+              new StreamHttpClientCodec
+            ),
+            client
+          )
+          worker.worker ! WorkerCommand.Bind(handler)
+          new BasicLiftedClient(client, Some(config))(implicitly[AsyncBuilder[Callback, WorkerRef]].build(worker))
+            with StreamingHttpClient
+        }
+      }.head
     }
   }
 

--- a/colossus/src/main/scala/colossus/service/Async.scala
+++ b/colossus/src/main/scala/colossus/service/Async.scala
@@ -1,5 +1,7 @@
 package colossus.service
 
+import java.net.InetSocketAddress
+
 import scala.concurrent.Future
 import scala.language.higherKinds
 import colossus.IOSystem
@@ -13,10 +15,13 @@ trait Sender[P <: Protocol, M[_]] {
 
   def send(input: P#Request): M[P#Response]
 
-  def disconnect()
-  
+  def disconnect(): Unit
+
   def addInterceptor(interceptor: Interceptor[P]): Unit
 
+  def address(): InetSocketAddress
+
+  def update(addresses: Seq[InetSocketAddress]): Unit
 }
 
 /**

--- a/colossus/src/main/scala/colossus/service/LoadBalancer.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancer.scala
@@ -1,0 +1,157 @@
+package colossus.service
+
+import java.net.InetSocketAddress
+
+import colossus.core.RetryAttempt.{RetryIn, RetryNow, Stop}
+import colossus.core.{BackoffPolicy, ConnectionStatus, NoRetry, WorkerRef}
+import colossus.metrics.logging.ColossusLogging
+
+import scala.collection.mutable.ArrayBuffer
+import scala.util.{Failure, Success}
+
+private class LoadBalancer[P <: Protocol](
+    config: ClientConfig,
+    clientFactory: ServiceClientFactory[P],
+    permutationFactory: Seq[Client[P, Callback]] => PermutationGenerator[Client[P, Callback]])(
+    implicit worker: WorkerRef)
+    extends Client[P, Callback]
+    with ColossusLogging {
+
+  implicit val cbe: CallbackExecutor = worker.callbackExecutor
+
+  private var interceptors = Seq.empty[Interceptor[P]]
+
+  private var clients: Seq[Client[P, Callback]] = config.address.map(address => createClient(address))
+
+  private var permutations = permutationFactory(clients)
+
+  override def send(request: P#Request): Callback[P#Response] = {
+    config.requestRetry match {
+      case NoRetry =>
+        permutations.next().head.send(request)
+      case BackoffPolicy(_, _, _, maxTries, _) =>
+        if (clients.isEmpty) {
+          Callback.failed(new SendFailedException(0, new Exception("Empty client list!")))
+        } else {
+          val retryList = maxTries match {
+            case None =>
+              permutations.next().take(clients.size)
+            case Some(limit) =>
+              if (clients.size < limit) {
+                // this is very hacky, probably should rewrite PermutationGenerator to better support this behavior
+                val list = ArrayBuffer.empty[Client[P, Callback]]
+                while (list.size < limit) {
+                  list.appendAll(permutations.next().take(limit))
+                }
+                list.take(limit).toList
+              } else {
+                permutations.next().take(limit)
+              }
+          }
+
+          val retryIncident = config.requestRetry.start()
+
+          def go(next: Sender[P, Callback], list: Seq[Sender[P, Callback]]): Callback[P#Response] = {
+            next.send(request).recoverWith {
+              case throwable =>
+                list match {
+                  case head :: tail =>
+                    retryIncident.nextAttempt() match {
+                      case Stop =>
+                        Callback.failed(new SendFailedException(retryIncident.attempts + 1, throwable))
+                      case RetryNow =>
+                        go(head, tail)
+                      case RetryIn(time) =>
+                        if (time.toMillis == 0) {
+                          go(head, tail)
+                        } else {
+                          Callback.schedule(time)(go(head, tail))
+                        }
+                    }
+                  case Nil =>
+                    Callback.failed(new SendFailedException(retryIncident.attempts + 1, throwable))
+                }
+            }
+          }
+
+          go(retryList.head, retryList.tail)
+        }
+    }
+
+  }
+
+  override def disconnect(): Unit = {
+    clients.foreach(_.disconnect())
+  }
+
+  // this is fine on clients, but not sure it is useful on the load balancer; if this is just used for tests, maybe
+  // it should not be exposed
+  override def connectionStatus: Callback[ConnectionStatus] = {
+    Callback.sequence(clients.map(_.connectionStatus)).map { seq =>
+      seq.head match {
+        case Success(connectStatus) =>
+          if (seq.forall(_ == seq.head)) {
+            connectStatus
+          } else {
+            ConnectionStatus.Mixed
+          }
+        case Failure(exception) =>
+          ConnectionStatus.Mixed
+      }
+    }
+  }
+
+  override def address() = throw new NotImplementedError("Load balancer does not have an address")
+
+  override def addInterceptor(interceptor: Interceptor[P]): Unit = {
+    // save interceptors so they can be added when new clients need to be added
+    interceptors = interceptors :+ interceptor
+    clients.foreach(_.addInterceptor(interceptor))
+  }
+
+  override def update(addresses: Seq[InetSocketAddress]): Unit = {
+    val newSetup      = addresses.groupBy(a => a).mapValues(_.size)
+    val oldClientsMap = clients.groupBy(_.address())
+
+    val newClientsMap = newSetup.foldLeft(Map.empty[InetSocketAddress, Seq[Client[P, Callback]]]) {
+      case (aggregation, (address, newCount)) =>
+        val newClients = oldClientsMap.get(address) match {
+          case None =>
+            debug(s"[$address|$newCount] Adding $newCount client(s)")
+            (1 to newCount).map(_ => createClient(address))
+          case Some(oldClients) =>
+            if (oldClients.size == newCount) {
+              debug(s"[$address|$newCount] Keeping $newCount client(s)")
+              oldClients
+            } else if (oldClients.size > newCount) {
+              val (keepClients, killClients) = oldClients.splitAt(newCount)
+              killClients.foreach(_.disconnect())
+              debug(s"[$address|$newCount] Keeping ${keepClients.size} and killing ${killClients.size} client(s)")
+              keepClients
+            } else {
+              val clientsToCreate = newCount - oldClients.size
+              debug(s"[$address|$newCount] Adding $clientsToCreate client(s)")
+              oldClients ++ (1 to clientsToCreate).map(_ => createClient(address))
+            }
+        }
+
+        aggregation + (address -> newClients)
+    }
+
+    val leftovers = oldClientsMap -- newClientsMap.keys
+
+    leftovers.foreach {
+      case (address, deadClients) =>
+        debug(s"[$address|0] Killing ${deadClients.size} clients(s)")
+    }
+
+    clients = newClientsMap.values.flatten.toSeq
+    permutations = permutationFactory(clients)
+  }
+
+  private def createClient(address: InetSocketAddress): Client[P, Callback] = {
+    val client = clientFactory.createClient(config, address)
+    interceptors.foreach(interceptor => client.addInterceptor(interceptor))
+    client
+  }
+}

--- a/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancingClient.scala
@@ -6,6 +6,10 @@ import scala.reflect.ClassTag
 import java.net.InetSocketAddress
 import colossus.core.{WorkerItem, WorkerRef}
 
+trait PermutationGenerator[T] {
+  def next(): List[T]
+}
+
 /**
   * The PermutationGenerator creates permutations such that consecutive calls
   * are guaranteed to cycle though all items as the first element.
@@ -13,7 +17,9 @@ import colossus.core.{WorkerItem, WorkerRef}
   * This currently doesn't iterate through every possible permutation, but it
   * does evenly distribute 1st and 2nd tries...needs some more work
   */
-class PermutationGenerator[T: ClassTag](val seedlist: Seq[T]) extends Iterator[List[T]] {
+class PrinciplePermutationGenerator[T: ClassTag](val seedlist: Seq[T])
+    extends PermutationGenerator[T]
+    with Iterator[List[T]] {
   private val items: Array[T] = seedlist.toArray
 
   private var swapIndex = 1
@@ -72,9 +78,9 @@ class SendFailedException(tries: Int, finalCause: Throwable)
   * so setting maxTries to a very large number will mean that every client will
   * be tried once
   *
-  * TODO: does this need to actually be a WorkerItem anymore?
+  *
   */
-class LoadBalancingClient[P <: Protocol](
+@deprecated("Load balancer now built into client", "0.11.0") class LoadBalancingClient[P <: Protocol](
     worker: WorkerRef,
     generator: InetSocketAddress => Sender[P, Callback],
     maxTries: Int = Int.MaxValue,
@@ -88,7 +94,7 @@ class LoadBalancingClient[P <: Protocol](
       factory: ClientFactory[P, Callback, Sender[P, Callback], WorkerRef],
       maxTries: Int
   )(implicit worker: WorkerRef) = {
-    this(worker, address => factory(baseConfig.copy(address = address)), maxTries, addresses)
+    this(worker, address => factory(baseConfig.copy(address = Seq(address))), maxTries, addresses)
   }
 
   val context = worker.generateContext
@@ -99,12 +105,12 @@ class LoadBalancingClient[P <: Protocol](
 
   private val clients = collection.mutable.ArrayBuffer[Client]()
 
-  private var permutations = new PermutationGenerator(clients.map { _.client })
+  private var permutations = new PrinciplePermutationGenerator(clients.map { _.client })
 
   update(initialClients, true)
 
   private def regeneratePermutations() {
-    permutations = new PermutationGenerator(clients.map { _.client })
+    permutations = new PrinciplePermutationGenerator(clients.map { _.client })
   }
 
   private def addClient(address: InetSocketAddress, regen: Boolean): Unit = {
@@ -172,6 +178,11 @@ class LoadBalancingClient[P <: Protocol](
 
   override def receivedMessage(message: Any, sender: ActorRef) {}
 
-  // TODO: fix this
   override def addInterceptor(interceptor: Interceptor[P]): Unit = clients.foreach(_.client.addInterceptor(interceptor))
+
+  override def address(): InetSocketAddress = throw new NotImplementedError("Deprecated class")
+
+  override def update(addresses: Seq[InetSocketAddress]): Unit = {
+    update(addresses, allowDuplicates = false)
+  }
 }

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -33,7 +33,7 @@ import scala.util.{Failure, Success, Try}
   * @param maxResponseSize max allowed response size -- larger responses are dropped
   */
 case class ClientConfig(
-    address: InetSocketAddress,
+    address: Seq[InetSocketAddress],
     requestTimeout: Duration,
     name: MetricAddress,
     pendingBufferSize: Int = 500,
@@ -41,7 +41,8 @@ case class ClientConfig(
     failFast: Boolean = false,
     connectRetry: RetryPolicy = BackoffPolicy(50.milliseconds, BackoffMultiplier.Exponential(5.seconds)),
     idleTimeout: Duration = Duration.Inf,
-    maxResponseSize: DataSize = 1.MB
+    maxResponseSize: DataSize = 1.MB,
+    requestRetry: RetryPolicy = BackoffPolicy(0.milliseconds, BackoffMultiplier.Constant)
 )
 
 object ClientConfig {
@@ -66,7 +67,7 @@ object ClientConfig {
     */
   def load(config: Config): ClientConfig = {
     import colossus.metrics.ConfigHelpers._
-    val address            = config.getInetSocketAddress("address")
+    val address            = config.getInetSocketAddressList("address")
     val name               = config.getString("name")
     val requestTimeout     = config.getScalaDuration("request-timeout")
     val pendingBufferSize  = config.getInt("pending-buffer-size")
@@ -75,6 +76,8 @@ object ClientConfig {
     val connectRetryPolicy = RetryPolicy.fromConfig(config.getConfig("connect-retry-policy"))
     val idleTimeout        = config.getScalaDuration("idle-timeout")
     val maxResponseSize    = DataSize(config.getString("max-response-size"))
+    val requestRetry       = RetryPolicy.fromConfig(config.getConfig("request-retry-policy"))
+
     ClientConfig(address,
                  requestTimeout,
                  name,
@@ -83,7 +86,8 @@ object ClientConfig {
                  failFast,
                  connectRetryPolicy,
                  idleTimeout,
-                 maxResponseSize)
+                 maxResponseSize,
+                 requestRetry)
   }
 }
 
@@ -158,6 +162,7 @@ class UnbindHandler(ds: CoreDownstream, tail: HandlerTail) extends PipelineHandl
   * TODO: make underlying output controller data size configurable
   */
 class ServiceClient[P <: Protocol](
+    val address: InetSocketAddress,
     val config: ClientConfig,
     val context: Context
 )(implicit tagDecorator: TagDecorator[P] = TagDecorator.default[P])
@@ -228,7 +233,8 @@ class ServiceClient[P <: Protocol](
   private var retryIncident: Option[RetryIncident] = None
 
   //TODO way too application specific
-  private val hpTags: TagMap = Map("client_host" -> address.getHostName, "client_port" -> address.getPort.toString)
+  private val hpTags: TagMap =
+    Map("client_host" -> address.getHostName, "client_port" -> address.getPort.toString)
 
   private var interceptors = mutable.ListBuffer[Interceptor[P]]()
 
@@ -447,4 +453,7 @@ class ServiceClient[P <: Protocol](
   def disconnect() {
     connection.disconnect()
   }
+
+  override def update(addresses: Seq[InetSocketAddress]): Unit =
+    throw new NotImplementedError("Can not directly update service client")
 }

--- a/colossus/src/main/scala/colossus/service/ServiceClientPool.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClientPool.scala
@@ -18,7 +18,7 @@ class ServiceClientPool[T <: Sender[_, Callback]](val commonConfig: ClientConfig
 
   private def create(address: InetSocketAddress) = {
     val config = commonConfig.copy(
-      address = address
+      address = Seq(address)
     )
     val client = creator(config, worker)
     client

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -161,15 +161,21 @@ trait ClientFactory[P <: Protocol, M[_], +T <: Sender[P, M], E] {
 
   def apply(config: ClientConfig)(implicit env: E): T
 
+  def apply(hosts: Seq[InetSocketAddress])(implicit env: E): T = {
+    // TODO default request timeout should come from config
+    apply(hosts, 1.second)
+  }
+
   def apply(host: String, port: Int)(implicit env: E): T = {
+    // TODO default request timeout should come from config
     apply(host, port, 1.second)
   }
 
   def apply(host: String, port: Int, requestTimeout: Duration)(implicit env: E): T = {
-    apply(new InetSocketAddress(host, port), requestTimeout)
+    apply(Seq(new InetSocketAddress(host, port)), requestTimeout)
   }
 
-  def apply(address: InetSocketAddress, requestTimeout: Duration)(implicit env: E): T = {
+  def apply(address: Seq[InetSocketAddress], requestTimeout: Duration)(implicit env: E): T = {
     val config = ClientConfig(
       address = address,
       requestTimeout = requestTimeout,
@@ -179,31 +185,36 @@ trait ClientFactory[P <: Protocol, M[_], +T <: Sender[P, M], E] {
   }
 }
 
-trait ServiceClientFactory[P <: Protocol] extends ClientFactory[P, Callback, ServiceClient[P], WorkerRef] {
+trait ServiceClientFactory[P <: Protocol] extends ClientFactory[P, Callback, Client[P, Callback], WorkerRef] {
 
   implicit def clientTagDecorator: TagDecorator[P]
-  
+
   def connectionHandler(base: ServiceClient[P], codec: Codec[Encoding.Client[P]]): ClientConnectionHandler = {
     new UnbindHandler(new Controller[Encoding.Client[P]](base, codec), base)
   }
 
   def codecProvider: Codec.Client[P]
 
-  def apply(config: ClientConfig)(implicit worker: WorkerRef): ServiceClient[P] = {
+  def apply(config: ClientConfig)(implicit worker: WorkerRef): Client[P, Callback] = {
+    new LoadBalancer[P](config, this, new PrinciplePermutationGenerator[Client[P, Callback]](_))
+  }
+
+  def createClient(config: ClientConfig, address: InetSocketAddress)(
+      implicit worker: WorkerRef): Client[P, Callback] = {
     //TODO : binding a client needs to be split up from creating the connection handler
     // we should make a method called "create" the abstract method, and have
     // this apply call it, then move this to a more generic parent type
-    val base    = new ServiceClient[P](config, worker.generateContext())
+    val base    = new ServiceClient[P](address, config, worker.generateContext())
     val handler = connectionHandler(base, codecProvider)
     worker.worker ! WorkerCommand.Bind(handler)
     base
   }
-
 }
 
 object ServiceClientFactory {
 
-  def basic[P <: Protocol](name: String, provider: () => Codec.Client[P],
+  def basic[P <: Protocol](name: String,
+                           provider: () => Codec.Client[P],
                            tagDecorator: TagDecorator[P] = TagDecorator.default[P]) = new ServiceClientFactory[P] {
 
     def defaultName = name
@@ -270,19 +281,20 @@ abstract class ClientFactories[P <: Protocol, T[M[_]] <: Sender[P, M]](lifter: C
 
 trait LiftedClient[P <: Protocol, M[_]] extends Sender[P, M] {
 
+  def address: InetSocketAddress = client.address()
   def clientConfig: Option[ClientConfig]
   def client: Sender[P, M]
   implicit val async: Async[M]
 
-  def send(input: P#Request): M[P#Response] = client.send(input)
+  override def send(input: P#Request): M[P#Response] = client.send(input)
 
   protected def executeAndMap[T](i: P#Request)(f: P#Response => M[T]) = async.flatMap(send(i))(f)
 
-  def addInterceptor(interceptor: Interceptor[P]): Unit = client.addInterceptor(interceptor)
+  override def addInterceptor(interceptor: Interceptor[P]): Unit = client.addInterceptor(interceptor)
 
-  def disconnect() {
-    client.disconnect()
-  }
+  override def disconnect(): Unit = client.disconnect()
+
+  override def update(addresses: Seq[InetSocketAddress]): Unit = client.update(addresses)
 
 }
 


### PR DESCRIPTION
Service client with load balancer and retries built in! Includes tests and doc changes.

Overall I feel like this is moving in the correct direction, but I think it can be cleaned up in future PRs. My problem is that we are squishing different functionality into the client trait. I think what we currently call clients, should be renamed connections. A client would then contain one-to-many connections, which it can manage. You can conceive that if you want to skip the client and just talk to the connection, that should be possible. Anyways, that can wait for another day.

@aliyakamercan @jlbelmonte @amotamed @DanSimon 



