### PR TITLE
Simplify redis API

### DIFF
--- a/colossus-docs/src/main/scala/RedisClient.scala
+++ b/colossus-docs/src/main/scala/RedisClient.scala
@@ -8,8 +8,6 @@ import colossus.protocols.http.{HttpServer, Initializer, RequestHandler}
 import colossus.protocols.redis.Redis
 import colossus.service.GenRequestHandler.PartialHandler
 
-import scala.util.{Failure, Success}
-
 object RedisClient extends App {
 
   implicit val actorSystem = ActorSystem()
@@ -21,23 +19,22 @@ object RedisClient extends App {
 
       val redisClient = Redis.client("localhost", 6379)
 
-      override def onConnect = serverContext => new RequestHandler(serverContext) {
-        override def handle: PartialHandler[Http] = {
+      override def onConnect =
+        serverContext =>
+          new RequestHandler(serverContext) {
+            override def handle: PartialHandler[Http] = {
+              case req @ Get on Root / "get" / key =>
+                redisClient.get(ByteString(key)).map {
+                  case Some(data) => req.ok(data.utf8String)
+                  case None       => req.notFound(s"Key $key was not found")
+                }
 
-          case req @ Get on Root / "get" / key => {
-            redisClient.get(ByteString(key)).mapTry {
-              case Success(data) => Success(req.ok(data.utf8String))
-              case Failure(_)    => Success(req.notFound(s"Key $key was not found"))
+              case req @ Get on Root / "set" / key / value =>
+                redisClient.set(ByteString(key), ByteString(value)).map { _ =>
+                  req.ok("OK")
+                }
             }
-          }
-
-          case req @ Get on Root / "set" / key / value => {
-            redisClient.set(ByteString(key), ByteString(value)).map { _ =>
-              req.ok("OK")
-            }
-          }
         }
-      }
     }
   }
   // #redis-client

--- a/colossus-docs/src/main/scala/RedisClientExample.scala
+++ b/colossus-docs/src/main/scala/RedisClientExample.scala
@@ -19,17 +19,20 @@ object RedisClientExample extends App {
 
       val redisClient = Redis.client("localhost", 6379)
 
-      override def onConnect = serverContext => new RequestHandler(serverContext) {
-        override def handle: PartialHandler[Http] = {
+      override def onConnect =
+        serverContext =>
+          new RequestHandler(serverContext) {
+            override def handle: PartialHandler[Http] = {
 
-          case request @ Get on Root / "get" / key => {
-            val asyncResult = redisClient.get(ByteString("1"))
-            asyncResult.map {
-              case bytes => request.ok(bytes.utf8String)
+              case request @ Get on Root / "get" / key => {
+                val asyncResult = redisClient.get(ByteString("1"))
+                asyncResult.map {
+                  case Some(bytes) => request.ok(bytes.utf8String)
+                  case None        => request.ok("Not found")
+                }
+              }
             }
-          }
         }
-      }
     }
   }
   // #example

--- a/colossus-examples/src/main/scala/colossus.examples/HttpExample.scala
+++ b/colossus-examples/src/main/scala/colossus.examples/HttpExample.scala
@@ -42,8 +42,9 @@ object HttpExample {
       }
 
       case req @ Get on Root / "get" / key =>
-        redis.get(ByteString(key)).map { x =>
-          req.ok(x.utf8String)
+        redis.get(ByteString(key)).map {
+          case Some(value) => req.ok(value.utf8String)
+          case None        => req.ok("No value found")
         }
 
       case req @ Get on Root / "set" / key / value =>

--- a/colossus-tests/src/it/scala/colossus/RedisHashITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/RedisHashITSpec.scala
@@ -2,7 +2,7 @@ package colossus
 
 import akka.util.ByteString
 
-class RedisHashITSpec extends BaseRedisITSpec{
+class RedisHashITSpec extends BaseRedisITSpec {
 
   val keyPrefix = "colossusITHash"
 
@@ -11,9 +11,9 @@ class RedisHashITSpec extends BaseRedisITSpec{
     val field1 = ByteString("field")
     val field2 = ByteString("field2")
     val field3 = ByteString("field3")
-    val val1 = ByteString("value1")
-    val val2 = ByteString("value2")
-    val val3 = ByteString("value3")
+    val val1   = ByteString("value1")
+    val val2   = ByteString("value2")
+    val val3   = ByteString("value3")
 
     "hdel" in {
       val delKey = getKey()
@@ -23,10 +23,10 @@ class RedisHashITSpec extends BaseRedisITSpec{
         _ <- client.hset(delKey, field3, val3)
         x <- client.hdel(delKey, field1, field2)
         y <- client.hget(delKey, field3) //should be unaffected
-        z <- client.hgetOption(delKey, field1) //snould be none, since it was deleted
-      } yield { (x,y,z) }
+        z <- client.hget(delKey, field1) //snould be none, since it was deleted
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((2, val3, None))
+      res.futureValue must be((2, Some(val3), None))
     }
 
     "hexists" in {
@@ -35,9 +35,9 @@ class RedisHashITSpec extends BaseRedisITSpec{
         x <- client.hexists(exKey, field1) //false, doesn't exist yet
         y <- client.hset(exKey, field1, val1)
         z <- client.hexists(exKey, field1) //true, now exists
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((false, true, true))
+      res.futureValue must be((false, true, true))
     }
 
     "hget && hset" in {
@@ -45,20 +45,20 @@ class RedisHashITSpec extends BaseRedisITSpec{
       val res = for {
         x <- client.hset(setKey, field1, val1)
         y <- client.hget(setKey, field1)
-      } yield { (x,y) }
+      } yield { (x, y) }
 
-      res.futureValue must be ((true, val1))
+      res.futureValue must be((true, Some(val1)))
     }
 
     "hgetOption && hset" in {
       val setKey = getKey()
       val res = for {
-        x <- client.hgetOption(setKey, field1) //none, doesn't exist yet
+        x <- client.hget(setKey, field1) //none, doesn't exist yet
         y <- client.hset(setKey, field1, val1)
-        z <- client.hgetOption(setKey, field1) //should now return a value
-      } yield { (x,y, z) }
+        z <- client.hget(setKey, field1) //should now return a value
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((None, true, Some(val1)))
+      res.futureValue must be((None, true, Some(val1)))
     }
 
     "hgetall" in {
@@ -69,10 +69,10 @@ class RedisHashITSpec extends BaseRedisITSpec{
         _ <- client.hset(setKey, field2, val2)
         _ <- client.hset(setKey, field3, val3)
         y <- client.hgetall(setKey)
-      } yield { (x,y) }
+      } yield { (x, y) }
 
       val expected = Seq(field1, val1, field2, val2, field3, val3)
-      res.futureValue must be ((Nil, expected))
+      res.futureValue must be((Nil, expected))
     }
 
     "hincrby" in {
@@ -81,9 +81,9 @@ class RedisHashITSpec extends BaseRedisITSpec{
         x <- client.hincrby(key, field1, 10) //should create hash
         y <- client.hincrby(key, field1, 10) //should increment value
         z <- client.hget(key, field1)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((10, 20, ByteString("20")))
+      res.futureValue must be((10, 20, Some(ByteString("20"))))
 
     }
 
@@ -93,9 +93,9 @@ class RedisHashITSpec extends BaseRedisITSpec{
         x <- client.hincrbyfloat(key, field1, 10.5) //should create hash
         y <- client.hincrbyfloat(key, field1, 10.5) //should increment value
         z <- client.hget(key, field1)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((10.5, 21.0, ByteString("21")))
+      res.futureValue must be((10.5, 21.0, Some(ByteString("21"))))
 
     }
 
@@ -107,10 +107,10 @@ class RedisHashITSpec extends BaseRedisITSpec{
         _ <- client.hset(setKey, field2, val2)
         _ <- client.hset(setKey, field3, val3)
         y <- client.hkeys(setKey)
-      } yield { (x,y) }
+      } yield { (x, y) }
 
       val expected = Seq(field1, field2, field3)
-      res.futureValue must be ((Nil, expected))
+      res.futureValue must be((Nil, expected))
     }
 
     "hlen" in {
@@ -121,9 +121,9 @@ class RedisHashITSpec extends BaseRedisITSpec{
         _ <- client.hset(setKey, field2, val2)
         _ <- client.hset(setKey, field3, val3)
         y <- client.hlen(setKey)
-      } yield { (x,y) }
+      } yield { (x, y) }
 
-      res.futureValue must be ((0, 3))
+      res.futureValue must be((0, 3))
     }
 
     "hmget" in {
@@ -133,9 +133,9 @@ class RedisHashITSpec extends BaseRedisITSpec{
         _ <- client.hset(setKey, field1, val1)
         _ <- client.hset(setKey, field2, val2)
         y <- client.hmget(setKey, field1, field2, field3)
-      } yield { (x,y) }
+      } yield { (x, y) }
 
-      res.futureValue must be ((Seq(None, None, None), Seq(Some(val1), Some(val2), None)))
+      res.futureValue must be((Seq(None, None, None), Seq(Some(val1), Some(val2), None)))
     }
 
     "hmset" in {
@@ -146,7 +146,7 @@ class RedisHashITSpec extends BaseRedisITSpec{
         y <- client.hmget(setKey, field1, field2, field3)
       } yield { y }
 
-      res.futureValue must be (Seq(Some(val2), None, Some(val3)))
+      res.futureValue must be(Seq(Some(val2), None, Some(val3)))
     }
 
     "hsetnx" in {
@@ -154,11 +154,11 @@ class RedisHashITSpec extends BaseRedisITSpec{
       val res = for {
         w <- client.hsetnx(setnxKey, field1, val1) //should create if it doesn't exist
         x <- client.hget(setnxKey, field1)
-        y <- client.hsetnx(setnxKey, field1, val2)  //should not do anything
+        y <- client.hsetnx(setnxKey, field1, val2) //should not do anything
         z <- client.hget(setnxKey, field1)
-      } yield { (w,x,y,z) }
+      } yield { (w, x, y, z) }
 
-      res.futureValue must be ((true, val1, false, val1))
+      res.futureValue must be((true, Some(val1), false, Some(val1)))
     }
 
     "hvals" in {
@@ -169,23 +169,10 @@ class RedisHashITSpec extends BaseRedisITSpec{
         _ <- client.hset(setKey, field2, val2)
         _ <- client.hset(setKey, field3, val3)
         y <- client.hvals(setKey)
-      } yield { (x,y) }
+      } yield { (x, y) }
 
       val expected = Seq(val1, val2, val3)
-      res.futureValue must be ((Nil, expected))
+      res.futureValue must be((Nil, expected))
     }
-
-    /*"hstrlen" in {
-      val key = getKey()("colIThstrlen")
-      val res = for {
-        x <- client.hstrlen(key, field1)
-        _ <- client.hset(key, field1, val1)
-        y <- client.hstrlen(key, field1)
-      } yield { (x,y) }
-
-      res.futureValue must be (0, 6)
-    }*/
-
   }
-
 }

--- a/colossus-tests/src/it/scala/colossus/RedisHashITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/RedisHashITSpec.scala
@@ -23,7 +23,7 @@ class RedisHashITSpec extends BaseRedisITSpec {
         _ <- client.hset(delKey, field3, val3)
         x <- client.hdel(delKey, field1, field2)
         y <- client.hget(delKey, field3) //should be unaffected
-        z <- client.hget(delKey, field1) //snould be none, since it was deleted
+        z <- client.hget(delKey, field1) //should be none, since it was deleted
       } yield { (x, y, z) }
 
       res.futureValue must be((2, Some(val3), None))

--- a/colossus-tests/src/it/scala/colossus/RedisITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/RedisITSpec.scala
@@ -21,9 +21,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
       val res = for {
         x <- client.append(appKey, value) //should create if key doesn't exist
         y <- client.append(appKey, value) //should append
-      } yield { (x,y) }
+      } yield { (x, y) }
 
-      res.futureValue must be ((5,10))
+      res.futureValue must be((5, 10))
     }
 
     "decr" in {
@@ -33,9 +33,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.decr(key) //should create if key doesn't exist
         y <- client.decr(key)
         z <- client.get(key)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((-1, -2, ByteString("-2")))
+      res.futureValue must be((-1, -2, Some(ByteString("-2"))))
     }
 
     "decrby" in {
@@ -45,9 +45,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.decrBy(key, 3) //should create if key doesn't exist
         y <- client.decrBy(key, 3)
         z <- client.get(key)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((-3, -6, ByteString("-6")))
+      res.futureValue must be((-3, -6, Some(ByteString("-6"))))
 
     }
 
@@ -58,9 +58,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         w <- client.del(delKey)
         x <- client.set(delKey, value)
         y <- client.del(delKey)
-      } yield { (w,x,y) }
+      } yield { (w, x, y) }
 
-      res.futureValue must be ((0, true, 1))
+      res.futureValue must be((0, true, 1))
     }
 
     "exists" in {
@@ -69,33 +69,33 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.exists(exKey)
         y <- client.set(exKey, value)
         z <- client.exists(exKey)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((false, true, true))
+      res.futureValue must be((false, true, true))
     }
 
     "expire" in {
       val key = getKey()
-      val res = for{
-        x <- client.expire(key, 1.second) //doesn't exist, should get false
-        y <- client.set(key, value) //set key
-        z <- client.expire(key, 10.seconds) //create expiration
-        ttl <- client.ttl(key) //get ttl
-      } yield { (x,y,z,ttl >= 0) }
+      val res = for {
+        x   <- client.expire(key, 1.second)   //doesn't exist, should get false
+        y   <- client.set(key, value)         //set key
+        z   <- client.expire(key, 10.seconds) //create expiration
+        ttl <- client.ttl(key)                //get ttl
+      } yield { (x, y, z, ttl >= 0) }
 
       //not checking for the actual TTL, that value will be hard to pin down, just its existence is good
       res.futureValue must be((false, true, true, true))
     }
 
     "expireat" in {
-      val key = getKey()
+      val key      = getKey()
       val tomorrow = (System.currentTimeMillis() / 1000) + 86400
-      val res = for{
-        x <- client.expireat(key, tomorrow)
-        y <- client.set(key, value)
-        z <- client.expireat(key, tomorrow)
+      val res = for {
+        x   <- client.expireat(key, tomorrow)
+        y   <- client.set(key, value)
+        z   <- client.expireat(key, tomorrow)
         ttl <- client.ttl(key)
-      } yield { (x,y,z, ttl >= 0) }
+      } yield { (x, y, z, ttl >= 0) }
 
       //not checking for the actual TTL, that value will be hard to pin down, just its existence is good
       res.futureValue must be((false, true, true, true))
@@ -106,20 +106,20 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
       val res = for {
         x <- client.set(setKey, value)
         y <- client.get(setKey)
-      } yield { (x,y) }
+      } yield { (x, y) }
 
-      res.futureValue must be ((true, value))
+      res.futureValue must be((true, Some(value)))
     }
 
     "getOption && set" in {
       val setKey = getKey()
       val res = for {
-        x <- client.getOption(setKey)
+        x <- client.get(setKey)
         y <- client.set(setKey, value)
-        z <- client.getOption(setKey)
-      } yield { (x,y, z) }
+        z <- client.get(setKey)
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((None, true, Some(value)))
+      res.futureValue must be((None, true, Some(value)))
     }
 
     "getrange" in {
@@ -128,9 +128,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         w <- client.getrange(setKey, 0, 1)
         x <- client.set(setKey, value)
         y <- client.getrange(setKey, 0, 1)
-      } yield { (w,x,y) }
+      } yield { (w, x, y) }
 
-      res.futureValue must be ((ByteString(""), true, ByteString("va")))
+      res.futureValue must be((ByteString(""), true, ByteString("va")))
     }
 
     "getset" in {
@@ -140,23 +140,10 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         y <- client.getset(key, ByteString("value2"))
         z <- client.get(key)
       } yield {
-          (x,y,z)
-        }
+        (x, y, z)
+      }
 
-      res.futureValue must be ((true, value, ByteString("value2")))
-    }
-
-    "getsetOption" in {
-      val key = getKey()
-      val res = for {
-        x <- client.getsetOption(key, value)
-        y <- client.getsetOption(key, ByteString("value2"))
-        z <- client.get(key)
-      } yield {
-          (x,y,z)
-        }
-
-      res.futureValue must be ((None, Some(value), ByteString("value2")))
+      res.futureValue must be((true, Some(value), Some(ByteString("value2"))))
     }
 
     "incr" in {
@@ -166,9 +153,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.incr(key)
         y <- client.incr(key)
         z <- client.get(key)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((1,2, ByteString("2")))
+      res.futureValue must be((1, 2, Some(ByteString("2"))))
     }
 
     "incrby" in {
@@ -177,9 +164,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.incrby(key, 10)
         y <- client.incrby(key, 10)
         z <- client.get(key)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((10, 20, ByteString("20")))
+      res.futureValue must be((10, 20, Some(ByteString("20"))))
 
     }
 
@@ -189,9 +176,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.incrbyfloat(key, 10.25)
         y <- client.incrbyfloat(key, 10.25)
         z <- client.get(key)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((10.25, 20.5, ByteString("20.5")))
+      res.futureValue must be((10.25, 20.5, Some(ByteString("20.5"))))
     }
 
     "keys" in {
@@ -202,9 +189,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         _ <- client.set(key2, value)
         x <- client.keys(ByteString("colossusKeysKeysIT*"))
       } yield {
-          x
-        }
-      res.futureValue.toSet must be (Set(key1, key2))
+        x
+      }
+      res.futureValue.toSet must be(Set(key1, key2))
     }
 
     "mget" in {
@@ -218,7 +205,7 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
       } yield {
         x
       }
-      res.futureValue must be (Seq(Some(value), Some(value), None))
+      res.futureValue must be(Seq(Some(value), Some(value), None))
     }
 
     "mset" in {
@@ -228,10 +215,10 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.mset(key1, value, key2, value)
         y <- client.mget(key1, key2)
       } yield {
-          (x,y)
-        }
+        (x, y)
+      }
 
-      res.futureValue must be ((true, Seq(Some(value), Some(value))))
+      res.futureValue must be((true, Seq(Some(value), Some(value))))
     }
 
     "msetnx" in {
@@ -243,8 +230,8 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         y <- client.msetnx(key1, value, key3, value) //should not work, one key is already set
         z <- client.mget(key1, key2, key3)
       } yield {
-          (x,y,z)
-        }
+        (x, y, z)
+      }
 
       res.futureValue must be((true, false, Seq(Some(value), Some(value), None)))
     }
@@ -253,39 +240,39 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
 
       val key1 = getKey()
       val res = for {
-        w <- client.persist(key1) //non existent, should be false
+        w <- client.persist(key1)                  //non existent, should be false
         x <- client.setex(key1, value, 10.minutes) //set value
-        y <- client.persist(key1) //should remove ttl
-        z <- client.ttl(key1)  //should not be set
+        y <- client.persist(key1)                  //should remove ttl
+        z <- client.ttl(key1)                      //should not be set
       } yield {
-          (w,x,y,z >= 0)
-        }
+        (w, x, y, z >= 0)
+      }
 
-      res.futureValue must be ((false, true, true, false))
+      res.futureValue must be((false, true, true, false))
     }
 
     "pexpire" in {
       val key = getKey()
-      val res = for{
-        x <- client.pexpire(key, 1.second) //doesn't exist, should get false
-        y <- client.set(key, value) //set key
-        z <- client.pexpire(key, 10.seconds) //create expiration
-        ttl <- client.ttl(key) //get ttl
-      } yield { (x,y,z,ttl >= 0) }
+      val res = for {
+        x   <- client.pexpire(key, 1.second)   //doesn't exist, should get false
+        y   <- client.set(key, value)          //set key
+        z   <- client.pexpire(key, 10.seconds) //create expiration
+        ttl <- client.ttl(key)                 //get ttl
+      } yield { (x, y, z, ttl >= 0) }
 
       //not checking for the actual TTL, that value will be hard to pin down, just its existence is good
       res.futureValue must be((false, true, true, true))
     }
 
     "pexpireat" in {
-      val key = getKey()
-      val tomorrow = (System.currentTimeMillis()) + 86400
-      val res = for{
-        x <- client.pexpireat(key, tomorrow)
-        y <- client.set(key, value)
-        z <- client.pexpireat(key, tomorrow)
+      val key      = getKey()
+      val tomorrow = System.currentTimeMillis() + 86400
+      val res = for {
+        x   <- client.pexpireat(key, tomorrow)
+        y   <- client.set(key, value)
+        z   <- client.pexpireat(key, tomorrow)
         ttl <- client.ttl(key)
-      } yield { (x,y,z, ttl >= 0) }
+      } yield { (x, y, z, ttl >= 0) }
 
       //not checking for the actual TTL, that value will be hard to pin down, just its existence is good
       res.futureValue must be((false, true, true, true))
@@ -298,9 +285,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.psetex(setexKey, value, 10.seconds)
         y <- client.get(setexKey)
         z <- client.ttl(setexKey) //can't test for exact value
-      } yield { (w >= 0,x,y,z >= 0) }
+      } yield { (w >= 0, x, y, z >= 0) }
 
-      res.futureValue must be ((false, true, value, true))
+      res.futureValue must be((false, true, Some(value), true))
     }
 
     "pttl" in {
@@ -310,13 +297,13 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.setex(key, value, 10.seconds)
         y <- client.get(key)
         z <- client.pttl(key) //can't test for exact value
-      } yield { (w >= 0,x,y,z >= 0) }
+      } yield { (w >= 0, x, y, z >= 0) }
 
-      res.futureValue must be ((false, true, value, true))
+      res.futureValue must be((false, true, Some(value), true))
     }
 
     "randomkey" in {
-      val key = getKey()
+      val key  = getKey()
       val key2 = getKey()
       val res = for {
         _ <- client.mset(key, value, key2, value)
@@ -324,25 +311,25 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
       } yield {
         x.isDefined
       }
-      res.futureValue must be (true)
+      res.futureValue must be(true)
     }
 
     "rename" in {
-      val key = getKey()
+      val key  = getKey()
       val key2 = getKey()
       val res = for {
         _ <- client.set(key, value)
         x <- client.rename(key, key2)
         y <- client.mget(key, key2)
       } yield {
-          (x, y)
-        }
+        (x, y)
+      }
 
       res.futureValue must be((true, Seq(None, Some(value))))
     }
 
     "renamenx" in {
-      val key = getKey()
+      val key  = getKey()
       val key2 = getKey()
       val key3 = getKey()
       val res = for {
@@ -351,8 +338,8 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         y <- client.renamenx(key, key3)
         z <- client.mget(key, key2, key3)
       } yield {
-          (x, y, z)
-        }
+        (x, y, z)
+      }
 
       res.futureValue must be((false, true, Seq(None, Some(value), Some(value))))
     }
@@ -363,25 +350,25 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
     }
 
     "set (with NX)" in {
-      val key = getKey()
+      val key  = getKey()
       val key2 = getKey()
       val res = for {
         x <- client.set(key, value)
         y <- client.set(key, value, notExists = true)
         z <- client.set(key2, value, notExists = true)
       } yield (x, y, z)
-      res.futureValue must be ((true, false, true))
+      res.futureValue must be((true, false, true))
     }
 
     "set (with EX)" in {
-      val key = getKey()
+      val key  = getKey()
       val key2 = getKey()
       val res = for {
         x <- client.set(key, value)
         y <- client.set(key, value, exists = true)
         z <- client.set(key2, value, exists = true)
       } yield (x, y, z)
-      res.futureValue must be ((true, true, false))
+      res.futureValue must be((true, true, false))
     }
 
     "set (with ttl)" in {
@@ -390,7 +377,7 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.set(key, value, ttl = 10.seconds)
         y <- client.ttl(key)
       } yield (x, y >= 0 && y <= 10)
-      res.futureValue must be ((true, true))
+      res.futureValue must be((true, true))
     }
 
     "setnx" in {
@@ -400,9 +387,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.setnx(setnxKey, value)
         y <- client.get(setnxKey)
         z <- client.setnx(setnxKey, value)
-      } yield { (x,y,z) }
+      } yield { (x, y, z) }
 
-      res.futureValue must be ((true, value, false))
+      res.futureValue must be((true, Some(value), false))
     }
 
     "setex && ttl" in {
@@ -412,9 +399,9 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         x <- client.setex(setexKey, value, 10.seconds)
         y <- client.get(setexKey)
         z <- client.ttl(setexKey) //can't test for exact value
-      } yield { (w >= 0,x,y,z >= 0) }
+      } yield { (w >= 0, x, y, z >= 0) }
 
-      res.futureValue must be ((false, true, value, true))
+      res.futureValue must be((false, true, Some(value), true))
     }
 
     "strlen" in {
@@ -423,23 +410,24 @@ class RedisITSpec extends BaseRedisITSpec with Eventually {
         w <- client.strlen(strlenKey)
         x <- client.set(strlenKey, value)
         y <- client.strlen(strlenKey)
-      } yield { (w,x,y) }
+      } yield { (w, x, y) }
 
-      res.futureValue must be (0, true, 5)
+      res.futureValue must be(0, true, 5)
     }
 
     "generic command" in {
-      client.send(Command.c("DBSIZE")).map{
+      client.send(Command.c("DBSIZE")).map {
         case IntegerReply(x) => //sweet
-        case other => throw new Exception(s"bad response! $other")
+        case other           => throw new Exception(s"bad response! $other")
       }
     }
-    
+
     "tag requests with operation" in {
       client.set(getKey(), value).futureValue
-      
+
       eventually {
-        val requests = metricSystem.collectionIntervals(1.second)
+        val requests = metricSystem
+          .collectionIntervals(1.second)
           .last(MetricAddress("redis/requests/count"))
 
         assert(requests.nonEmpty)

--- a/colossus-tests/src/it/scala/colossus/RedisListITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/RedisListITSpec.scala
@@ -2,11 +2,11 @@ package colossus
 
 import akka.util.ByteString
 
-class RedisListITSpec extends BaseRedisITSpec{
+class RedisListITSpec extends BaseRedisITSpec {
 
   val keyPrefix = "colossusITList"
-  val lValue = ByteString("value")
-  val lValue2 = ByteString("value2")
+  val lValue    = ByteString("value")
+  val lValue2   = ByteString("value2")
 
   "Redis List commands" should {
 
@@ -14,30 +14,30 @@ class RedisListITSpec extends BaseRedisITSpec{
       val key = getKey()
 
       val res = for {
-        w <- client.lindexOption(key, 0) //non existent key check
+        w <- client.lindex(key, 0)     //non existent key check
         _ <- client.lpush(key, lValue) //create list
-        x <- client.lindex(key, 0) //should get lValue
-        y <- client.lindexOption(key, 0) //should get lValue as option
-        z <- client.lindexOption(key, 1) //out of bounds should be None
+        x <- client.lindex(key, 0)     //should get lValue
+        y <- client.lindex(key, 0)     //should get lValue as option
+        z <- client.lindex(key, 1)     //out of bounds should be None
       } yield {
-          (w,x,y,z)
-        }
+        (w, x, y, z)
+      }
 
-      res.futureValue must be ((None, lValue, Some(lValue), None))
+      res.futureValue must be((None, Some(lValue), Some(lValue), None))
     }
 
     "linsert" in {
       val key = getKey()
 
       val res = for {
-        _ <- client.lpush(key, lValue) //create list
+        _ <- client.lpush(key, lValue)                  //create list
         w <- client.linsertBefore(key, lValue, lValue2) //insert value2 before value1
-        x <- client.lindex(key, 0) //should be lValue2
-      }yield {
-          (w,x)
-        }
+        x <- client.lindex(key, 0)                      //should be lValue2
+      } yield {
+        (w, x)
+      }
 
-      res.futureValue must be ((2, lValue2))
+      res.futureValue must be((2, Some(lValue2)))
     }
 
     "llen" in {
@@ -47,25 +47,25 @@ class RedisListITSpec extends BaseRedisITSpec{
         w <- client.llen(key) //non existent list should be 0
         _ <- client.lpush(key, lValue, lValue2) //populate list
         x <- client.llen(key)
-      }yield {
-          (w,x)
-        }
+      } yield {
+        (w, x)
+      }
 
-      res.futureValue mustBe ((0,2))
+      res.futureValue mustBe ((0, 2))
     }
 
     "lpop" in {
       val key = getKey()
 
       val res = for {
-        w <- client.lpopOption(key) //shouldn't work on an empty key
+        w <- client.lpop(key) //shouldn't work on an empty key
         _ <- client.lpush(key, lValue, lValue2)
         x <- client.lpop(key) //should be lValue2, see redis doc on lpush
       } yield {
-          (w,x)
-        }
+        (w, x)
+      }
 
-      res.futureValue must be((None, lValue2))
+      res.futureValue must be((None, Some(lValue2)))
 
     }
 
@@ -75,39 +75,39 @@ class RedisListITSpec extends BaseRedisITSpec{
       val res = for {
         w <- client.lpush(key, lValue, lValue2) //lpush on non existent list should create
         x <- client.lpush(key, lValue2, lValue) //push some more, returns length
-        y <- client.lrange(key, 0,3) //push some more, returns length
+        y <- client.lrange(key, 0, 3)           //push some more, returns length
       } yield {
-          (w,x,y)
-        }
+        (w, x, y)
+      }
 
-      res.futureValue must be((2,4, Seq(lValue, lValue2, lValue2, lValue)))
+      res.futureValue must be((2, 4, Seq(lValue, lValue2, lValue2, lValue)))
     }
 
     "lpushx" in {
       val key = getKey()
 
       val res = for {
-        w <- client.lpushx(key, lValue) //lpushx on non existent list should not create
-        x <- client.lpush(key, lValue) //push stuff
+        w <- client.lpushx(key, lValue)  //lpushx on non existent list should not create
+        x <- client.lpush(key, lValue)   //push stuff
         y <- client.lpushx(key, lValue2) //pushx should work now
-        z <- client.lrange(key, 0,1) //push some more, returns length
+        z <- client.lrange(key, 0, 1)    //push some more, returns length
       } yield {
-          (w,x,y,z)
-        }
+        (w, x, y, z)
+      }
 
-      res.futureValue must be((0,1,2,Seq(lValue2, lValue)))
+      res.futureValue must be((0, 1, 2, Seq(lValue2, lValue)))
     }
 
     "lrange" in {
       val key = getKey()
 
       val res = for {
-        w <- client.lrange(key, 0, 0) //should be empty
+        w <- client.lrange(key, 0, 0)                   //should be empty
         _ <- client.lpush(key, lValue, lValue2, lValue) //push stuff
-        x <- client.lrange(key, 0,1) //get list
+        x <- client.lrange(key, 0, 1)                   //get list
       } yield {
-          (w,x)
-        }
+        (w, x)
+      }
 
       res.futureValue must be((Nil, Seq(lValue, lValue2)))
     }
@@ -119,11 +119,11 @@ class RedisListITSpec extends BaseRedisITSpec{
         _ <- client.lpush(key, lValue, lValue, lValue, lValue)
         x <- client.lrem(key, 2, lValue) //this should remove 2 copies of lValue
         y <- client.llen(key) //should now be 2
-      }yield {
-          (x,y)
-        }
+      } yield {
+        (x, y)
+      }
 
-      res.futureValue must be ((2,2))
+      res.futureValue must be((2, 2))
     }
 
     "lset" in {
@@ -134,13 +134,12 @@ class RedisListITSpec extends BaseRedisITSpec{
         _ <- client.lset(key, 1, lValue2)
         x <- client.lindex(key, 1)
 
-      }yield{
-          x
-        }
+      } yield {
+        x
+      }
 
-      res.futureValue must be (lValue2)
+      res.futureValue must be(Some(lValue2))
     }
-
 
     "ltrim" in {
       val key = getKey()
@@ -150,45 +149,45 @@ class RedisListITSpec extends BaseRedisITSpec{
         _ <- client.ltrim(key, 0, 2) //trim the list to 3 elements
         x <- client.llen(key)
 
-      }yield{
-          x
-        }
+      } yield {
+        x
+      }
 
-      res.futureValue must be (3)
+      res.futureValue must be(3)
     }
 
     "rpop" in {
       val key = getKey()
 
       val res = for {
-        w <- client.rpopOption(key) //should be None, list doesn't exist
+        w <- client.rpop(key)                                   //should be None, list doesn't exist
         _ <- client.lpush(key, lValue, lValue, lValue, lValue2) //create list
-        x <- client.rpop(key) //pop last element, lValue
-        y <- client.llen(key) //should be 3
+        x <- client.rpop(key)                                   //pop last element, lValue
+        y <- client.llen(key)                                   //should be 3
 
-      }yield{
-          (w,x,y)
-        }
+      } yield {
+        (w, x, y)
+      }
 
-      res.futureValue must be ((None, lValue, 3))
+      res.futureValue must be((None, Some(lValue), 3))
     }
 
     "rpoplpush" in {
-      val key = getKey()
+      val key     = getKey()
       val destKey = getKey()
 
       val res = for {
-        w <- client.rpoplpushOption(key, destKey) //should be None, source key doesn't exist
+        w <- client.rpoplpush(key, destKey)                     //should be None, source key doesn't exist
         _ <- client.lpush(key, lValue, lValue, lValue, lValue2) //create source list
-        x <- client.rpoplpush(key, destKey) //x should be lValue
-        y <- client.llen(key) //should be 3 , since item was popped
-        z <- client.llen(destKey) //should be 1 since item was added
+        x <- client.rpoplpush(key, destKey)                     //x should be lValue
+        y <- client.llen(key)                                   //should be 3 , since item was popped
+        z <- client.llen(destKey)                               //should be 1 since item was added
 
-      }yield{
-          (w,x,y,z)
-        }
+      } yield {
+        (w, x, y, z)
+      }
 
-      res.futureValue must be ((None, lValue, 3, 1))
+      res.futureValue must be((None, Some(lValue), 3, 1))
     }
 
     "rpush" in {
@@ -197,27 +196,27 @@ class RedisListITSpec extends BaseRedisITSpec{
       val res = for {
         w <- client.rpush(key, lValue, lValue2) //rpush on non existent list should create
         x <- client.rpush(key, lValue2, lValue) //push some more, returns length
-        z <- client.lrange(key, 0, 3) //get the list to make sure the push was at the tail
+        z <- client.lrange(key, 0, 3)           //get the list to make sure the push was at the tail
       } yield {
-          (w,x,z)
-        }
+        (w, x, z)
+      }
 
-      res.futureValue must be((2,4, Seq(lValue,lValue2, lValue2, lValue)))
+      res.futureValue must be((2, 4, Seq(lValue, lValue2, lValue2, lValue)))
     }
 
     "rpushx" in {
       val key = getKey()
 
       val res = for {
-        w <- client.rpushx(key, lValue) //rpushx on non existent list should not create
-        x <- client.rpush(key, lValue) //push stuff
+        w <- client.rpushx(key, lValue)  //rpushx on non existent list should not create
+        x <- client.rpush(key, lValue)   //push stuff
         y <- client.rpushx(key, lValue2) //pushx should now work
-        z <- client.lrange(key, 0,1) //get list
+        z <- client.lrange(key, 0, 1)    //get list
       } yield {
-          (w,x,y,z)
-        }
+        (w, x, y, z)
+      }
 
-      res.futureValue must be((0,1,2,Seq(lValue, lValue2)))
+      res.futureValue must be((0, 1, 2, Seq(lValue, lValue2)))
     }
   }
 

--- a/colossus-tests/src/it/scala/colossus/RedisSetITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/RedisSetITSpec.scala
@@ -22,7 +22,7 @@ class RedisSetITSpec extends BaseRedisITSpec {
         (x, y)
       }
 
-      res.futureValue must be ((3, Set(val1, val2, val3)))
+      res.futureValue must be((3, Set(val1, val2, val3)))
     }
 
     "scard" in {
@@ -32,10 +32,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         x <- client.sadd(key, val1, val2, val3)
         y <- client.scard(key)
       } yield {
-          (x, y)
-        }
+        (x, y)
+      }
 
-      res.futureValue must be ((3, 3))
+      res.futureValue must be((3, 3))
     }
 
     "sdiff" in {
@@ -46,10 +46,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key2, val2)
         x <- client.sdiff(key1, key2)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Set(val1))
+      res.futureValue must be(Set(val1))
     }
 
     "sdiffstore" in {
@@ -62,10 +62,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         x <- client.sdiffstore(key3, key1, key2)
         y <- client.smembers(key3)
       } yield {
-          (x, y)
-        }
+        (x, y)
+      }
 
-      res.futureValue must be ((1,Set(val1)))
+      res.futureValue must be((1, Set(val1)))
     }
 
     "sinter" in {
@@ -76,10 +76,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key2, val1, val2)
         x <- client.sinter(key1, key2)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Set(val1))
+      res.futureValue must be(Set(val1))
     }
 
     "sinterstore" in {
@@ -92,10 +92,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         x <- client.sinterstore(key3, key1, key2)
         y <- client.smembers(key3)
       } yield {
-          (x, y)
-        }
+        (x, y)
+      }
 
-      res.futureValue must be ((1,Set(val1)))
+      res.futureValue must be((1, Set(val1)))
     }
 
     "sismember" in {
@@ -106,10 +106,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         x <- client.sismember(key, val1)
         y <- client.sismember(key, val2)
       } yield {
-          (w, x, y)
-        }
+        (w, x, y)
+      }
 
-      res.futureValue must be ((false, true, false))
+      res.futureValue must be((false, true, false))
     }
 
     "smembers" in {
@@ -119,27 +119,27 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key, val1, val2, val3)
         y <- client.smembers(key)
       } yield {
-          (x, y)
-        }
+        (x, y)
+      }
 
-      res.futureValue must be ((Set(), Set(val1, val2, val3)))
+      res.futureValue must be((Set(), Set(val1, val2, val3)))
 
     }
 
     "smove" in {
 
-      val key = getKey()
+      val key     = getKey()
       val destKey = getKey()
       val res = for {
-        _ <- client.sadd(key, val1, val2 )
+        _ <- client.sadd(key, val1, val2)
         _ <- client.sadd(destKey, val2)
         w <- client.smove(key, destKey, val1)
         x <- client.scard(key)
         y <- client.scard(destKey)
-      }yield {
-        (w,x,y)
+      } yield {
+        (w, x, y)
       }
-      res.futureValue must be ((true, 1, 2))
+      res.futureValue must be((true, 1, 2))
     }
 
     "spop" in {
@@ -148,11 +148,11 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key, val1, val2)
         x <- client.spop(key)
         y <- client.scard(key)
-      }yield{
-          (Set(val1, val2).contains(x) ,y)
-        }
+      } yield {
+        (Set(val1, val2).contains(x.get), y)
+      }
 
-      res.futureValue mustBe((true, 1))
+      res.futureValue mustBe ((true, 1))
     }
 
     "spopOption" in {
@@ -162,11 +162,11 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key, val1, val2)
         y <- client.spopOption(key)
         z <- client.scard(key)
-      }yield{
-          (x,  y.map(v => Set(val1, val2).contains(v)) ,z)
-        }
+      } yield {
+        (x, y.map(v => Set(val1, val2).contains(v)), z)
+      }
 
-      res.futureValue mustBe((None, Some(true), 1))
+      res.futureValue mustBe ((None, Some(true), 1))
     }
 
     "srandmember" in {
@@ -175,11 +175,11 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key, val1, val2)
         x <- client.srandmember(key)
         y <- client.scard(key)
-      }yield{
-          (Set(val1, val2).contains(x) ,y)
-        }
+      } yield {
+        (Set(val1, val2).contains(x.get), y)
+      }
 
-      res.futureValue mustBe((true, 2))
+      res.futureValue mustBe ((true, 2))
     }
 
     "srandmemberOption" in {
@@ -189,11 +189,11 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key, val1, val2)
         y <- client.srandmemberOption(key)
         z <- client.scard(key)
-      }yield{
-          (x,  y.map(v => Set(val1, val2).contains(v)) ,z)
-        }
+      } yield {
+        (x, y.map(v => Set(val1, val2).contains(v)), z)
+      }
 
-      res.futureValue mustBe((None, Some(true), 2))
+      res.futureValue mustBe ((None, Some(true), 2))
     }
 
     "srandmembers" in {
@@ -202,11 +202,11 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key, val1, val2)
         x <- client.srandmember(key, 2)
         z <- client.scard(key)
-      }yield{
-          (x.size, z)
-        }
+      } yield {
+        (x.size, z)
+      }
 
-      res.futureValue mustBe((2, 2))
+      res.futureValue mustBe ((2, 2))
     }
 
     "srem" in {
@@ -216,10 +216,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         x <- client.srem(key, val1, val2)
         y <- client.scard(key)
       } yield {
-          (x, y)
-        }
+        (x, y)
+      }
 
-      res.futureValue must be ((2, 1))
+      res.futureValue must be((2, 1))
     }
 
     "sunion" in {
@@ -230,10 +230,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         _ <- client.sadd(key2, val1, val2)
         x <- client.sunion(key1, key2)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Set(val1,val2))
+      res.futureValue must be(Set(val1, val2))
     }
 
     "sunionstore" in {
@@ -246,10 +246,10 @@ class RedisSetITSpec extends BaseRedisITSpec {
         x <- client.sunionstore(key3, key1, key2)
         y <- client.smembers(key3)
       } yield {
-          (x, y)
-        }
+        (x, y)
+      }
 
-      res.futureValue must be ((3,Set(val1, val2, val3)))
+      res.futureValue must be((3, Set(val1, val2, val3)))
     }
 
   }

--- a/colossus-tests/src/it/scala/colossus/RedisZSetITSpec.scala
+++ b/colossus-tests/src/it/scala/colossus/RedisZSetITSpec.scala
@@ -6,10 +6,10 @@ class RedisZSetITSpec extends BaseRedisITSpec {
 
   val keyPrefix = "colossusITZSet"
 
-  val val1  = ByteString("value1")
-  val val2  = ByteString("value2")
-  val val3  = ByteString("value3")
-  val val4  = ByteString("value4")
+  val val1 = ByteString("value1")
+  val val2 = ByteString("value2")
+  val val3 = ByteString("value3")
+  val val4 = ByteString("value4")
 
   "Redis zset commands" should {
 
@@ -19,8 +19,8 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         x <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
         y <- client.zcard(key)
       } yield {
-          (x,y)
-        }
+        (x, y)
+      }
 
       res.futureValue must be((2D, 2))
     }
@@ -31,8 +31,8 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         x <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
         y <- client.zcard(key)
       } yield {
-          (x,y)
-        }
+        (x, y)
+      }
 
       res.futureValue must be((2D, 2))
     }
@@ -42,11 +42,11 @@ class RedisZSetITSpec extends BaseRedisITSpec {
       val res = for {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
         x <- client.zcount(key, None, Some(1.0))
-      } yield{
-          x
-        }
+      } yield {
+        x
+      }
 
-      res.futureValue must be (1)
+      res.futureValue must be(1)
     }
 
     "zincrby" in {
@@ -54,44 +54,52 @@ class RedisZSetITSpec extends BaseRedisITSpec {
       val res = for {
         x <- client.zincrby(key, 5.0, val1)
         y <- client.zincrby(key, 5.0, val1)
-      }yield {
-          (x,y)
-        }
+      } yield {
+        (x, y)
+      }
 
       res.futureValue must be((5.0D, 10D))
     }
 
     "zinterstore" in {
-      val key = getKey()
-      val key2 = getKey()
+      val key     = getKey()
+      val key2    = getKey()
       val destKey = getKey()
       val res = for {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
         _ <- client.zadd(key2, ByteString("1"), val1, ByteString("2"), val2)
         x <- client.zinterstore(destKey, 2, key, key2)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (2)
+      res.futureValue must be(2)
 
     }
 
     "zinterstore with arguments" in {
-      val key = getKey()
-      val key2 = getKey()
+      val key     = getKey()
+      val key2    = getKey()
       val destKey = getKey()
       val res = for {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
         _ <- client.zadd(key2, ByteString("5"), val1, ByteString("10"), val2)
-        x <- client.zinterstore(destKey, 2, key, key2, ByteString("WEIGHTS"), ByteString("2"), ByteString("3"), ByteString("AGGREGATE"), ByteString("MAX"))
+        x <- client.zinterstore(destKey,
+                                2,
+                                key,
+                                key2,
+                                ByteString("WEIGHTS"),
+                                ByteString("2"),
+                                ByteString("3"),
+                                ByteString("AGGREGATE"),
+                                ByteString("MAX"))
         y <- client.zscore(destKey, val1)
         z <- client.zscore(destKey, val2)
       } yield {
-          (x, y, z)
-        }
+        (x, y, z)
+      }
 
-      res.futureValue must be ((2, 15D, 30D))
+      res.futureValue must be((2, Some(15D), Some(30D)))
 
     }
 
@@ -101,34 +109,34 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("1"), val2)
         x <- client.zlexcount(key)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (2)
+      res.futureValue must be(2)
     }
 
     "zrange" in {
       val key = getKey()
       val res = for {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
-        x <- client.zrange(key, 0,1)
+        x <- client.zrange(key, 0, 1)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Seq(val1, val2))
+      res.futureValue must be(Seq(val1, val2))
     }
 
     "zrangewithscores" in {
       val key = getKey()
       val res = for {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
-        x <- client.zrange(key, 0,1, ByteString("withscores"))
+        x <- client.zrange(key, 0, 1, ByteString("withscores"))
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Seq(val1, ByteString("1"), val2, ByteString("2")))
+      res.futureValue must be(Seq(val1, ByteString("1"), val2, ByteString("2")))
     }
 
     "zrangebylex" in {
@@ -137,22 +145,27 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         _ <- client.zadd(key, ByteString("0"), val1, ByteString("0"), val2, ByteString("0"), val3)
         x <- client.zrangebylex(key, ByteString("-"), ByteString("+"))
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Seq(val1, val2, val3))
+      res.futureValue must be(Seq(val1, val2, val3))
     }
 
     "zrangebylex with arguments" in {
       val key = getKey()
       val res = for {
         _ <- client.zadd(key, ByteString("0"), val1, ByteString("0"), val2, ByteString("0"), val3)
-        x <- client.zrangebylex(key, ByteString("-"), ByteString("+"), ByteString("LIMIT"), ByteString("1"), ByteString("1"))
+        x <- client.zrangebylex(key,
+                                ByteString("-"),
+                                ByteString("+"),
+                                ByteString("LIMIT"),
+                                ByteString("1"),
+                                ByteString("1"))
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Seq(val2))
+      res.futureValue must be(Seq(val2))
     }
 
     "zrangebyscore" in {
@@ -161,10 +174,10 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
         x <- client.zrangebyscore(key, ByteString("1"), ByteString("2"))
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Seq(val1, val2))
+      res.futureValue must be(Seq(val1, val2))
     }
 
     "zrank" in {
@@ -173,24 +186,24 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
         x <- client.zrank(key, val1)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (0)
+      res.futureValue must be(Some(0))
     }
 
     "zrankoption" in {
       val key = getKey()
       val res = for {
-        x <- client.zrankOption(key, val1)
+        x <- client.zrank(key, val1)
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
-        y <- client.zrankOption(key, val3)
-        z <- client.zrankOption(key, val1)
+        y <- client.zrank(key, val3)
+        z <- client.zrank(key, val1)
       } yield {
-          (x,y,z)
-        }
+        (x, y, z)
+      }
 
-      res.futureValue must be ((None, None, Some(0)))
+      res.futureValue must be((None, None, Some(0)))
     }
 
     "zrem" in {
@@ -198,62 +211,80 @@ class RedisZSetITSpec extends BaseRedisITSpec {
       val res = for {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
         x <- client.zrem(key, val1, val3)
-      }yield {
-          x
-        }
+      } yield {
+        x
+      }
 
-      res.futureValue must be (1)
+      res.futureValue must be(1)
     }
 
     "zremrangebylex" in {
       val key = getKey()
       val res = for {
-        _ <- client.zadd(key, ByteString("1"), ByteString("a"), ByteString("1"), ByteString("b"), ByteString("1"), ByteString("c"))
+        _ <- client.zadd(key,
+                         ByteString("1"),
+                         ByteString("a"),
+                         ByteString("1"),
+                         ByteString("b"),
+                         ByteString("1"),
+                         ByteString("c"))
         x <- client.zremrangebylex(key, ByteString("[a"), ByteString("[b"))
         y <- client.zcard(key)
-      }yield {
-          (x,y)
-        }
+      } yield {
+        (x, y)
+      }
 
-      res.futureValue must be ((2, 1))
+      res.futureValue must be((2, 1))
     }
 
     "zremrangebyrank" in {
       val key = getKey()
       val res = for {
-        _ <- client.zadd(key, ByteString("1"), ByteString("a"), ByteString("2"), ByteString("b"), ByteString("3"), ByteString("c"))
+        _ <- client.zadd(key,
+                         ByteString("1"),
+                         ByteString("a"),
+                         ByteString("2"),
+                         ByteString("b"),
+                         ByteString("3"),
+                         ByteString("c"))
         x <- client.zremrangebyrank(key, 0, 1)
         y <- client.zcard(key)
-      }yield {
-          (x,y)
-        }
+      } yield {
+        (x, y)
+      }
 
-      res.futureValue must be ((2, 1))
+      res.futureValue must be((2, 1))
     }
 
     "zremrangebyscore" in {
       val key = getKey()
       val res = for {
-        _ <- client.zadd(key, ByteString("1"), ByteString("a"), ByteString("2"), ByteString("b"), ByteString("3"), ByteString("c"))
+        _ <- client.zadd(key,
+                         ByteString("1"),
+                         ByteString("a"),
+                         ByteString("2"),
+                         ByteString("b"),
+                         ByteString("3"),
+                         ByteString("c"))
         x <- client.zremrangebyscore(key, ByteString("-inf"), ByteString("(2"))
         y <- client.zcard(key)
-      }yield {
-          (x,y)
-        }
+      } yield {
+        (x, y)
+      }
 
-      res.futureValue must be ((1,2))
+      res.futureValue must be((1, 2))
     }
 
     "zrevrange" in {
       val key = getKey()
       val res = for {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
-        x <- client.zrevrange(key, 1,2)
+        x <- client.zrevrange(key, 1, 2)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Seq(val2, val1))
+      res.futureValue must be(Seq(val2, val1))
     }
 
     "zrevrangebylex" in {
@@ -262,10 +293,10 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         _ <- client.zadd(key, ByteString("0"), val1, ByteString("0"), val2, ByteString("0"), val3)
         x <- client.zrevrangebylex(key, ByteString("+"), ByteString("-"))
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Seq(val3, val2, val1))
+      res.futureValue must be(Seq(val3, val2, val1))
     }
 
     "zrevrangebyscore" in {
@@ -274,10 +305,10 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
         x <- client.zrevrangebyscore(key, ByteString("2"), ByteString("1"))
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (Seq(val2, val1))
+      res.futureValue must be(Seq(val2, val1))
     }
 
     "zrevrank" in {
@@ -286,24 +317,24 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
         x <- client.zrevrank(key, val1)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (2)
+      res.futureValue must be(Some(2))
     }
 
     "zrevrankoption" in {
       val key = getKey()
       val res = for {
-        x <- client.zrevrankOption(key, val1)
+        x <- client.zrevrank(key, val1)
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
-        y <- client.zrevrankOption(key, val3)
-        z <- client.zrevrankOption(key, val1)
+        y <- client.zrevrank(key, val3)
+        z <- client.zrevrank(key, val1)
       } yield {
-          (x,y,z)
-        }
+        (x, y, z)
+      }
 
-      res.futureValue must be ((None, None, Some(1)))
+      res.futureValue must be((None, None, Some(1)))
     }
 
     "zscore" in {
@@ -312,39 +343,39 @@ class RedisZSetITSpec extends BaseRedisITSpec {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
         x <- client.zscore(key, val1)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (1D)
+      res.futureValue must be(Some(1D))
     }
 
     "zscoreoption" in {
       val key = getKey()
       val res = for {
-        x <- client.zscoreOption(key, val1)
+        x <- client.zscore(key, val1)
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2)
-        y <- client.zscoreOption(key, val3)
-        z <- client.zscoreOption(key, val1)
+        y <- client.zscore(key, val3)
+        z <- client.zscore(key, val1)
       } yield {
-          (x,y,z)
-        }
+        (x, y, z)
+      }
 
-      res.futureValue must be ((None, None, Some(1)))
+      res.futureValue must be((None, None, Some(1)))
     }
 
     "zunionstore" in {
-      val key = getKey()
-      val key2 = getKey()
+      val key     = getKey()
+      val key2    = getKey()
       val destKey = getKey()
       val res = for {
         _ <- client.zadd(key, ByteString("1"), val1, ByteString("2"), val2, ByteString("3"), val3)
         _ <- client.zadd(key2, ByteString("1"), val1, ByteString("2"), val2)
         x <- client.zunionstore(destKey, 2, key, key2)
       } yield {
-          x
-        }
+        x
+      }
 
-      res.futureValue must be (3)
+      res.futureValue must be(3)
 
     }
   }


### PR DESCRIPTION
This PR simplifies the Redis API by merging calls that return an option with their counterparts that don't. In other words, returning an option is the default behavior. See https://github.com/tumblr/colossus/issues/632 for more details. Fixes #632 

@DanSimon @aliyakamercan @jlbelmonte @amotamed 

