### PR TITLE
Colossus root project name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ lazy val ExamplesSettings = Seq(
   )
 )
 
-lazy val RootProject = Project(id = "root", base = file("."))
+lazy val RootProject = Project(id = "colossus-root", base = file("."))
   .settings(noPubSettings: _*)
   .configs(IntegrationTest)
   .dependsOn(ColossusProject)


### PR DESCRIPTION
Change the root level project to `colossus-root` so it doesn't just show up as `root` in IntelliJ menu.

@aliyakamercan @jlbelmonte @amotamed @DanSimon 