### PR TITLE
memcache: implement CAS and GETS

### DIFF
--- a/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheCommandSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheCommandSpec.scala
@@ -3,79 +3,78 @@ package colossus.protocols.memcache
 import org.scalatest._
 import akka.util.ByteString
 import colossus.protocols.memcache.MemcacheCommand._
-import colossus.util.compress.NoCompressor
 
 class MemcacheCommandSuite extends FlatSpec with Matchers {
   "MemcacheCommand" should "format a GET correctly" in {
     val experimental = Get(ByteString("test"))
     experimental.toString() should equal("get test\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("get test\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("get test\r\n"))
   }
 
   it should "format a GETS correctly" in {
     val experimental = Gets(ByteString("test"))
     experimental.toString() should equal("gets test\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("gets test\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("gets test\r\n"))
   }
 
   it should "format a SET correctly" in {
     val experimental = Set(ByteString("key"), ByteString("value"), 30) // key, value, ttl
     experimental.toString() should equal("set key 0 30 5\r\nvalue\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("set key 0 30 5\r\nvalue\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("set key 0 30 5\r\nvalue\r\n"))
   }
 
   it should "format a CAS correctly" in {
     val experimental = Cas(ByteString("key"), ByteString("value"), 30, casUniqueMaybe = Some(1337)) // key, value, ttl, cas
     experimental.toString() should equal("cas key 0 30 5 1337\r\nvalue\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("cas key 0 30 5 1337\r\nvalue\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("cas key 0 30 5 1337\r\nvalue\r\n"))
   }
 
   it should "format an ADD correctly" in {
     val experimental = Add(ByteString("key"), ByteString("magic"), 30)
     experimental.toString() should equal("add key 0 30 5\r\nmagic\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("add key 0 30 5\r\nmagic\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("add key 0 30 5\r\nmagic\r\n"))
   }
 
   it should "format a REPLACE correctly" in {
     val experimental = Replace(ByteString("key"), ByteString("magic"), 30)
     experimental.toString() should equal("replace key 0 30 5\r\nmagic\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("replace key 0 30 5\r\nmagic\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("replace key 0 30 5\r\nmagic\r\n"))
   }
 
   it should "format an APPEND correctly" in {
     val experimental = Append(ByteString("key"), ByteString("magic"))
     experimental.toString() should equal("append key 0 0 5\r\nmagic\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("append key 0 0 5\r\nmagic\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("append key 0 0 5\r\nmagic\r\n"))
   }
 
   it should "format a PREPEND correctly" in {
     val experimental = Prepend(ByteString("key"), ByteString("magic"))
     experimental.toString() should equal("prepend key 0 0 5\r\nmagic\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("prepend key 0 0 5\r\nmagic\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("prepend key 0 0 5\r\nmagic\r\n"))
   }
 
   it should "format DELETE correctly" in {
     val experimental = Delete(ByteString("key"))
     experimental.toString() should equal("delete key\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("delete key\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("delete key\r\n"))
   }
 
   it should "format INCR correctly" in {
     val experimental = Incr(ByteString("key"), 1L)
     experimental.toString() should equal("incr key 1\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("incr key 1\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("incr key 1\r\n"))
   }
 
   it should "format DECR correctly" in {
     val experimental = Decr(ByteString("key"), 1L)
     experimental.toString() should equal("decr key 1\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("decr key 1\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("decr key 1\r\n"))
   }
 
   it should "format TOUCH correctly" in {
     val experimental = Touch(ByteString("key"), 30)
     experimental.toString() should equal("touch key 30\r\n")
-    experimental.bytes(NoCompressor) should equal(ByteString("touch key 30\r\n"))
+    experimental.memcacheCommandMsg() should equal(ByteString("touch key 30\r\n"))
   }
 
 }

--- a/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheCommandSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheCommandSpec.scala
@@ -12,10 +12,22 @@ class MemcacheCommandSuite extends FlatSpec with Matchers {
     experimental.bytes(NoCompressor) should equal(ByteString("get test\r\n"))
   }
 
+  it should "format a GETS correctly" in {
+    val experimental = Gets(ByteString("test"))
+    experimental.toString() should equal("gets test\r\n")
+    experimental.bytes(NoCompressor) should equal(ByteString("gets test\r\n"))
+  }
+
   it should "format a SET correctly" in {
     val experimental = Set(ByteString("key"), ByteString("value"), 30) // key, value, ttl
     experimental.toString() should equal("set key 0 30 5\r\nvalue\r\n")
     experimental.bytes(NoCompressor) should equal(ByteString("set key 0 30 5\r\nvalue\r\n"))
+  }
+
+  it should "format a CAS correctly" in {
+    val experimental = Cas(ByteString("key"), ByteString("value"), 30, casUniqueMaybe = Some(1337)) // key, value, ttl, cas
+    experimental.toString() should equal("cas key 0 30 5 1337\r\nvalue\r\n")
+    experimental.bytes(NoCompressor) should equal(ByteString("cas key 0 30 5 1337\r\nvalue\r\n"))
   }
 
   it should "format an ADD correctly" in {
@@ -41,12 +53,6 @@ class MemcacheCommandSuite extends FlatSpec with Matchers {
     experimental.toString() should equal("prepend key 0 0 5\r\nmagic\r\n")
     experimental.bytes(NoCompressor) should equal(ByteString("prepend key 0 0 5\r\nmagic\r\n"))
   }
-
-  /*  it should "format a CAS correctly" in {
-    val experimental = Cas(ByteString("key"), "magic", 30)
-    //experimental.bytes(NoCompressor) should equal(ByteString("cas key 0 30 5\r\nmagic\r\n"))
-    experimental.toString() should equal("cas key 0 30 5\r\nmagic\r\n")
-  }*/
 
   it should "format DELETE correctly" in {
     val experimental = Delete(ByteString("key"))

--- a/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheParserSpec.scala
+++ b/colossus-tests/src/test/scala/colossus/protocols/memcache/MemcacheParserSpec.scala
@@ -13,6 +13,12 @@ class MemcacheParserSpec extends FlatSpec with Matchers {
     p.parse(reply) should equal(Some(Value(ByteString("foo"), ByteString("hello"), 0)))
   }
 
+  it should "parse a cas value reply" in {
+    val reply = DataBuffer(ByteString("VALUE foo 0 5 1337\r\nhello\r\nEND\r\n"))
+    val p     = new MemcacheReplyParser
+    p.parse(reply) should equal(Some(CasValue(ByteString("foo"), ByteString("hello"), 0, 1337)))
+  }
+
   it should "parse actual reply from memcache" in {
     val reply = DataBuffer(
       ByteString(86, 65, 76, 85, 69, 32, 102, 111, 111, 32, 48, 32, 51, 13, 10, 104, 101, 108, 13, 10, 69, 78, 68, 13,

--- a/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
@@ -25,9 +25,11 @@ import colossus.util.compress.{Compressor, NoCompressor}
 object UnifiedProtocol {
   val ADD     = ByteString("add")
   val APPEND  = ByteString("append")
+  val CAS     = ByteString("cas")
   val DECR    = ByteString("decr")
   val DELETE  = ByteString("delete")
   val GET     = ByteString("get")
+  val GETS    = ByteString("gets")
   val INCR    = ByteString("incr")
   val PREPEND = ByteString("prepend")
   val REPLACE = ByteString("replace")
@@ -41,73 +43,86 @@ object UnifiedProtocol {
 }
 
 //TODO: 'Flags' doesn't fully support the memcached protocol:  ie: using an Int doesn't allow us to utilize the full 32 unsigned int space
-//TODO: implement CAS
-//TODO: incrs/decrs are not utilizing full 64 bit unsigned int space since we are using singed Longs
+//TODO: incrs/decrs are not utilizing full 64 bit unsigned int space since we are using signed Longs
 object MemcacheCommand {
 
   import UnifiedProtocol._
 
+  private def getBytes(commandName: ByteString, compressor: Compressor = NoCompressor)
+                      (keys: ByteString*): ByteString = {
+    val b = new ByteStringBuilder
+    val totalKeyBytes = keys.foldLeft(0) {
+      case (acc, key) =>
+        acc + key.length + 1
+    }
+    //padding is 2..for the \r\n.  The spaces between keys are already accounted for in the foldLeft
+    b.sizeHint(commandName.size + totalKeyBytes + 2)
+    b.append(commandName)
+    keys.foreach { x =>
+      b.append(SP).append(x)
+    }
+    b.append(RN).result()
+  }
+
   case class Get(keys: ByteString*) extends MemcacheCommand {
+    val commandName: ByteString = GET
 
-    val commandName = GET
+    def bytes(compressor: Compressor = NoCompressor): ByteString = {
+      getBytes(commandName, compressor)(keys: _*)
+    }
+  }
 
-    def bytes(compressor: Compressor = NoCompressor) = {
-      val b = new ByteStringBuilder
-      val totalKeyBytes = keys.foldLeft(0) {
-        case (acc, key) =>
-          acc + key.length + 1
-      }
-      //padding is 2..for the \r\n.  The spaces between keys are already accounted for in the foldLeft
-      b.sizeHint(GET.size + totalKeyBytes + 2)
-      b.append(GET)
-      keys.foreach { x =>
-        b.append(SP).append(x)
-      }
-      b.append(RN).result()
+  case class Gets(keys: ByteString*) extends MemcacheCommand {
+    val commandName: ByteString = GETS
+
+    def bytes(compressor: Compressor = NoCompressor): ByteString = {
+      getBytes(commandName, compressor)(keys: _*)
     }
   }
 
   case class Set(key: ByteString, value: ByteString, ttl: Int = 0, flags: Int = 0) extends MemcacheWriteCommand {
-    val commandName = SET
+    val commandName: ByteString = SET
+    override def casUniqueMaybe: Option[Int] = None
+  }
+
+  case class Cas(key: ByteString,
+               value: ByteString,
+                    ttl: Int = 0,
+                  flags: Int = 0,
+      casUniqueMaybe: Option[Int]) extends MemcacheWriteCommand {
+    val commandName: ByteString = CAS
   }
 
   case class Add(key: ByteString, value: ByteString, ttl: Int = 0, flags: Int = 0) extends MemcacheWriteCommand {
-    val commandName = ADD
+    val commandName: ByteString = ADD
+    val casUniqueMaybe: Option[Int] = None
   }
 
   case class Replace(key: ByteString, value: ByteString, ttl: Int = 0, flags: Int = 0) extends MemcacheWriteCommand {
-    val commandName = REPLACE
+    val commandName: ByteString = REPLACE
+    val casUniqueMaybe: Option[Int] = None
   }
 
   // Append does not take <flags> or <expiretime> but we have to provide them according to the protocol
   case class Append(key: ByteString, value: ByteString) extends MemcacheWriteCommand {
-    val commandName = APPEND
+    val commandName: ByteString = APPEND
     val ttl         = 0
     val flags       = 0
+    val casUniqueMaybe: Option[Int] = None
   }
 
   // Prepend does not take <flags> or <expiretime> but we have to provide them according to the protocol
   case class Prepend(key: ByteString, value: ByteString) extends MemcacheWriteCommand {
-    val commandName = PREPEND
+    val commandName: ByteString = PREPEND
     val ttl         = 0
     val flags       = 0
+    val casUniqueMaybe: Option[Int] = None
   }
-
-  /*object Cas {
-    def apply(key: String, value: String, ttl: Integer = 0): Cas = Cas(ByteString(key), ByteString(value), ttl)
-  }
-  case class Cas(key: ByteString, value: ByteString, ttl: Integer) extends MemcachedCommand {
-    def bytes(compressor: Compressor) = {
-      val data = compressor.compress(value)
-      formatCommand(ByteString("cas"), key, Some(data), Some(ByteString(s"${ttl}")), Some(ByteString(s"0")))
-    }
-  }*/
 
   case class Delete(key: ByteString) extends MemcacheCommand {
+    val commandName: ByteString = DELETE
 
-    val commandName = DELETE
-
-    def bytes(c: Compressor = NoCompressor) = {
+    def bytes(c: Compressor = NoCompressor): ByteString = {
       val b = new ByteStringBuilder()
       //3 for SP and \R\N
       val hintSize = DELETE.size + key.size + 3
@@ -180,7 +195,7 @@ sealed trait MemcacheCommand {
   def commandName: ByteString
 }
 
-//set, add, replace, append, prepend
+//set, cas, add, replace, append, prepend
 sealed trait MemcacheWriteCommand extends MemcacheCommand {
 
   import UnifiedProtocol._
@@ -189,6 +204,7 @@ sealed trait MemcacheWriteCommand extends MemcacheCommand {
   def value: ByteString
   def ttl: Int
   def flags: Int
+  def casUniqueMaybe: Option[Int]
 
   def bytes(compressor: Compressor): ByteString = {
 
@@ -196,21 +212,28 @@ sealed trait MemcacheWriteCommand extends MemcacheCommand {
 
     /*write commands are of the format
     We don't support the [noreply] semantics at this time
-    <COMMAND> <KEY> <FLAGS> <EXPTIME> <BYTECOUNT>\r\n<data>\r\n
+    <COMMAND> <KEY> <FLAGS> <EXPTIME> <BYTECOUNT> [<CAS UNIQUE>]\r\n<data>\r\n
 
     padding accounts for spaces, \r\n's, bytecount and exptime:
-       4 spaces
+       4 or 5 spaces, depending if <CAS UNIQUE> is present
     +  4 (2 \r\n's)
      ----
-       8 */
-
-    val padding = 8
+       8 or 9, depending if <CAS UNIQUE> is present*/
 
     val flagsStr    = ByteString(flags.toString)
     val ttlStr      = ByteString(ttl.toString)
     val dataSizeStr = ByteString(value.size.toString)
+    val casUniqueStr = ByteString(casUniqueMaybe.getOrElse("").toString)
 
-    val sizeHint = commandName.length + flagsStr.length + ttlStr.length + dataSizeStr.length + value.size + padding
+    val padding = 8 + (if (casUniqueStr.nonEmpty) 1 else 0)
+
+    val sizeHint = commandName.length +
+                      flagsStr.length +
+                        ttlStr.length +
+                   dataSizeStr.length +
+                  casUniqueStr.length +
+                           value.size +
+                              padding
 
     b.sizeHint(sizeHint)
     b.append(commandName)
@@ -226,12 +249,17 @@ sealed trait MemcacheWriteCommand extends MemcacheCommand {
     b.append(SP)
 
     b.append(dataSizeStr)
+
+    if (casUniqueStr.nonEmpty) {
+      b.append(SP)
+      b.append(casUniqueStr)
+    }
+
     b.append(RN)
     b.append(value)
     b.append(RN)
 
     b.result()
-
   }
 }
 
@@ -254,10 +282,11 @@ sealed trait MemcacheHeader
 object MemcacheReply {
   sealed trait DataReply extends MemcacheReply
 
-  case class Value(key: ByteString, data: ByteString, flags: Int) extends DataReply
-  case class Counter(value: Long)                                 extends DataReply
-  case class Values(values: Vector[Value])                        extends DataReply
-  case object NoData                                              extends DataReply
+  case class Value(key: ByteString, data: ByteString, flags: Int)                    extends DataReply
+  case class CasValue(key: ByteString, data: ByteString, flags: Int, casUnique: Int) extends DataReply
+  case class Counter(value: Long)                                                    extends DataReply
+  case class Values(values: Vector[Value])                                           extends DataReply
+  case object NoData                                                                 extends DataReply
 
   //these are all one-line responses
   sealed trait MemcacheError extends MemcacheReply with MemcacheHeader
@@ -291,11 +320,18 @@ object MemcacheReplyParser {
   import colossus.util.Combinators._
   import MemcacheReply._
 
+  val numberPiecesInCasValueReply = 5
+
   def apply() = reply
 
-  def reply = delimitedString(' ', '\r') <~ byte |> { pieces =>
+  def reply = delimitedString(' ', '\r') <~ byte |> { pieces: Seq[String] =>
     pieces.head match {
-      case "VALUE"                   => value(Vector.empty, pieces(1), pieces(2).toInt, pieces(3).toInt)
+      case "VALUE"                   =>
+        if (pieces.size < numberPiecesInCasValueReply) {
+          value(Vector.empty, pieces(1), pieces(2).toInt, pieces(3).toInt)
+        } else {
+          casValue(pieces(1), pieces(2).toInt, pieces(3).toInt, pieces(4).toInt)
+        }
       case "END"                     => const(NoData)
       case "NOT_STORED"              => const(NotStored)
       case "STORED"                  => const(Stored)
@@ -311,7 +347,7 @@ object MemcacheReplyParser {
     }
   }
 
-  def isNumeric(str: String) = str.forall(_.isDigit)
+  def isNumeric(str: String): Boolean = str.forall(_.isDigit)
 
   //returns either a Value or Values object depending if 1 or >1 values received
   def values(build: Vector[Value]): Parser[DataReply] = delimitedString(' ', '\r') <~ byte |> { pieces =>
@@ -321,8 +357,12 @@ object MemcacheReplyParser {
     }
   }
 
-  def value(build: Vector[Value], key: String, flags: Int, len: Int) = bytes(len) <~ bytes(2) |> { b =>
-    values(build :+ Value(ByteString(key), ByteString(b), flags))
+  def value(build: Vector[Value], key: String, flags: Int, len: Int): Parser[DataReply] =
+    bytes(len) <~ bytes(2) |> { b => values(build :+ Value(ByteString(key), ByteString(b), flags))
+  }
+
+  def casValue(key: String, flags: Int, len: Int, casUnique: Int): Parser[CasValue] =
+    bytes(len) <~ bytes(2) |> { b => const(CasValue(ByteString(key), ByteString(b), flags, casUnique))
   }
 }
 

--- a/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
@@ -221,11 +221,7 @@ sealed trait MemcacheWriteCommand extends MemcacheCommand {
     val flagsStr     = ByteString(flags.toString)
     val ttlStr       = ByteString(ttl.toString)
     val dataSizeStr  = ByteString(value.size.toString)
-
-    val casUniqueStr = casUniqueMaybe match {
-      case Some(casUnique) => ByteString(casUnique.toString)
-      case None            => ByteString("")
-    }
+    val casUniqueStr = ByteString(casUniqueMaybe.map(_.toString).getOrElse(""))
 
     val padding = getMemcacheCommandPadding(casUniqueStr.nonEmpty)
 

--- a/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/Memcache.scala
@@ -221,7 +221,11 @@ sealed trait MemcacheWriteCommand extends MemcacheCommand {
     val flagsStr     = ByteString(flags.toString)
     val ttlStr       = ByteString(ttl.toString)
     val dataSizeStr  = ByteString(value.size.toString)
-    val casUniqueStr = ByteString(casUniqueMaybe.getOrElse("").toString)
+
+    val casUniqueStr = casUniqueMaybe match {
+      case Some(casUnique) => ByteString(casUnique.toString)
+      case None            => ByteString("")
+    }
 
     val padding = getMemcacheCommandPadding(casUniqueStr.nonEmpty)
 

--- a/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
+++ b/colossus/src/main/scala/colossus/protocols/memcache/MemcacheOps.scala
@@ -68,7 +68,7 @@ trait MemcacheClient[M[_]] extends LiftedClient[Memcache, M] {
     executeCommand(Cas(key, value, ttl, flags, Some(casUnique)), key) {
       case Stored   => success(true)
       case Exists   => success(false)
-      case NotFound => failure(CasNotFoundException("The key we're trying to CAS does not exist."))
+      case NotFound => failure(KeyNotFoundException("The key we're trying to CAS does not exist."))
     }
   }
 
@@ -137,4 +137,4 @@ object MemcacheClient {
 }
 
 case class UnexpectedMemcacheReplyException(message: String) extends Exception
-case class CasNotFoundException(message: String)             extends Exception
+case class KeyNotFoundException(message: String)             extends Exception

--- a/colossus/src/main/scala/colossus/util/Parsing.scala
+++ b/colossus/src/main/scala/colossus/util/Parsing.scala
@@ -528,7 +528,7 @@ object Combinators {
   def repeat[T](times: Parser[Long], parser: Parser[T]): Parser[Vector[T]] = new Parser[Vector[T]] {
     var build: Vector[T]          = Vector()
     var parsedTimes: Option[Long] = None
-    def parse(data: DataBuffer) = {
+    def parse(data: DataBuffer): Option[Vector[T]] = {
       if (parsedTimes.isEmpty) {
         parsedTimes = times.parse(data)
         if (parsedTimes.isDefined) {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.0-SNAPSHOT"
+version in ThisBuild := "0.11.1-SNAPSHOT"


### PR DESCRIPTION
what
---
implements the `CAS` and `GETS` commands in our memcache client; more on the commands [here](https://github.com/memcached/memcached/blob/master/doc/protocol.txt#L153).

reran [these benchmark tests](https://github.com/tumblr/colossus/blob/master/colossus-tests/src/it/scala/colossus/MemcacheITSpec.scala#L194) with 10 cycles @ 1000 iterations each to confirm that the changes to the parser & writer do not negatively impact the performance of the existing get/set commands. on a mbp with an unstable environment, we have similar results: [benchmark results](https://gist.github.com/dkarivalis/7b07ccd4dea3f0f0535529879bcb493e)

@byxorna @vrrs
@DanSimon @benblack86 @aliyakamercan @amotamed @jlbelmonte @dxuhuang 


