### PR TITLE
LoadBalancer: disconnecting deadClients on #update(...)

### DIFF
--- a/colossus/src/main/scala/colossus/service/LoadBalancer.scala
+++ b/colossus/src/main/scala/colossus/service/LoadBalancer.scala
@@ -18,7 +18,7 @@ private class LoadBalancer[P <: Protocol](
     with ColossusLogging {
 
   implicit val cbe: CallbackExecutor = worker.callbackExecutor
-  
+
   private var clients: Seq[Client[P, Callback]] = config.address.map(address => createClient(address))
 
   private var permutations = permutationFactory(clients)
@@ -93,7 +93,7 @@ private class LoadBalancer[P <: Protocol](
           } else {
             ConnectionStatus.Mixed
           }
-        case Failure(exception) =>
+        case Failure(_) =>
           ConnectionStatus.Mixed
       }
     }
@@ -135,6 +135,7 @@ private class LoadBalancer[P <: Protocol](
     leftovers.foreach {
       case (address, deadClients) =>
         debug(s"[$address|0] Killing ${deadClients.size} clients(s)")
+        deadClients.foreach(_.disconnect())
     }
 
     clients = newClientsMap.values.flatten.toSeq

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.11.1-SNAPSHOT"
+version in ThisBuild := "0.11.2-SNAPSHOT"


### PR DESCRIPTION
[what](https://github.com/tumblr/colossus/issues/668)
---
small fix for a bug where `#update(...)`'ing the addresses of a `LoadBalancer` would not disconnect clients no longer in use

@vrrs @kevinsteck
cc @benblack86 