### PR TITLE
Better exception message format handling

### DIFF
--- a/colossus-docs/src/main/paradox/services.md
+++ b/colossus-docs/src/main/paradox/services.md
@@ -84,10 +84,6 @@ colossus {
       log-errors : true
       request-metrics : true
       max-request-size : "1000 MB"
-      errors : {
-        do-not-log : []
-        log-only-name : ["DroppedReplyException"]
-      }
     }
   }
 }
@@ -99,8 +95,8 @@ To configure via code, create a `ServiceConfig` object and pass it to the `Reque
 
 @@snip [ServiceConfigExample.conf](../scala/ServiceConfigExample.scala) { #example1 }
 
-`RequestHandler` allows for the configuration of how request errors are reported. By default, requests are directly
-converted to `String`s and logged with the complete stack trace. This can be overridden by either filling in the
-`errors` config, or by providing a custom implementation of the `RequestFormatter` trait in the `RequestHandler`.
+`RequestHandler` allows for the configuration of how request errors are reported. By default, `ColossusRuntimeException`s
+are converted to `String`s and logged with no stack trace, and other exceptions are logged with a stack trace. A custom 
+implementation of `RequestFormatter` can be provided as demonstrated in this example.
 
 @@snip [ServiceConfigExample.conf](../scala/ServiceConfigExample.scala) { #example2 }

--- a/colossus-docs/src/main/paradox/services.md
+++ b/colossus-docs/src/main/paradox/services.md
@@ -97,6 +97,6 @@ To configure via code, create a `ServiceConfig` object and pass it to the `Reque
 
 `RequestHandler` allows for the configuration of how request errors are reported. By default, `ColossusRuntimeException`s
 are converted to `String`s and logged with no stack trace, and other exceptions are logged with a stack trace. A custom 
-implementation of `RequestFormatter` can be provided as demonstrated in this example.
+implementation of `RequestExceptionFormatter` can be provided as demonstrated in this example.
 
 @@snip [ServiceConfigExample.conf](../scala/ServiceConfigExample.scala) { #example2 }

--- a/colossus-docs/src/main/scala/ServiceConfigExample.scala
+++ b/colossus-docs/src/main/scala/ServiceConfigExample.scala
@@ -20,11 +20,7 @@ object ServiceConfigExample {
     requestBufferSize = 100,
     logErrors = true,
     requestMetrics = true,
-    maxRequestSize = 10.MB,
-    errorConfig = ErrorConfig(
-      doNotLog = Set.empty[String],
-      logOnlyName = Set("DroppedReplyException")
-    )
+    maxRequestSize = 10.MB
   )
   // #example
 
@@ -40,13 +36,12 @@ object ServiceConfigExample {
             }
 
             // #example2
-            override def requestLogFormat: Option[RequestFormatter[Request]] = {
-              val customFormatter = new ConfigurableRequestFormatter[Request](serviceConfig.errorConfig) {
-                override def format(request: Request, error: Throwable): Option[String] = {
-                  Some(s"$request failed with ${error.getClass.getSimpleName}")
-                }
+            override def requestLogFormat: RequestFormatter[Request] = new RequestFormatter[Request] {
+              override def format(request: Option[Request], error: Throwable): String = {
+                s"$request failed with ${error.getClass.getSimpleName}"
               }
-              Some(customFormatter)
+
+              override def formatterOption(error: Throwable): RequestFormatType = RequestFormatType.LogWithStackTrace
             }
             // #example2
         }

--- a/colossus-docs/src/main/scala/ServiceConfigExample.scala
+++ b/colossus-docs/src/main/scala/ServiceConfigExample.scala
@@ -36,7 +36,7 @@ object ServiceConfigExample {
             }
 
             // #example2
-            override def requestLogFormat: RequestFormatter[Request] = new RequestFormatter[Request] {
+            override def requestLogFormat: RequestExceptionFormatter[Request] = new RequestExceptionFormatter[Request] {
               override def format(request: Option[Request], error: Throwable): String = {
                 s"$request failed with ${error.getClass.getSimpleName}"
               }

--- a/colossus-tests/src/test/resources/application.conf
+++ b/colossus-tests/src/test/resources/application.conf
@@ -1,5 +1,4 @@
 colossus.service.config-loading-spec {
-
   request-buffer-size = 9876
 }
 

--- a/colossus-tests/src/test/scala/colossus/protocols/http/HttpServiceDefaultSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/http/HttpServiceDefaultSpec.scala
@@ -1,0 +1,38 @@
+package colossus.protocols.http
+
+import colossus.core.ServerRef
+import colossus.protocols.http.HttpMethod.Get
+import colossus.protocols.http.UrlParsing._
+import colossus.service.GenRequestHandler.PartialHandler
+import colossus.testkit.HttpServiceSpec
+
+class HttpServiceDefaultSpec extends HttpServiceSpec {
+
+  override def service: ServerRef = {
+    HttpServer.start("example-server", 8123) { initContext =>
+      new Initializer(initContext) {
+        override def onConnect: RequestHandlerFactory =
+          serverContext =>
+            new RequestHandler(serverContext) {
+              override def handle: PartialHandler[Http] = {
+                case request @ Get on Root / "bang" => throw new Exception("Shouldn't have done that")
+              }
+          }
+      }
+    }
+  }
+
+  "Http service" must {
+    "return not found on unhandled route" in {
+      expectCodeAndBody(HttpRequest.get("ping"), HttpCodes.NOT_FOUND, "Not found")
+    }
+
+    "return server exception on unhandled exception" in {
+      expectCodeAndBody(
+        HttpRequest.get("bang"),
+        HttpCodes.INTERNAL_SERVER_ERROR,
+        "java.lang.Exception: Shouldn't have done that"
+      )
+    }
+  }
+}

--- a/colossus-tests/src/test/scala/colossus/service/RequestFormatterSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/RequestFormatterSpec.scala
@@ -6,13 +6,13 @@ import org.scalatest.WordSpec
 class RequestFormatterSpec extends WordSpec {
   "Request formatter" must {
     "format log message with exception name, request and stack trace when no special format implementation provided" in {
-      val requestFormatter = new RequestFormatter[HttpRequest] {
+      val requestFormatter = new RequestExceptionFormatter[HttpRequest] {
         override def formatterOption(error: Throwable): RequestFormatType = RequestFormatType.LogWithStackTrace
       }
 
       val output = requestFormatter.formatLogMessage(Some(HttpRequest.get("/")), new Exception("Too fast"))
 
-      val expected = RequestFormatter.LogMessage(
+      val expected = RequestExceptionFormatter.LogMessage(
         "Exception: HttpRequest(BuiltHead(Get / 1.1,[]),)",
         includeStackTrace = true
       )
@@ -21,13 +21,13 @@ class RequestFormatterSpec extends WordSpec {
     }
 
     "format log message with exception name and request when no special format implementation provided" in {
-      val requestFormatter = new RequestFormatter[HttpRequest] {
+      val requestFormatter = new RequestExceptionFormatter[HttpRequest] {
         override def formatterOption(error: Throwable): RequestFormatType = RequestFormatType.LogNameOnly
       }
 
       val output = requestFormatter.formatLogMessage(Some(HttpRequest.get("/")), new RuntimeException("No running"))
 
-      val expected = RequestFormatter.LogMessage(
+      val expected = RequestExceptionFormatter.LogMessage(
         "RuntimeException: HttpRequest(BuiltHead(Get / 1.1,[]),)",
         includeStackTrace = false
       )
@@ -36,7 +36,7 @@ class RequestFormatterSpec extends WordSpec {
     }
 
     "return nothing if logging is turned off" in {
-      val requestFormatter = new RequestFormatter[HttpRequest] {
+      val requestFormatter = new RequestExceptionFormatter[HttpRequest] {
         override def formatterOption(error: Throwable): RequestFormatType = RequestFormatType.DoNotLog
       }
 

--- a/colossus-tests/src/test/scala/colossus/service/RequestFormatterSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/service/RequestFormatterSpec.scala
@@ -7,12 +7,10 @@ class RequestFormatterSpec extends WordSpec {
   "Request formatter" must {
     "format log message with exception name, request and stack trace when no special format implementation provided" in {
       val requestFormatter = new RequestFormatter[HttpRequest] {
-        override def logWithStackTrace(error: Throwable): Option[Boolean] = Some(true)
-
-        override def format(request: HttpRequest, error: Throwable): Option[String] = None
+        override def formatterOption(error: Throwable): RequestFormatType = RequestFormatType.LogWithStackTrace
       }
 
-      val output = requestFormatter.formatLogMessage(HttpRequest.get("/"), new Exception("Too fast"))
+      val output = requestFormatter.formatLogMessage(Some(HttpRequest.get("/")), new Exception("Too fast"))
 
       val expected = RequestFormatter.LogMessage(
         "Exception: HttpRequest(BuiltHead(Get / 1.1,[]),)",
@@ -24,12 +22,10 @@ class RequestFormatterSpec extends WordSpec {
 
     "format log message with exception name and request when no special format implementation provided" in {
       val requestFormatter = new RequestFormatter[HttpRequest] {
-        override def logWithStackTrace(error: Throwable): Option[Boolean] = Some(false)
-
-        override def format(request: HttpRequest, error: Throwable): Option[String] = None
+        override def formatterOption(error: Throwable): RequestFormatType = RequestFormatType.LogNameOnly
       }
 
-      val output = requestFormatter.formatLogMessage(HttpRequest.get("/"), new RuntimeException("No running"))
+      val output = requestFormatter.formatLogMessage(Some(HttpRequest.get("/")), new RuntimeException("No running"))
 
       val expected = RequestFormatter.LogMessage(
         "RuntimeException: HttpRequest(BuiltHead(Get / 1.1,[]),)",
@@ -41,12 +37,10 @@ class RequestFormatterSpec extends WordSpec {
 
     "return nothing if logging is turned off" in {
       val requestFormatter = new RequestFormatter[HttpRequest] {
-        override def logWithStackTrace(error: Throwable): Option[Boolean] = None
-
-        override def format(request: HttpRequest, error: Throwable): Option[String] = None
+        override def formatterOption(error: Throwable): RequestFormatType = RequestFormatType.DoNotLog
       }
 
-      val output = requestFormatter.formatLogMessage(HttpRequest.get("/"), new RuntimeException("No running"))
+      val output = requestFormatter.formatLogMessage(Some(HttpRequest.get("/")), new RuntimeException("No running"))
 
       assert(output.isEmpty)
     }

--- a/colossus/src/main/resources/reference.conf
+++ b/colossus/src/main/resources/reference.conf
@@ -54,10 +54,6 @@ colossus{
       log-errors : true
       request-metrics : true
       max-request-size : "10 MB"
-      errors : {
-        do-not-log : []
-        log-only-name : ["DroppedReplyException"]
-      }
     }
   }
 

--- a/colossus/src/main/scala/colossus/core/IOSystem.scala
+++ b/colossus/src/main/scala/colossus/core/IOSystem.scala
@@ -224,3 +224,9 @@ object IOCommand {
   case class BindWithContext(context: Context, item: Context => WorkerItem) extends IOCommand
 
 }
+
+/**
+  * Exceptions extending `ColossusRuntimeException` can occur under normal conditions of handling connections
+  * and requests. Stack traces for these exceptions are not useful.
+  */
+trait ColossusRuntimeException

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -43,7 +43,7 @@ package object http {
       def errorResponse(error: ProcessingFailure[HttpRequest]): HttpResponse = error match {
         case RecoverableError(request, reason) =>
           reason match {
-            case _: UnhandledRequestException => request.notFound(s"Not found")
+            case _: UnhandledRequestException => request.notFound("Not found")
             case _                            => request.error(reason.toString)
           }
 

--- a/colossus/src/main/scala/colossus/protocols/http/package.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/package.scala
@@ -40,16 +40,16 @@ package object http {
       ServiceClientFactory.basic("http", () => new HttpClientCodec)
 
     class ServerDefaults {
-      def errorResponse(error: ProcessingFailure[HttpRequest]) = error match {
+      def errorResponse(error: ProcessingFailure[HttpRequest]): HttpResponse = error match {
         case RecoverableError(request, reason) =>
           reason match {
-            case c: UnhandledRequestException => request.notFound(s"Not found")
-            case other                        => request.error(reason.toString)
+            case _: UnhandledRequestException => request.notFound(s"Not found")
+            case _                            => request.error(reason.toString)
           }
-        case IrrecoverableError(reason) => {
+
+        case IrrecoverableError(_) =>
           HttpResponse(HttpResponseHead(HttpVersion.`1.1`, HttpCodes.BAD_REQUEST, HttpHeaders.Empty),
                        HttpBody("Bad Request"))
-        }
       }
     }
 

--- a/colossus/src/main/scala/colossus/service/RequestExceptionFormatter.scala
+++ b/colossus/src/main/scala/colossus/service/RequestExceptionFormatter.scala
@@ -15,11 +15,11 @@ object RequestFormatType {
 }
 
 /**
-  * A request formatter is used to determine the message that is logged when a request fails.
+  * A request exception formatter is used to determine the message that is logged when a request fails.
   *
   * @tparam I Protocol request
   */
-trait RequestFormatter[I] {
+trait RequestExceptionFormatter[I] {
 
   def formatterOption(error: Throwable): RequestFormatType
 
@@ -27,16 +27,16 @@ trait RequestFormatter[I] {
     s"${error.getClass.getSimpleName}: ${request.getOrElse("Invalid request")}"
   }
 
-  final def formatLogMessage(request: Option[I], error: Throwable): Option[RequestFormatter.LogMessage] = {
+  final def formatLogMessage(request: Option[I], error: Throwable): Option[RequestExceptionFormatter.LogMessage] = {
     formatterOption(error) match {
       case RequestFormatType.DoNotLog =>
         None
       case other =>
-        Some(RequestFormatter.LogMessage(format(request, error), other == RequestFormatType.LogWithStackTrace))
+        Some(RequestExceptionFormatter.LogMessage(format(request, error), other == RequestFormatType.LogWithStackTrace))
     }
   }
 }
 
-object RequestFormatter {
+object RequestExceptionFormatter {
   case class LogMessage(message: String, includeStackTrace: Boolean)
 }

--- a/colossus/src/main/scala/colossus/service/RequestHandler.scala
+++ b/colossus/src/main/scala/colossus/service/RequestHandler.scala
@@ -1,6 +1,6 @@
 package colossus.service
 
-import colossus.ColossusRuntimeException
+import colossus.core.ColossusRuntimeException
 import colossus.core._
 
 class UnhandledRequestException(message: String) extends Exception(message) with ColossusRuntimeException

--- a/colossus/src/main/scala/colossus/service/RequestHandler.scala
+++ b/colossus/src/main/scala/colossus/service/RequestHandler.scala
@@ -1,10 +1,11 @@
 package colossus.service
 
+import colossus.ColossusRuntimeException
 import colossus.core._
 
-class UnhandledRequestException(message: String) extends Exception(message)
-class ReceiveException(message: String)          extends Exception(message)
-class RequestHandlerException(message: String)   extends Exception(message)
+class UnhandledRequestException(message: String) extends Exception(message) with ColossusRuntimeException
+
+class RequestHandlerException(message: String) extends Exception(message)
 
 object GenRequestHandler {
 
@@ -58,13 +59,14 @@ abstract class GenRequestHandler[P <: Protocol](val serverContext: ServerContext
   }
 
   def handleRequest(request: Request): Callback[Response] = fullHandler(request)
-  private lazy val errorHandler: ErrorHandler[P]          = onError orElse unhandledError
+
+  private lazy val errorHandler: ErrorHandler[P] = onError orElse unhandledError
 
   def handleFailure(error: ProcessingFailure[Request]): Response = errorHandler(error)
 
   def tagDecorator: TagDecorator[P] = TagDecorator.default[P]
-  def requestLogFormat: Option[RequestFormatter[Request]] =
-    Some(new ConfigurableRequestFormatter[Request](config.errorConfig))
+
+  def requestLogFormat: RequestFormatter[Request] = new StandardRequestFormatter[Request]
 
   protected def disconnect() {
     connection.disconnect()

--- a/colossus/src/main/scala/colossus/service/RequestHandler.scala
+++ b/colossus/src/main/scala/colossus/service/RequestHandler.scala
@@ -66,7 +66,7 @@ abstract class GenRequestHandler[P <: Protocol](val serverContext: ServerContext
 
   def tagDecorator: TagDecorator[P] = TagDecorator.default[P]
 
-  def requestLogFormat: RequestFormatter[Request] = new StandardRequestFormatter[Request]
+  def requestLogFormat: RequestExceptionFormatter[Request] = new StandardRequestFormatter[Request]
 
   protected def disconnect() {
     connection.disconnect()

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -3,6 +3,7 @@ package colossus.service
 import java.net.InetSocketAddress
 
 import akka.event.Logging
+import colossus.ColossusRuntimeException
 import colossus.controller._
 import colossus.core._
 import colossus.metrics.{MetricAddress, TagMap}
@@ -92,7 +93,7 @@ object ClientConfig {
   }
 }
 
-class ServiceClientException(message: String) extends Exception(message)
+class ServiceClientException(message: String) extends Exception(message) with ColossusRuntimeException
 
 /**
   * Thrown when a request is lost in transit

--- a/colossus/src/main/scala/colossus/service/ServiceClient.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceClient.scala
@@ -3,7 +3,7 @@ package colossus.service
 import java.net.InetSocketAddress
 
 import akka.event.Logging
-import colossus.ColossusRuntimeException
+import colossus.core.ColossusRuntimeException
 import colossus.controller._
 import colossus.core._
 import colossus.metrics.{MetricAddress, TagMap}

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -2,7 +2,7 @@ package colossus.service
 
 import com.typesafe.config.{Config, ConfigException, ConfigFactory}
 import akka.event.Logging
-import colossus.ColossusRuntimeException
+import colossus.core.ColossusRuntimeException
 import colossus.controller._
 import colossus.core.{DisconnectCause, DownstreamEventHandler, UpstreamEventHandler, UpstreamEvents}
 import colossus.metrics.collectors.{Counter, Histogram, Rate}

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -2,6 +2,7 @@ package colossus.service
 
 import com.typesafe.config.{Config, ConfigException, ConfigFactory}
 import akka.event.Logging
+import colossus.ColossusRuntimeException
 import colossus.controller._
 import colossus.core.{DisconnectCause, DownstreamEventHandler, UpstreamEventHandler, UpstreamEvents}
 import colossus.metrics.collectors.{Counter, Histogram, Rate}
@@ -13,7 +14,6 @@ import colossus.util.{ConfigCache, DataSize, ParseException}
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
-import collection.JavaConverters._
 
 class ServiceConfigException(err: Throwable) extends Exception("Error loading config", err)
 
@@ -33,8 +33,7 @@ case class ServiceConfig(requestTimeout: Duration,
                          requestBufferSize: Int,
                          logErrors: Boolean,
                          requestMetrics: Boolean,
-                         maxRequestSize: DataSize,
-                         errorConfig: ErrorConfig)
+                         maxRequestSize: DataSize)
 
 object ServiceConfig {
 
@@ -83,44 +82,22 @@ object ServiceConfig {
     val requestMetrics = config.getBoolean("request-metrics")
     val maxRequestSize = DataSize(config.getString("max-request-size"))
 
-    val errorConf      = config.getConfig("errors")
-    val errorsDoNotLog = errorConf.getStringList("do-not-log").asScala.toSet
-    val errorsLogName  = errorConf.getStringList("log-only-name").asScala.toSet
-    ServiceConfig(timeout,
-                  bufferSize,
-                  logErrors,
-                  requestMetrics,
-                  maxRequestSize,
-                  ErrorConfig(errorsDoNotLog, errorsLogName))
+    ServiceConfig(timeout, bufferSize, logErrors, requestMetrics, maxRequestSize)
   }
 }
 
-case class ErrorConfig(doNotLog: Set[String], logOnlyName: Set[String])
-
-/**
-  * The ErrorConfig here is normally loaded from the ServiceConfig.
-  */
-class ConfigurableRequestFormatter[I](errorConfig: ErrorConfig) extends RequestFormatter[I] {
-  override def logWithStackTrace(error: Throwable): Option[Boolean] = {
-    val errorName = error.getClass.getSimpleName
-    if (errorConfig.doNotLog.contains(errorName)) {
-      None
-    } else if (errorConfig.logOnlyName.contains(errorName)) {
-      Some(false)
-    } else {
-      Some(true)
+class StandardRequestFormatter[I] extends RequestFormatter[I] {
+  override def formatterOption(error: Throwable): RequestFormatType = {
+    error match {
+      case _: ColossusRuntimeException => RequestFormatType.LogNameOnly
+      case _                           => RequestFormatType.LogWithStackTrace
     }
   }
-
-  override def format(request: I, error: Throwable): Option[String] = None
 }
 
-class ServiceServerException(message: String) extends Exception(message)
+class ServiceServerException(message: String) extends Exception(message) with ColossusRuntimeException
 
 class RequestBufferFullException extends ServiceServerException("Request Buffer full")
-
-//if this exception is ever thrown it indicates a bug
-class FatalServiceServerException(message: String) extends ServiceServerException(message)
 
 class DroppedReplyException extends ServiceServerException("Dropped Reply")
 
@@ -130,7 +107,7 @@ trait ServiceUpstream[P <: Protocol] extends UpstreamEvents
   * The ServiceServer provides an interface and basic functionality to create a server that processes
   * requests and returns responses over a codec.
   *
-  * A Codec is simply the format in which the data is represented.  Http, Redis protocol, Memcached protocl are all
+  * A Codec is simply the format in which the data is represented.  Http, Redis protocol, Memcached protocol are all
   * examples(and natively supported).  It is entirely possible to use an additional Codec by creating a Codec to parse
   * the desired protocol.
   *
@@ -181,29 +158,20 @@ class ServiceServer[P <: Protocol](val requestHandler: GenRequestHandler[P])
   private def addError(failure: ProcessingFailure[Request], extraTags: TagMap = TagMap.Empty) {
     val tags = extraTags + ("type" -> failure.reason.metricsName)
     errors.hit(tags = tags)
+
     if (config.logErrors) {
-      requestHandler.requestLogFormat match {
-        case Some(formatter) => {
-          val logMessage = failure match {
-            case RecoverableError(request, reason) =>
-              formatter.formatLogMessage(request, reason)
-            case IrrecoverableError(reason) =>
-              formatter.logWithStackTrace(reason).map(b => RequestFormatter.LogMessage("Invalid Request", b))
-          }
-          logMessage.foreach { x =>
-            if (x.includeStackTrace) {
-              error(s"Error processing request: ${x.message}", failure.reason)
-            } else {
-              error(s"Error processing request: ${x.message}")
-            }
-          }
-        }
-        case None => {
-          val requestString = failure match {
-            case RecoverableError(request, _) => request.toString
-            case IrrecoverableError(_)        => "Invalid Request"
-          }
-          error(s"Error processing request: $requestString", failure.reason)
+      val logMessage = failure match {
+        case RecoverableError(request, reason) =>
+          requestHandler.requestLogFormat.formatLogMessage(Some(request), reason)
+        case IrrecoverableError(reason) =>
+          requestHandler.requestLogFormat.formatLogMessage(None, reason)
+      }
+
+      logMessage.foreach { x =>
+        if (x.includeStackTrace) {
+          error(s"Error processing request: ${x.message}", failure.reason)
+        } else {
+          error(s"Error processing request: ${x.message}")
         }
       }
     }

--- a/colossus/src/main/scala/colossus/service/ServiceServer.scala
+++ b/colossus/src/main/scala/colossus/service/ServiceServer.scala
@@ -86,7 +86,7 @@ object ServiceConfig {
   }
 }
 
-class StandardRequestFormatter[I] extends RequestFormatter[I] {
+class StandardRequestFormatter[I] extends RequestExceptionFormatter[I] {
   override def formatterOption(error: Throwable): RequestFormatType = {
     error match {
       case _: ColossusRuntimeException => RequestFormatType.LogNameOnly


### PR DESCRIPTION
Created a `ColossusRuntimeException` trait that is extended by `ServiceClientException`, `ServiceClientExceptions` and `UnhandledRequestException`. I then updated the `RequestFormatter` so it is no longer configurable, but instead will log the name of any `ColossusRuntimeException` and suppress the stack trace. If users want different behavior, then they can write their own `RequestFormatter`. Hopefully this makes the logic a little simpler. Fixes #594

@dkarivalis @DanSimon @aliyakamercan @jlbelmonte @amotamed 