### PR TITLE
Request handler factory type

### DIFF
--- a/colossus-docs/src/main/scala/CallbackClient.scala
+++ b/colossus-docs/src/main/scala/CallbackClient.scala
@@ -17,7 +17,7 @@ object CallbackClient extends App {
 
       val callbackClient = Http.client("example.org", 80)
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/Fibonacci.scala
+++ b/colossus-docs/src/main/scala/Fibonacci.scala
@@ -20,7 +20,7 @@ object Fibonacci extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/Fibonacci2.scala
+++ b/colossus-docs/src/main/scala/Fibonacci2.scala
@@ -23,7 +23,7 @@ object Fibonacci2 extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/Fibonacci3.scala
+++ b/colossus-docs/src/main/scala/Fibonacci3.scala
@@ -29,7 +29,7 @@ object Fibonacci3 extends App {
 
       val cache = Memcache.client("localhost", 11211)
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/FilterExample.scala
+++ b/colossus-docs/src/main/scala/FilterExample.scala
@@ -15,7 +15,7 @@ object FilterExample extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/GenericClient.scala
+++ b/colossus-docs/src/main/scala/GenericClient.scala
@@ -32,7 +32,7 @@ object GenericClient extends App {
     new Initializer(initContext) {
       val client = Http.client("example.org", 80)
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/HelloWorld.scala
+++ b/colossus-docs/src/main/scala/HelloWorld.scala
@@ -1,6 +1,5 @@
 import akka.actor.ActorSystem
 import colossus.IOSystem
-import colossus.core.ServerContext
 import colossus.protocols.http.Http
 import colossus.protocols.http.HttpMethod._
 import colossus.protocols.http.UrlParsing._

--- a/colossus-docs/src/main/scala/HelloWorld.scala
+++ b/colossus-docs/src/main/scala/HelloWorld.scala
@@ -1,5 +1,6 @@
 import akka.actor.ActorSystem
 import colossus.IOSystem
+import colossus.core.ServerContext
 import colossus.protocols.http.Http
 import colossus.protocols.http.HttpMethod._
 import colossus.protocols.http.UrlParsing._
@@ -15,7 +16,7 @@ object HelloWorld extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/HelloWorld2.scala
+++ b/colossus-docs/src/main/scala/HelloWorld2.scala
@@ -27,7 +27,7 @@ object HelloWorld2 extends App {
 // #hello_world_part2
 class HelloInitializer(context: InitContext) extends Initializer(context) {
 
-  override def onConnect = context => new HelloRequestHandler(context)
+  override def onConnect: RequestHandlerFactory = context => new HelloRequestHandler(context)
 
 }
 // #hello_world_part2

--- a/colossus-docs/src/main/scala/HttpClientExample.scala
+++ b/colossus-docs/src/main/scala/HttpClientExample.scala
@@ -16,7 +16,7 @@ object HttpClientExample extends App {
 
       val httpClient = Http.client("google.com", 80)
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/HttpCompressionExample.scala
+++ b/colossus-docs/src/main/scala/HttpCompressionExample.scala
@@ -15,7 +15,7 @@ object HttpCompressionExample extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/HttpService2.scala
+++ b/colossus-docs/src/main/scala/HttpService2.scala
@@ -14,7 +14,7 @@ object HttpService2 {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/HttpServiceExample.scala
+++ b/colossus-docs/src/main/scala/HttpServiceExample.scala
@@ -15,7 +15,7 @@ object HttpServiceExample extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/MemcacheClientExample.scala
+++ b/colossus-docs/src/main/scala/MemcacheClientExample.scala
@@ -18,7 +18,7 @@ object MemcacheClientExample extends App {
 
       val memcacheClient = Memcache.client("localhost", 11211)
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/MetricTickExample.scala
+++ b/colossus-docs/src/main/scala/MetricTickExample.scala
@@ -24,7 +24,7 @@ object MetricTickExample extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/MiddlewareAsFunctions.scala
+++ b/colossus-docs/src/main/scala/MiddlewareAsFunctions.scala
@@ -14,7 +14,7 @@ object MiddlewareAsFunctions extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/RedisClientExample.scala
+++ b/colossus-docs/src/main/scala/RedisClientExample.scala
@@ -19,7 +19,7 @@ object RedisClientExample extends App {
 
       val redisClient = Redis.client("localhost", 6379)
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/RedisClientExample2.scala
+++ b/colossus-docs/src/main/scala/RedisClientExample2.scala
@@ -19,7 +19,7 @@ object RedisClientExample2 extends App {
 
       val redisClient = Redis.client("localhost", 6379)
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/RedisRetryClient.scala
+++ b/colossus-docs/src/main/scala/RedisRetryClient.scala
@@ -37,7 +37,7 @@ object RedisRetryClient extends App {
 
       val redisClient = Redis.client(config)
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus-docs/src/main/scala/RedisServiceExample.scala
+++ b/colossus-docs/src/main/scala/RedisServiceExample.scala
@@ -19,7 +19,7 @@ object RedisServiceExample extends App {
 
   RedisServer.start("example-server", 6379) { initContext =>
     new Initializer(initContext) {
-      override def onConnect: ServerContext => MyRequestHandler = { serverContext =>
+      override def onConnect: RequestHandlerFactory = { serverContext =>
         new MyRequestHandler(serverContext, db)
       }
     }

--- a/colossus-docs/src/main/scala/ServiceConfigExample.scala
+++ b/colossus-docs/src/main/scala/ServiceConfigExample.scala
@@ -31,7 +31,7 @@ object ServiceConfigExample {
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
       // #example1
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext, serviceConfig) {
             // #example1

--- a/colossus-docs/src/main/scala/SimpleMetricExample.scala
+++ b/colossus-docs/src/main/scala/SimpleMetricExample.scala
@@ -21,7 +21,7 @@ object SimpleMetricExample extends App {
 
   HttpServer.start("example-server", 9000) { initContext =>
     new Initializer(initContext) {
-      override def onConnect: ServerContext => SimpleMetricRequestHandler = { serverContext =>
+      override def onConnect: RequestHandlerFactory = { serverContext =>
         new SimpleMetricRequestHandler(serverContext, controller)
       }
     }

--- a/colossus-docs/src/main/scala/WorkerExample.scala
+++ b/colossus-docs/src/main/scala/WorkerExample.scala
@@ -1,3 +1,4 @@
+import akka.actor.Actor.Receive
 import akka.actor.ActorSystem
 import colossus.IOSystem
 import colossus.protocols.http.Http
@@ -19,11 +20,11 @@ object WorkerExample extends App {
 
       var currentName = "Jones"
 
-      override def receive = {
+      override def receive: Receive = {
         case NameChange(name) => currentName = name
       }
 
-      override def onConnect =
+      override def onConnect: RequestHandlerFactory =
         serverContext =>
           new RequestHandler(serverContext) {
             override def handle: PartialHandler[Http] = {

--- a/colossus/src/main/scala/colossus/core/server/ServerDSL.scala
+++ b/colossus/src/main/scala/colossus/core/server/ServerDSL.scala
@@ -1,9 +1,6 @@
 package colossus.core.server
 
-object ServerDSL {
-  type Receive = PartialFunction[Any, Unit]
-}
-import ServerDSL._
+import akka.actor.Actor.Receive
 import colossus.IOSystem
 import colossus.core._
 import com.typesafe.config.{Config, ConfigFactory}
@@ -13,7 +10,7 @@ import com.typesafe.config.{Config, ConfigFactory}
   * [[Server!]] inside a [[WorkerRef Worker]].  Initializers are also used to provide new
   * connections from the server with connection handlers.  An initializer is
   * created per worker, so all actions on a single Initializer are
-  * single-threaded.  See [[colossus.core.Server!]] to see how `Initializer` is
+  * single-threaded.  See [[colossus.core.server.Server]] to see how `Initializer` is
   * used when starting servers.
   */
 abstract class Initializer(context: InitContext) {

--- a/colossus/src/main/scala/colossus/service/ServiceDSL.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceDSL.scala
@@ -7,6 +7,7 @@ import scala.concurrent.Future
 import scala.language.higherKinds
 import java.net.InetSocketAddress
 
+import akka.actor.Actor.Receive
 import colossus.IOSystem
 import colossus.controller.{Codec, Controller, Encoding}
 import colossus.core.server.{Initializer, Server, ServerDSL}
@@ -19,17 +20,22 @@ trait Protocol {
 }
 
 abstract class HandlerGenerator[T](ctx: InitContext) {
-  implicit val worker = ctx.worker
-  val server          = ctx.server
+
+  implicit val worker: WorkerRef = ctx.worker
+
+  val server: ServerRef = ctx.server
 
   def fullHandler: T => ServerConnectionHandler
 }
 
 trait ServiceInitializer[T] extends HandlerGenerator[T] {
 
-  def onConnect: ServerContext => T
+  type RequestHandlerFactory = ServerContext => T
 
-  def receive: ServerDSL.Receive = Map()
+  def onConnect: RequestHandlerFactory
+
+  def receive: Receive = Map()
+
   def onShutdown() {}
 }
 
@@ -38,9 +44,15 @@ trait ServiceDSL[T, I <: ServiceInitializer[T]] {
   def basicInitializer: InitContext => HandlerGenerator[T]
 
   class BridgeInitializer(init: InitContext, val serviceInitializer: I) extends Initializer(init) {
-    def onConnect        = ctx => serviceInitializer.fullHandler(serviceInitializer.onConnect(ctx))
-    override def receive = serviceInitializer.receive
-    override def onShutdown() { serviceInitializer.onShutdown() }
+    override def onConnect: (ServerContext) => ServerConnectionHandler = { ctx =>
+      serviceInitializer.fullHandler(serviceInitializer.onConnect(ctx))
+    }
+
+    override def receive: Receive = serviceInitializer.receive
+
+    override def onShutdown(): Unit = {
+      serviceInitializer.onShutdown()
+    }
   }
 
   def start(name: String, settings: ServerSettings)(init: InitContext => I)(implicit io: IOSystem): ServerRef = {
@@ -199,7 +211,8 @@ trait ServiceClientFactory[P <: Protocol] extends ClientFactory[P, Callback, Cli
     new LoadBalancer[P](config, this, new PrinciplePermutationGenerator[Client[P, Callback]](_))
   }
 
-  def createClient(config: ClientConfig, address: InetSocketAddress)(implicit worker: WorkerRef): Client[P, Callback] = {
+  def createClient(config: ClientConfig, address: InetSocketAddress)(
+      implicit worker: WorkerRef): Client[P, Callback] = {
     //TODO : binding a client needs to be split up from creating the connection handler
     // we should make a method called "create" the abstract method, and have
     // this apply call it, then move this to a more generic parent type


### PR DESCRIPTION
+ Created a type `RequestHandlerFactory`, which can be used to define the return value of the `onConnect` method. 
+ Replaced `ServerDSL.Receive` with the akka version.
+ Slightly cleaned up `ServiceDSL`

No logic changes, just cleaning code.

@DanSimon @amotamed @aliyakamercan @jlbelmonte 