### PR TITLE
fix: contentType in StringEncoder should specify charset=utf-8

### DIFF
--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -420,7 +420,7 @@ object Connection {
 
 object ContentType {
   val TextPlain       = "text/plain"
-  val TextPlainUtf8   = "text/plain; charset=utf-8"
+  val TextPlainUtf8   = "text/plain; charset=UTF-8"
   val ApplicationJson = "application/json"
   val OctetStream     = "application/octet-stream"
 }

--- a/colossus/src/main/scala/colossus/protocols/http/Header.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/Header.scala
@@ -420,6 +420,7 @@ object Connection {
 
 object ContentType {
   val TextPlain       = "text/plain"
+  val TextPlainUtf8   = "text/plain; charset=utf-8"
   val ApplicationJson = "application/json"
   val OctetStream     = "application/octet-stream"
 }

--- a/colossus/src/main/scala/colossus/protocols/http/HttpBody.scala
+++ b/colossus/src/main/scala/colossus/protocols/http/HttpBody.scala
@@ -73,7 +73,7 @@ object HttpBodyEncoder {
   }
 
   implicit object StringEncoder extends HttpBodyEncoder[String] {
-    val contentType: String = ContentType.TextPlain
+    val contentType: String = ContentType.TextPlainUtf8
     def encode(data: String): HttpBody = new HttpBody(data.getBytes("UTF-8"))
   }
 }


### PR DESCRIPTION
in order to avoid encoding detection issues in web browsers